### PR TITLE
enh(openapi): migrate hand-written API documentation to OpenAPI 3.1

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -3264,7 +3264,7 @@ paths:
                 type: object
                 properties:
                   global: { type: object, properties: { title: { type: string, description: 'title of the graph', example: 'graph title' }, start: { type: integer, description: 'timestamp of the start interval', example: 1594504800 }, end: { type: integer, description: 'timestamp of the end interval', example: 1594591200 }, vertical-label: { type: string, description: 'vertical label (should not be used cause multiple y-axis possible)', example: Value }, base: { type: string, description: 'base scale', example: '1024' }, width: { type: string, description: 'width of the graph (should not be used)', example: '550' }, height: { type: string, description: 'height of the graph (should not be used)', example: '140' }, lower-limit: { type: string, description: 'lower value of the graph', example: '0' }, scaled: { type: integer, description: 'if the graph needs to be automatically scaled', example: 1 }, multiple_services: { type: boolean, description: 'if multiple services are selected (always false)', example: false } } }
-                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, last_value: { type: number, nullable: true, description: 'last value', example: 5.0 }, minimum_value: { type: number, nullable: true, description: 'minimum value', example: 0.0 }, maximum_value: { type: number, nullable: true, description: 'maximum value', example: 10.0 }, average_value: { type: number, nullable: true, description: 'average value', example: 5.64 } } } }
+                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: [string, 'null'], description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: [string, 'null'], description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: [string, 'null'], description: 'warning threshold', example: null }, warn_low: { type: [string, 'null'], description: 'low warning threshold', example: null }, crit: { type: [string, 'null'], description: 'critical threshold', example: null }, crit_low: { type: [string, 'null'], description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, last_value: { type: [number, 'null'], description: 'last value', example: 5.0 }, minimum_value: { type: [number, 'null'], description: 'minimum value', example: 0.0 }, maximum_value: { type: [number, 'null'], description: 'maximum value', example: 10.0 }, average_value: { type: [number, 'null'], description: 'average value', example: 5.64 } } } }
                   times: { type: array, items: { type: string, format: timestamp, description: 'timestamp of the tick' }, example: ['1594505100', '1594505400', '1594505700'] }
         '403':
           $ref: '#/components/responses/Forbidden'
@@ -3336,7 +3336,7 @@ paths:
                 type: object
                 properties:
                   base: { type: string, description: 'base scale', example: 1024 }
-                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, format: float, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, minimum_value: { type: number, format: float, description: 'minimum value', example: 1.0 }, maximum_value: { type: number, format: float, description: 'maximum value', example: 1.0 } } } }
+                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: [string, 'null'], description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: [string, 'null'], description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: [string, 'null'], description: 'warning threshold', example: null }, warn_low: { type: [string, 'null'], description: 'low warning threshold', example: null }, crit: { type: [string, 'null'], description: 'critical threshold', example: null }, crit_low: { type: [string, 'null'], description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, format: float, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, minimum_value: { type: number, format: float, description: 'minimum value', example: 1.0 }, maximum_value: { type: number, format: float, description: 'maximum value', example: 1.0 } } } }
                   times: { type: array, items: { type: string, format: timestamp, description: 'datetime of the tick' }, example: ['1690965300'] }
         '403':
           $ref: '#/components/responses/Forbidden'
@@ -5516,15 +5516,17 @@ components:
               default: true
             attempts:
               description: 'login attempts before blocking'
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               minimum: 1
               maximum: 10
               default: 5
             blocking_duration:
               description: 'blocking duration in seconds before new login attempt'
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               maximum: 604800
               default: 900
             password_expiration:
@@ -5536,23 +5538,23 @@ components:
               properties:
                 expiration_delay:
                   description: 'password expiration delay in seconds'
-                  type: integer
-                  nullable: true
+                  type: [integer, 'null']
                   minimum: 604800
                   maximum: 31557600
                   default: 15552000
                 excluded_users:
                   description: 'list of users without password expiration rule'
                   type: array
-                  items: { type: string, description: 'user login', nullable: false, example: admin, minLength: 1, maxLength: 255 }
+                  items: { type: string, description: 'user login', example: admin, minLength: 1, maxLength: 255 }
             can_reuse_passwords:
               description: 'is allowed or not to reuse a password among 3 last'
               type: boolean
               default: false
             delay_before_new_password:
               description: 'delay in seconds before a new password can be set'
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               minimum: 3600
               maximum: 604800
               default: 3600
@@ -5610,17 +5612,19 @@ components:
           type: boolean
           description: Logout
         logout_from_url:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Indicates the logout URL'
           example: 'https://idp/saml'
-          nullable: true
         auto_import:
           type: boolean
           description: 'Auto import user from external provider'
           example: true
         contact_template:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             id:
               type: integer
@@ -5631,15 +5635,17 @@ components:
               description: 'Contact template name'
               example: Default
         email_bind_attribute:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Email bind attribute'
           example: email
-          nullable: true
         fullname_bind_attribute:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Fullname bind attribute'
           example: name
-          nullable: true
         authentication_conditions:
           type: object
           required:
@@ -5667,7 +5673,6 @@ components:
               type: boolean
             attribute_path:
               type: string
-              nullable: false
               example: info.items.groups
             relations:
               type: array
@@ -5765,18 +5770,21 @@ components:
             description: 'IP address'
             example: 127.0.0.1
         login_header_attribute:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Header used to retrieve user's login"
           example: HTTP_AUTH_USER
         pattern_matching_login:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Pattern to search for in the login header attribute name'
           example: '/@.*/'
         pattern_replace_login:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'String that will replace the string defined in the Pattern match login (regex) field'
           example: '/@.*/'
     Comment.Resources:
@@ -5804,14 +5812,16 @@ components:
                 description: 'Resource ID'
                 example: 10
               parent:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 properties:
                   id: { type: integer, description: 'Parent resource ID', example: 17 }
               date:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 format: date-time
-                nullable: true
                 description: 'Date of the comment (ISO8601)'
               comment:
                 type: string
@@ -5958,8 +5968,9 @@ components:
           description: 'is active or not (enable/disable)'
           example: true
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'some comment'
     Configuration.Service.Category:
       type: object
@@ -5996,8 +6007,9 @@ components:
           description: 'is active or not (enable/disable)'
           example: true
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'some comment'
     Configuration.Service.Category.Add:
       type: object
@@ -6038,9 +6050,10 @@ components:
           description: 'Define the image ID associated with this severity'
           example: 1
         comment:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Host severity comment'
-          nullable: true
         is_activated:
           type: boolean
           description: 'Indicates whether this host severity is enabled or not'
@@ -6064,9 +6077,10 @@ components:
           description: 'Define the image ID associated with this severity'
           example: 1
         comment:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Host severity comment'
-          nullable: true
         is_activated:
           type: boolean
           description: 'Indicates whether this host severity is enabled or not'
@@ -6094,60 +6108,71 @@ components:
           description: 'Host template alias'
           example: generic-active-host
         snmp_community:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Community of the SNMP agent'
         snmp_version:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           enum:
             - '1'
             - 2c
             - '3'
+            - null
           description: |
             Version of the SNMP agent.
 
             The value can be `1`, `2c` or `3`
           example: 2c
         timezone_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Timezone ID'
           example: 1
-          nullable: true
         severity_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Severity ID'
           example: 1
-          nullable: true
         check_command_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Check command ID'
           example: 1
-          nullable: true
         check_command_args:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Check command arguments'
           example: '!0!OK'
-          nullable: true
         check_timeperiod_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Check command timeperiod ID'
           example: 1
-          nullable: true
         max_check_attempts:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Define the number of times that monitoring engine will retry the host check command if it returns any non-OK state'
         check_interval:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of 'time units' between regularly scheduled checks of the host.
 
             With the default time unit of 60s, this number will mean multiples of 1 minute.
         retry_check_interval:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -6195,8 +6220,9 @@ components:
             example: A value equal to 5 corresponding to the selected options DOWN and RECOVERY
           example: 5
         notification_interval:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -6204,10 +6230,11 @@ components:
 
             A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
         notification_timeperiod_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Notification timeperiod ID'
           example: 1
-          nullable: true
         add_inherited_contact_group:
           type: boolean
           description: |
@@ -6221,22 +6248,25 @@ components:
 
             When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
         first_notification_delay:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
             With the default time unit of 60s, this number will mean multiples of 1 minute.
         recovery_notification_delay:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
             With the default time unit of 60s, this number will mean multiples of 1 minute.
         acknowledgement_timeout:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify a duration of acknowledgement for this host.'
         freshness_checked:
           type: integer
@@ -6247,8 +6277,9 @@ components:
             * `1` - STATUS_ENABLE
             * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of the Centreon Engine)
         freshness_threshold:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify the freshness threshold (in seconds) for this host.'
         flap_detection_enabled:
           type: integer
@@ -6259,12 +6290,14 @@ components:
             * `1` - STATUS_ENABLE
             * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of the Centreon Engine)
         low_flap_threshold:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify the low state change threshold used in flap detection for this host'
         high_flap_threshold:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify the high state change threshold used in flap detection for this host'
         event_handler_enabled:
           type: integer
@@ -6275,43 +6308,51 @@ components:
             * `1` - STATUS_ENABLE
             * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of the Centreon Engine)
         event_handler_command_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Event handler command ID'
           example: 1
-          nullable: true
         event_handler_command_args:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Event handler command arguments'
           example: '!0!OK'
-          nullable: true
         note_url:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Define an optional URL that can be used to provide more information about the host.'
         note:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Define an optional note.'
         action_url:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Define an optional URL that can be used to provide more actions to be performed on the host.'
         icon_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Define the image ID that should be associated with this host template'
           example: 1
         icon_alternative:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 200
           description: 'Define an optional string that is used in the alternative description of the icon image'
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Host template comments'
         is_activated:
           type: boolean
@@ -6334,20 +6375,23 @@ components:
           description: 'Service group name'
           example: MySQL-Servers
         alias:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 200
           description: 'Service group alias'
           example: 'All MySQL Servers'
         geo_coords:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 32
           description: 'Geographical coordinates use by Centreon Map module to position element on map'
           example: '48.51,2.20'
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Comments on this service group'
         is_activated:
@@ -6409,8 +6453,9 @@ components:
           maxLength: 255
           description: 'Image path'
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Image comments'
     User.Filter:
@@ -6636,23 +6681,26 @@ components:
           description: 'Name of the server'
           example: Central
         address:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'IP address of the server'
           example: 127.0.0.1
-          nullable: true
         isRunning:
           type: boolean
           description: 'Indicates if the server is running or not'
           example: true
         lastAlive:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Timestamp of last time server was alive'
-          nullable: true
         version:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Version of the server (centreon-engine)'
           example: 20.10.0
-          nullable: true
     Monitoring.Category:
       type: object
       properties:
@@ -6722,8 +6770,9 @@ components:
           items:
             $ref: '#/components/schemas/Monitoring.Resource.Action'
     Acknowledgement.Host:
-      type: object
-      nullable: true
+      type:
+        - object
+        - 'null'
       properties:
         id:
           type: integer
@@ -6744,9 +6793,10 @@ components:
           description: 'Short description of the acknowledgement'
           example: 'Acknowledged by admin'
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of the request for cancellation of the acknowledgement (ISO8601)'
         entry_time:
           type: string
@@ -6783,13 +6833,15 @@ components:
              * `3` - UNKNOWN
           example: 1
     Acknowledgement.Service:
-      type: object
-      nullable: true
+      type:
+        - object
+        - 'null'
       allOf:
         - $ref: '#/components/schemas/Acknowledgement.Host'
         -
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             service_id:
               type: integer
@@ -6922,9 +6974,10 @@ components:
           format: date-time
           description: 'Scheduled end date of the downtime (ISO8601)'
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of cancellation of downtime (ISO8601)'
           example: null
         actual_start_time:
@@ -7044,8 +7097,9 @@ components:
                 description: 'Resource ID'
                 example: 10
               parent:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 properties:
                   id: { type: integer, description: 'Parent resource ID', example: 17 }
     SubmitResult.Host:
@@ -7066,13 +7120,15 @@ components:
             * `2` - UNREACHABLE
           example: 1
         output:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Output result of the check sent'
           example: 'CRITICAL: Connection lost'
         performance_data:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Performance data result of the check sent'
           example: "'nbproc'=0;;1:1;0;"
     SubmitResult.Service:
@@ -7095,13 +7151,15 @@ components:
             * `3` - UNKNOWN
           example: 2
         output:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Output result of the check sent'
           example: 'CRITICAL: Memory exceeded '
         performance_data:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Performance data result of the check sent'
           example: "'used'=453849088B;;;0;1927262208"
     SubmitResult.Resources:
@@ -7130,8 +7188,9 @@ components:
                 description: 'Resource ID'
                 example: 10
               parent:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 properties:
                   id: { type: integer, description: 'Parent resource ID', example: 17 }
               status:
@@ -7149,13 +7208,15 @@ components:
                   * `3` - UNKNOWN
                 example: 2
               output:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: 'Output result of the check sent'
                 example: 'CRITICAL: Memory exceeded '
               performance_data:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: 'Performance data result of the check sent'
                 example: "'used'=453849088B;;;0;1927262208"
     Monitoring.Resource.Action:
@@ -7171,8 +7232,9 @@ components:
           description: 'ID of the resource'
           example: 12
         parent:
-          nullable: true
-          type: object
+          type:
+            - object
+            - 'null'
           properties:
             id:
               type: integer
@@ -7205,8 +7267,9 @@ components:
           description: 'ID of the host behind the resource'
           example: 12
         service_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           format: int32
           description: 'ID of the service behind the resource'
           example: 12
@@ -7215,13 +7278,15 @@ components:
           description: 'Resource name'
           example: Ping
         alias:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Resource alias'
           example: null
         fqdn:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Resource fqdn'
           example: null
         links:
@@ -7231,8 +7296,9 @@ components:
           description: 'Monitoring Server from which is monitored the Resource'
           example: Central
         icon:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             id:
               type: integer
@@ -7248,8 +7314,9 @@ components:
               description: 'Url of the icon'
               example: /media/memory.png
         parent:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             type:
               type: string
@@ -7269,8 +7336,9 @@ components:
               description: 'Parent resource name'
               example: Central
             alias:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Parent resource alias'
               example: Host
             fqdn:
@@ -7292,48 +7360,57 @@ components:
           description: 'Indicates whether resource is acknowledged'
           example: false
         duration:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Duration since last status change'
           example: '2h 3m'
         last_status_change:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of the last status change (ISO8601)'
         last_time_with_no_issue:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of the last status change (ISO8601)'
         tries:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Number of check tries'
           example: '3/3 (H)'
         last_check:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Duration since last check'
           example: '1h 45m'
         information:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Output of the resource'
           example: 'OK - Ping is ok'
         has_active_checks_enabled:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: 'Indicates whether active checks are enabled'
           example: true
         has_passive_checks_enabled:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: 'Indicates whether passive checks are enabled'
           example: true
         performance_data:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Performance data result of the check sent'
           example: 'rta=0.025ms;200.000;400.000;0; rtmax=0.061ms;;;; rtmin=0.015ms;;;; pl=0%;20;50;0;100 '
         is_notification_enabled:
@@ -7341,8 +7418,9 @@ components:
           description: 'Indicates if notifications are enabled for the resource'
           example: false
         severity:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             type:
               type: string
@@ -7382,95 +7460,112 @@ components:
           type: object
           properties:
             configuration:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'configuration uri'
               example: '/centreon/main.php?p=60101&o=c&host_id=11'
             logs:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'logs uri'
               example: '/centreon/main.php?p=20301&h=11'
             reporting:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'reporting uri'
               example: '/centreon/main.php?p=307&host=11'
         endpoints:
           type: object
           properties:
             details:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource details endpoint'
               example: /centreon/api/latest/monitoring/resources/hosts/11
             timeline:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource timeline endpoint'
               example: /centreon/api/latest/monitoring/hosts/11/timeline
             status_graph:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource status graph endpoint'
               example: null
             performance_graph:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource performance graph endpoint'
               example: null
             acknowledgement:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'current resource acknowledgement endpoint'
               example: '/centreon/api/latest/monitoring/hosts/11/acknowledgements?limit=1'
             downtime:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'current resource downtimes endpoint'
               example: '/centreon/api/latest/monitoring/hosts/11/downtimes?search=%7B%22%24and%22:%5B%7B%22start_time%22:%7B%22%24lt%22:1599655905%7D,%22end_time%22:%7B%22%24gt%22:1599655905%7D,%220%22:%7B%22%24or%22:%7B%22is_cancelled%22:%7B%22%24neq%22:1%7D,%22deletion_time%22:%7B%22%24gt%22:1599655905%7D%7D%7D%7D%5D%7D'
             notification_policy:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'current resource notification policy endpoint'
               example: /centreon/api/latest/configurations/hosts/11/notification-policy
             check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Endpoint dedicated for checks (forced_check payload entry set to false)'
               example: /centreon/api/latest/monitoring/hosts/17/services/23/check
             forced_check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Endpoint dedicated for checks (forced_check payload entry set to true)'
               example: /centreon/api/latest/monitoring/hosts/17/services/23/check
             metrics:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Endpoint dedicated for service metrics'
               example: /centreon/api/latest/monitoring/hosts/17/services/23/metrics
         externals:
           type: object
           properties:
             action_url:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'URL that can be used to provide more actions to be performed on the resource'
               example: 'http://mediawiki/resource/name'
             notes:
               $ref: '#/components/schemas/Monitoring.Notes'
     Monitoring.Notes:
-      type: object
-      nullable: true
+      type:
+        - object
+        - 'null'
       properties:
         url:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'URL that can be used to provide more information on the resource'
           example: 'http://mediawiki/resource/name'
         label:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Note that can be used to describe the note url'
           example: 'How to turn back on the server'
     Monitoring.ResourceStatus:
@@ -7585,13 +7680,15 @@ components:
                   * `1` - Passive
               example: 0
             last_hard_state:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Date of the last hard state (ISO8601)'
             last_notification:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Date of the last notification (ISO8601)'
             latency:
@@ -7600,8 +7697,9 @@ components:
               description: 'Time difference between scheduled check time and actual check time'
               example: 0.005
             next_check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Scheduled date for the next check (ISO8601)'
             next_host_notification:
@@ -7688,9 +7786,10 @@ components:
               description: 'Indicates whether the host is checked'
               example: true
             execution_time:
-              type: number
+              type:
+                - number
+                - 'null'
               format: float
-              nullable: true
               description: 'Time duration to check the host'
               example: 0.070906
             icon_image:
@@ -7702,39 +7801,46 @@ components:
               description: 'Alternative text of the icon representing the host'
               example: ''
             last_check:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of last check (ISO8601)'
             last_hard_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last hard state change (ISO8601)'
             last_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last state change (soft or hard) (ISO8601)'
             last_time_down:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the host was DOWN (ISO8601)'
             last_time_unreachable:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the host was UNREACHABLE (ISO8601)'
             last_time_up:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the host was UP (ISO8601)'
             last_update:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of last update (ISO8601)'
             max_check_attempts:
               type: integer
@@ -7766,8 +7872,9 @@ components:
               description: 'Is there scheduled downtime for host or not (1 or 0)'
               example: 0
             criticality:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               description: 'Host criticality level (for display purposes)'
               example: 10
     Monitoring.HostWithService:
@@ -7869,14 +7976,16 @@ components:
               description: 'Alternative text of the icon representing the service'
               example: ''
             last_check:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of last check (ISO8601)'
             last_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last state change (ISO8601)'
             max_check_attempts:
               type: integer
@@ -7895,15 +8004,17 @@ components:
                   * `1` - HARD
               example: 1
             criticality:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               description: 'Service criticality level (for display purposes)'
               example: 10
             status:
               $ref: '#/components/schemas/Monitoring.ResourceStatus'
             duration:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Duration since last status change'
               example: '2h 3m'
     Monitoring.ServiceFull:
@@ -7933,8 +8044,9 @@ components:
                   * `1` - Passive
               example: 0
             command_line:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Command used for active checks'
               example: '/usr/lib64/nagios/plugins/check_icmp -H 127.0.0.1 -n 5 -w 200,20% -c 400,50%'
             execution_time:
@@ -7955,39 +8067,46 @@ components:
               description: 'Indicates whether the service has been checked'
               example: true
             last_hard_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last hard state change (ISO8601)'
             last_notification:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last notification (ISO8601)'
             last_time_critical:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was CRITICAL (ISO8601)'
             last_time_ok:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was OK (ISO8601)'
             last_time_unknown:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was UNKNOWN (ISO8601)'
             last_time_warning:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was WARNING (ISO8601)'
             last_update:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last update (ISO8601)'
             latency:
               type: number
@@ -7995,8 +8114,9 @@ components:
               description: 'Time difference between scheduled check time and actual check time'
               example: 0.031
             next_check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Scheduled date for the next check (ISO8601)'
             performance_data:
@@ -8014,8 +8134,9 @@ components:
             acknowledgement:
               allOf:
                 - $ref: '#/components/schemas/Acknowledgement.Service'
-              type: object
-              nullable: true
+              type:
+                - object
+                - 'null'
             flapping:
               type: boolean
               description: 'Is the host flapping or not'
@@ -8038,9 +8159,10 @@ components:
           description: 'ID of the resource'
           example: 12
         parent_resource_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           format: int64
-          nullable: true
           description: 'ID of the parent resource (eg: host id)'
           example: 5
     Configuration.Proxy:
@@ -8057,13 +8179,15 @@ components:
           maximum: 65535
           example: 3128
         user:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Login used to connect to proxy'
           example: proxy-user
         password:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Password used to connect to proxy'
           example: proxy-pass
       required:
@@ -8093,26 +8217,30 @@ components:
           format: date-time
           description: 'The date the event happened (ISO8601)'
         start_date:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'The date the event started (ISO8601) (start date of downtime)'
         end_date:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'The date the event ended (ISO8601) (end date of downtime)'
         content:
           type: string
           description: 'The content of the event'
         contact:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: 'The contact of the event'
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               description: 'Id of the contact'
             name:
               type: string
@@ -8120,8 +8248,9 @@ components:
         status:
           $ref: '#/components/schemas/Monitoring.ResourceStatus'
         tries:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'The count of retry'
     Topology.Register:
       type: object
@@ -8210,23 +8339,27 @@ components:
           type: object
           properties:
             host:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               example: example.proxy.com
               description: 'Host of your proxy'
             port:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               example: 80
               description: 'Proxy port'
             user:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               example: admin
               description: 'proxy username'
             password:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               example: centreon
               description: 'proxy password'
     Gorgone.Response:
@@ -8299,12 +8432,14 @@ components:
           type: string
         title:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         instance:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     ConstraintViolation.jsonld-jsonld:
       type: object
       description: 'Unprocessable entity'
@@ -8358,12 +8493,14 @@ components:
           type: string
         title:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         instance:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Error:
       type: object
       description: 'A representation of common errors.'
@@ -8444,28 +8581,32 @@ components:
       deprecated: false
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: $USER1$
         expression:
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
         comment:
           maxLength: 255
           description: 'Additional information about the macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
         is_password:
           type: boolean
@@ -8486,28 +8627,32 @@ components:
           readOnly: true
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: $USER1$
         expression:
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
         comment:
           maxLength: 255
           description: 'Additional information about the macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
         is_password:
           type: boolean
@@ -8526,8 +8671,9 @@ components:
         name:
           maxLength: 255
           description: 'Name of plugin'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: negate
     ListPlugins.jsonld:
       type: object
@@ -8545,8 +8691,9 @@ components:
         name:
           maxLength: 255
           description: 'Name of plugin'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: negate
     ServiceCategory:
       type: object
@@ -8591,11 +8738,13 @@ components:
       deprecated: false
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     StandardMacroResource.jsonld:
       type: object
       description: ''
@@ -8608,11 +8757,13 @@ components:
           readOnly: true
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Command:
       type: object
       properties:
@@ -8810,8 +8961,9 @@ components:
           example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
         description:
           description: 'The connector description'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'Connector using SSH to connect to remote hosts'
         is_activated:
           description: 'Indicates whether the connector is activated'
@@ -8840,8 +8992,9 @@ components:
           example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
         description:
           description: 'The connector description'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'Connector using SSH to connect to remote hosts'
         is_activated:
           description: 'Indicates whether the connector is activated'
@@ -9159,29 +9312,33 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
-          type: string
+          type:
+            - string
+            - 'null'
           example: $USER1$
-          nullable: true
         expression:
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
-          type: string
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
-          nullable: true
         comment:
           maxLength: 255
           description: 'Additional information about the macro'
-          type: string
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
-          nullable: true
         is_password:
           type: boolean
         is_activated:
@@ -9196,29 +9353,33 @@ components:
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
               minLength: 1
               maxLength: 255
               pattern: '^(\$.*\$)$'
               description: 'Name of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: $USER1$
-              nullable: true
             expression:
               minLength: 1
               maxLength: 255
               description: 'Expression (value) of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: /usr/lib64/nagios/plugins
-              nullable: true
             comment:
               maxLength: 255
               description: 'Additional information about the macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This macro is used to define the path of plugins'
-              nullable: true
             is_password:
               type: boolean
             is_activated:
@@ -9463,8 +9624,9 @@ components:
           maxLength: 255
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         is_activated:
           type: boolean
     Service.Category.jsonld:
@@ -9482,19 +9644,22 @@ components:
               maxLength: 255
               type: string
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             is_activated:
               type: boolean
     Standard.Macro:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Standard.Macro.jsonld:
       allOf:
         - $ref: '#/components/schemas/HydraItemBaseSchema'
@@ -9502,11 +9667,13 @@ components:
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
     GlobalMacro:
       type: object
       properties:
@@ -9603,14 +9770,17 @@ components:
           maxLength: 255
           type: string
         central_address:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         uid:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Poller-poller.write:
       type: object
       properties:
@@ -9651,14 +9821,17 @@ components:
               maxLength: 255
               type: string
             central_address:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             uid:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
     StandardMacro:
       type: object
       properties:

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddOrUpdateRuleRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddOrUpdateRuleRequest.yaml
@@ -32,8 +32,9 @@ properties:
           description: "Indicates that the rule should be applied to all current / future contact groups"
           example: true
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Short description of the rule"
     example: "Rule dedicated for users with limited rights"
   is_enabled:

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddRuleResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddRuleResponse.yaml
@@ -32,8 +32,9 @@ properties:
           description: "Indicates that the rule should be applied to all current / future contact groups"
           example: true
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Short description of the rule"
     example: "Rule dedicated for users with limited rights"
   is_enabled:

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilter.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilter.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - object
+  - 'null'
 properties:
   type:
     type: string

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilterWithNames.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilterWithNames.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - object
+  - 'null'
 properties:
   type:
     type: string

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
@@ -5,8 +5,9 @@ properties:
     description: "Resource access rule name"
     example: "Rule for viewers"
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Short description of the rule"
     example: "Rule dedicated for users with limited rights"
   is_enabled:

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostRequest.yaml
@@ -18,38 +18,44 @@ properties:
     description: "Host alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -57,24 +63,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -83,28 +93,33 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether the host is activated or not"
   categories:
     type: array
@@ -137,17 +152,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -159,7 +176,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostResponse.yaml
@@ -17,43 +17,50 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host alias"
     example: "generic-active-host"
-    nullable: true
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -61,24 +68,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -87,23 +98,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
@@ -165,8 +180,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -177,7 +193,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/FindHostsResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/FindHostsResponse.yaml
@@ -4,25 +4,20 @@ properties:
     type: integer
     description: "Host ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Host name"
     example: "Centreon-Server"
-    nullable: false
   alias:
     type: string
     description: "Host alias"
     example: ""
-    nullable: false
   address:
     type: string
     description: "IP or domain of the host"
     example: "127.0.0.1"
-    nullable: false
   monitoring_server:
     type: object
-    nullable: false
     properties:
       id:
         type: integer
@@ -47,15 +42,18 @@ properties:
           description: "Host template name"
           example: 'generic-host'
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
     default: 5
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -64,10 +62,10 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
     default: 1
-    nullable: true
   check_timeperiod:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -78,8 +76,9 @@ properties:
         description: "Check timeperiod name"
         example: "24x7"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -119,4 +118,3 @@ properties:
   is_activated:
     type: boolean
     description: "Indicates whether the host is activated or not"
-    nullable: false

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/GetHostResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/GetHostResponse.yaml
@@ -17,43 +17,50 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host alias"
     example: "generic-active-host"
-    nullable: true
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -61,24 +68,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -100,23 +111,27 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
@@ -178,8 +193,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -190,7 +206,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
@@ -17,38 +17,44 @@ properties:
     description: "Host alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -56,24 +62,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -90,33 +100,39 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether the host is activated or not"
   categories:
     type: array
@@ -149,17 +165,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -171,7 +189,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
@@ -6,31 +6,36 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "ID of the hostgroup Icon"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host group comment"
     example: "This is a comment"
   hosts:
-    type: array
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
-    nullable: true
     example: [1, 2, 3]
     items:
       type: integer

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
@@ -10,19 +10,22 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host group"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
@@ -10,14 +10,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -34,8 +36,9 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
@@ -6,14 +6,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -30,8 +32,9 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
@@ -6,29 +6,34 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "ID of the host group icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host group comment"
     example: "This is a comment"
   hosts:
-    type: array
-    nullable: true
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
     example: [1, 2, 3]
     items:

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
@@ -10,33 +10,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -44,24 +49,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   nornal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -70,23 +79,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   categories:
@@ -114,17 +127,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -136,7 +151,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -13,33 +13,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -47,24 +52,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -73,23 +82,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   is_locked:
@@ -138,8 +151,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -150,7 +164,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
@@ -13,33 +13,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -47,24 +52,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -80,28 +89,33 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   is_locked:
@@ -150,8 +164,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -162,7 +177,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/HostTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/HostTemplate.yaml
@@ -13,47 +13,55 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -62,23 +70,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   is_locked:

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -12,17 +12,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -34,8 +36,9 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"
   categories:
@@ -64,33 +67,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -98,24 +106,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -132,27 +144,32 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableResources.Listing.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableResources.Listing.yaml
@@ -15,9 +15,10 @@ properties:
           type: string
           example: "Host 1"
         alias:
-          type: string
+          type:
+            - string
+            - 'null'
           example: "Host 1"
-          nullable: true
         event:
           type: integer
           description: "Bitmask representing host's status triggering a notification"
@@ -34,9 +35,10 @@ properties:
                 type: string
                 example: "Ping"
               alias:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 example: "Ping"
-                nullable: true
               event:
                 type: integer
                 description: "Bitmask representing service's status triggering a notification"

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableRule.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableRule.yaml
@@ -7,8 +7,9 @@ properties:
     type: object
     properties:
       email:
-        type: object
-        nullable: true
+        type:
+          - object
+          - 'null'
         properties:
           contacts:
             type: array
@@ -28,8 +29,9 @@ properties:
             type: string
             example: "This is a formatted message"
       slack:
-        type: object
-        nullable: true
+        type:
+          - object
+          - 'null'
         properties:
           slack_channel:
             type: string
@@ -38,8 +40,9 @@ properties:
             type: string
             example: "This is a Slack message"
       sms:
-        type: object
-        nullable: true
+        type:
+          - object
+          - 'null'
         properties:
           phone_number:
             type: string

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceRequest.yaml
@@ -9,8 +9,9 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   service_template_id:
@@ -19,16 +20,18 @@ properties:
     minimum: 1
     example: null
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -37,18 +40,22 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -56,33 +63,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   service_categories:
     type: array
     description: "IDs of service categories linked to this service."

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceResponse.yaml
@@ -18,22 +18,25 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -42,18 +45,22 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,33 +68,37 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       categories:
         type: array
         description: "Service categories associated with this service"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/DeployServiceResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/DeployServiceResponse.yaml
@@ -18,30 +18,36 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -49,30 +55,34 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/FindServicesResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/FindServicesResponse.yaml
@@ -15,28 +15,24 @@ allOf:
           - $ref: 'simpleEntity.yaml'
       service_template:
         description: "Service template linked to this service."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       check_timeperiod:
         description: "Time period of the check command."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       notification_timeperiod:
         description: "Time period of the notification command."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       severity:
         description: "Severity linked to this service."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       categories:
         type: array
         description: "Service categories associated with this service."
@@ -61,14 +57,17 @@ allOf:
               type: string
               example: 'host-name'
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -76,7 +75,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/GetServiceResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/GetServiceResponse.yaml
@@ -17,12 +17,14 @@ allOf:
         description: 'Geographic coordinates of the service'
         example: '48.10,12.5'
       service_template_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Template ID of the service template.'
       check_command_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Check command ID.'
       check_command_args:
         type: array
@@ -31,29 +33,35 @@ allOf:
           description: 'Arguments of the check command.'
         example: ['80', '90']
       check_timeperiod_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Time period ID of the check command.'
       event_handler_enabled:
         type: integer
         description: 'Enable/disable event handler command (0/1/2).'
       event_handler_command_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Event handler command ID.'
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: 'Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state.'
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,35 +69,38 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       notification_timeperiod:
         description: 'Time period of the notification command.'
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: 'Define an optional note.'
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: 'Define an optional URL that can be used to provide more information about the service.'
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: 'Define an optional URL that can be used to specify actions to be performed on the service.'
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Icon ID associated with this service.'
       severity_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Severity ID.'
       is_activated:
         type: boolean

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
@@ -9,27 +9,31 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -38,18 +42,22 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -57,33 +65,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   is_activated:
     type: boolean
     description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/macro.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
@@ -18,22 +18,25 @@ allOf:
         description: "Service template alias."
         example: "generic-service"
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -42,18 +45,22 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,33 +68,37 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service template."
         minimum: 1
-        nullable: true
         example: null
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
@@ -13,16 +13,18 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -31,24 +33,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -56,33 +63,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
@@ -12,16 +12,18 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -39,30 +41,36 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -70,33 +78,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -9,16 +9,18 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -50,31 +52,36 @@ properties:
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/macro.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Common/Response/MultiStatus.yaml
+++ b/centreon/doc/API/latest/Common/Response/MultiStatus.yaml
@@ -11,14 +11,16 @@ content:
             type: object
             properties:
               href:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 example: "/path/to/entity/1"
               status:
                 type: integer
                 format: int64
                 example: 404
               message:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 example: "Not found"

--- a/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/PartialUpdateAuthenticationOpenIdProvider.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/PartialUpdateAuthenticationOpenIdProvider.yaml
@@ -9,35 +9,41 @@ properties:
     description: "Indicates whether the provider is forced or not"
     example: false
   base_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Base URL of the provider"
     example: "https://localhost:8080"
-    nullable: true
   authorization_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authorization endpoint of the provider"
     example: "/authorize"
-    nullable: true
   token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Token endpoint of the provider"
     example: "/token"
-    nullable: true
   introspection_token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Introspection token endpoint of the provider"
     example: "/introspect"
-    nullable: true
   userinfo_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Userinfo endpoint of the provider"
     example: "/userinfo"
-    nullable: true
   endsession_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Endsession endpoint of the provider"
     example: "/logout"
-    nullable: true
   connection_scopes:
     type: array
     description: "List of scopes to request"
@@ -46,28 +52,33 @@ properties:
       description: "Scope"
       example: "openid"
   login_claim:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Claim used to login"
     example: "sub"
-    nullable: true
   client_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client ID"
     example: "client_id"
-    nullable: true
   client_secret:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client secret"
     example: "client_secret"
-    nullable: true
   authentication_type:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authentication type"
     example: "client_secret_post"
-    nullable: true
     enum:
       - client_secret_post
       - client_secret_basic
+      - null
   verify_peer:
     type: boolean
     description: "Verify peer"
@@ -77,8 +88,9 @@ properties:
     description: "Auto import user from external provider"
     example: true
   contact_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -89,20 +101,23 @@ properties:
         description: "Contact template name"
         example: "Default"
   email_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Email bind attribute"
     example: "email"
-    nullable: true
   fullname_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Fullname bind attribute"
     example: "name"
-    nullable: true
   redirect_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "custom redirect url"
     example: "https://my_custom_domain.com"
-    nullable: true
   authentication_conditions:
     type: object
     properties:
@@ -133,8 +148,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       authorized_values:
         type: array
         items:
@@ -146,7 +162,6 @@ properties:
         type: boolean
       attribute_path:
         type: string
-        nullable: false
         example: info.items.groups
       endpoint:
         type: object
@@ -156,8 +171,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:
@@ -190,8 +206,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:

--- a/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/ReadAuthenticationOpenIdProvider.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/ReadAuthenticationOpenIdProvider.yaml
@@ -29,35 +29,41 @@ properties:
     description: "Indicates whether the provider is forced or not"
     example: false
   base_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Base URL of the provider"
     example: "https://localhost:8080"
-    nullable: true
   authorization_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authorization endpoint of the provider"
     example: "/authorize"
-    nullable: true
   token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Token endpoint of the provider"
     example: "/token"
-    nullable: true
   introspection_token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Introspection token endpoint of the provider"
     example: "/introspect"
-    nullable: true
   userinfo_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Userinfo endpoint of the provider"
     example: "/userinfo"
-    nullable: true
   endsession_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Endsession endpoint of the provider"
     example: "/logout"
-    nullable: true
   connection_scopes:
     type: array
     description: "List of scopes to request"
@@ -66,28 +72,33 @@ properties:
       description: "Scope"
       example: "openid"
   login_claim:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Claim used to login"
     example: "sub"
-    nullable: true
   client_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client ID"
     example: "client_id"
-    nullable: true
   client_secret:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client secret"
     example: "client_secret"
-    nullable: true
   authentication_type:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authentication type"
     example: "client_secret_post"
-    nullable: true
     enum:
       - client_secret_post
       - client_secret_basic
+      - null
   verify_peer:
     type: boolean
     description: "Verify peer"
@@ -97,8 +108,9 @@ properties:
     description: "Auto import user from external provider"
     example: true
   contact_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -109,20 +121,23 @@ properties:
         description: "Contact template name"
         example: "Default"
   email_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Email bind attribute"
     example: "email"
-    nullable: true
   fullname_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Fullname bind attribute"
     example: "name"
-    nullable: true
   redirect_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "custom redirect url"
     example: "https://my_custom_domain.com"
-    nullable: true
   authentication_conditions:
     type: object
     required:
@@ -159,8 +174,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       authorized_values:
         type: array
         items:
@@ -177,7 +193,6 @@ properties:
         type: boolean
       attribute_path:
         type: string
-        nullable: false
         example: info.items.groups
       endpoint:
         type: object
@@ -186,8 +201,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:
@@ -232,8 +248,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:

--- a/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/UpdateAuthenticationOpenIdProvider.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/UpdateAuthenticationOpenIdProvider.yaml
@@ -29,35 +29,41 @@ properties:
     description: "Indicates whether the provider is forced or not"
     example: false
   base_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Base URL of the provider"
     example: "https://localhost:8080"
-    nullable: true
   authorization_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authorization endpoint of the provider"
     example: "/authorize"
-    nullable: true
   token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Token endpoint of the provider"
     example: "/token"
-    nullable: true
   introspection_token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Introspection token endpoint of the provider"
     example: "/introspect"
-    nullable: true
   userinfo_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Userinfo endpoint of the provider"
     example: "/userinfo"
-    nullable: true
   endsession_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Endsession endpoint of the provider"
     example: "/logout"
-    nullable: true
   connection_scopes:
     type: array
     description: "List of scopes to request"
@@ -66,28 +72,33 @@ properties:
       description: "Scope"
       example: "openid"
   login_claim:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Claim used to login"
     example: "sub"
-    nullable: true
   client_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client ID"
     example: "client_id"
-    nullable: true
   client_secret:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client secret"
     example: "client_secret"
-    nullable: true
   authentication_type:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authentication type"
     example: "client_secret_post"
-    nullable: true
     enum:
       - client_secret_post
       - client_secret_basic
+      - null
   verify_peer:
     type: boolean
     description: "Verify peer"
@@ -97,8 +108,9 @@ properties:
     description: "Auto import user from external provider"
     example: true
   contact_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -109,20 +121,23 @@ properties:
         description: "Contact template name"
         example: "Default"
   email_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Email bind attribute"
     example: "email"
-    nullable: true
   fullname_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Fullname bind attribute"
     example: "name"
-    nullable: true
   redirect_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "custom redirect url"
     example: "https://my_custom_domain.com"
-    nullable: true
   authentication_conditions:
     type: object
     required:
@@ -159,8 +174,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       authorized_values:
         type: array
         items:
@@ -177,7 +193,6 @@ properties:
         type: boolean
       attribute_path:
         type: string
-        nullable: false
         example: info.items.groups
       endpoint:
         type: object
@@ -186,8 +201,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:
@@ -224,8 +240,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewToken.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewToken.yaml
@@ -9,11 +9,12 @@ properties:
     description: "User ID linked to the authentication token (mandatory for type API)"
     example: 23
   expiration_date:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Expiration date of the authentication token"
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
-    nullable: true
   type:
     type: string
     enum: ["cma", "api", "poller"]

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
@@ -9,8 +9,9 @@ properties:
     description: "Authentication token"
     example: "xxxxxxx"
   user:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -24,10 +25,11 @@ properties:
     type: object
     properties:
       id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Token creator ID"
         example: 23
-        nullable: true
       name:
         type: string
         description: "Token creator name"
@@ -38,11 +40,12 @@ properties:
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
   expiration_date:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
-    nullable: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/Token.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/Token.yaml
@@ -5,8 +5,9 @@ properties:
     description: "Token name."
     example: "my-api-token"
   user:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -20,10 +21,11 @@ properties:
     type: object
     properties:
       id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Token creator ID"
         example: 23
-        nullable: true
       name:
         type: string
         description: "Token creator name"
@@ -34,11 +36,12 @@ properties:
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
   expiration_date:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
-    nullable: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"

--- a/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/AddAccResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/AddAccResponse.yaml
@@ -50,13 +50,15 @@ properties:
         }
       ]
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID", example: 1 }
       name: { type: string,  description: "Creation contact name", example: "admin" }
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"

--- a/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccResponse.yaml
@@ -50,24 +50,28 @@ properties:
         }
       ]
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID", example: 1 }
       name: { type: string,  description: "Creation contact name", example: "admin" }
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Update contact ID", example: 1 }
       name: { type: string,  description: "Update contact name", example: "admin" }
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Update date (ISO8601)"

--- a/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccsResponse.yaml
@@ -20,24 +20,28 @@ properties:
         * vmware_v6
     example: vmware_v6
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID", example: 1 }
       name: { type: string,  description: "Creation contact name", example: "admin" }
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Update contact ID", example: 1 }
       name: { type: string,  description: "Update contact name", example: "admin" }
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Update date (ISO8601)"

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcRequest.yaml
@@ -49,9 +49,10 @@ properties:
             example: true
 
           port:
-            type: integer
+            type:
+              - integer
+              - 'null'
             description: Port used for connection (mandatory for agent initiated connection).
-            nullable: true
 
           create_host_auto:
             type: boolean
@@ -64,8 +65,9 @@ properties:
             example: true
 
           otel_public_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the public certificate.
               - Must end with `.crt`,`.cert` or `.cer`
@@ -74,8 +76,9 @@ properties:
             example: otel-cert.crt
 
           otel_ca_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the CA certificate used by the agent.
               - Must end with `.crt` or `.cer`
@@ -84,8 +87,9 @@ properties:
             example: ca-cert.cer
 
           otel_private_key:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the private key.
               - Must end with `.key`
@@ -134,18 +138,21 @@ properties:
                   description: Port used to connect to the host.
                   example: 1234
                 poller_ca_certificate:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: CA certificate expected by the host.
                   example: poller-ca-cert.crt
                 poller_ca_name:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: CA name for the host.
                   example: CentreonCA
                 token:
-                  type: object
-                  nullable: true
+                  type:
+                    - object
+                    - 'null'
                   description: Token used for the host.
                   properties:
                     name:
@@ -197,8 +204,9 @@ properties:
           - conf_private_key
         properties:
           otel_public_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the public certificate.
               - Must end with `.crt`,`.cert` or `.cer`
@@ -207,8 +215,9 @@ properties:
             example: otel-cert.crt
 
           otel_ca_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of CA certificate.
               - Must end with `.crt`,`.cert` or `.cer`
@@ -217,8 +226,9 @@ properties:
             example: telegraf-ca.crt
 
           otel_private_key:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the private key.
               - Must end with `.key`
@@ -232,8 +242,9 @@ properties:
             example: 1443
 
           conf_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path to certificate for the configuration server.
               - Must end with `.crt` or `.cer`
@@ -242,8 +253,9 @@ properties:
             example: conf-cert.crt
 
           conf_private_key:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Private key for the configuration server.
               - Must end with `.key`

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/UpdateAcRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/UpdateAcRequest.yaml
@@ -52,16 +52,18 @@ properties:
             description: Connection initiated by poller.
             example: true
         port:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: Port used for connection (mandatory for agent initiated connection).
-          nullable: true
         create_host_auto:
           type: boolean
           description: Whether to automatically create host (in agent initiated mode).
           example: false
         otel_public_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the public certificate.
 
@@ -71,8 +73,9 @@ properties:
           example: otel-cert.crt
 
         otel_ca_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the CA certificate.
 
@@ -82,8 +85,9 @@ properties:
           example: ca-cert.cer
 
         otel_private_key:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the private key.
 
@@ -133,18 +137,21 @@ properties:
                 description: Port number for host connection.
                 example: 1443
               poller_ca_certificate:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: Path to poller's CA certificate.
                 example: poller-ca.crt
               poller_ca_name:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: CA name expected by the host.
                 example: CentreonCA
               token:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 description: Token used for this host.
                 properties:
                   name:
@@ -195,8 +202,9 @@ properties:
         - conf_private_key
       properties:
         otel_public_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the public certificate.
 
@@ -206,8 +214,9 @@ properties:
           example: otel-cert.crt
 
         otel_ca_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the CA certificate.
 
@@ -217,8 +226,9 @@ properties:
           example: telegraf-ca.crt
 
         otel_private_key:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the private key.
 
@@ -233,8 +243,9 @@ properties:
           example: 1443
 
         conf_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Server certificate path.
 
@@ -244,8 +255,9 @@ properties:
           example: conf-cert.crt
 
         conf_private_key:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Server private key path.
 

--- a/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandRequest.yaml
@@ -28,8 +28,9 @@ properties:
       Note that commands that require shell features are slowing down the poller server.
     example: true
   argument_example:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Example of command argument values"
     example: "!80!90"
   arguments:
@@ -43,8 +44,9 @@ properties:
           description: "Name of the argument"
           example: "argument-name"
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the argument"
           example: "argument-description"
   macros:
@@ -66,16 +68,19 @@ properties:
             * `2` - SERVICE
           example: 1
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the macro"
           example: "macro-description"
   connector_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       A connector is run in the background and executes specific commands without the need to execute a binary.
   graph_template_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Graph template for the command"

--- a/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandResponse.yaml
@@ -39,8 +39,9 @@ properties:
     description: "Indicates whether the command is activated or not"
     example: true
   argument_example:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Example of command argument values"
     example: "!80!90"
   arguments:
@@ -54,8 +55,9 @@ properties:
           description: "Name of the argument"
           example: "argument-name"
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the argument"
           example: "argument-description"
   macros:
@@ -77,13 +79,15 @@ properties:
             * `2` - SERVICE
           example: 1
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the macro"
           example: "macro-description"
   connector:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: |
       A connector is run in background and executes specific commands without the need to execute a binary.
     properties:
@@ -96,8 +100,9 @@ properties:
         description: "Connector name"
         example: "SSH Connector"
   graph_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Graph template for the command"
     properties:
       id:

--- a/centreon/doc/API/latest/onPremise/Configuration/Connector/Schema/FindConnectorsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Connector/Schema/FindConnectorsResponse.yaml
@@ -12,8 +12,9 @@ properties:
     type: string
     description: "Command line to be executed by the poller"
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "A short description of the connector"
     example: "some description"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/ContactGroup/Schema/FindContactGroupsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ContactGroup/Schema/FindContactGroupsResponse.yaml
@@ -4,28 +4,23 @@ properties:
     type: integer
     description: "Contact group ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Contact group name"
     example: "Contact group"
-    nullable: false
   alias:
     type: string
     description: "Contact group alias"
     example: "Contact group alias"
-    nullable: false
   comments:
     type: string
     description: "Contact group comments"
     example: "Contact group comments"
-    nullable: false
   type:
     type: string
     description: "Contact group types"
     enum: [ local, ldap ]
     example: "local"
-    nullable: false
   is_activated:
     type: boolean
     description: "Contact group activation status"

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Add.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Add.yaml
@@ -11,8 +11,9 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
@@ -31,6 +32,7 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.One.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.One.yaml
@@ -14,36 +14,41 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
 
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID" }
       name: { type: string,  description: "Creation contact name" }
 
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Last update contact ID" }
       name: { type: string,  description: "Last update contact name" }
 
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
 
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Last update date (ISO8601)"
 
   own_role:
@@ -59,8 +64,9 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10
 
   is_favorite:

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.yaml
@@ -14,36 +14,41 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
 
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID" }
       name: { type: string,  description: "Creation contact name" }
 
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Last update contact ID" }
       name: { type: string,  description: "Last update contact name" }
 
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
 
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Last update date (ISO8601)"
 
   own_role:
@@ -65,13 +70,15 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10
 
   thumbnail:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
@@ -30,27 +30,32 @@ properties:
           description: name of the metric
           example: rta
         unit:
-          type: string
+          type:
+            - string
+            - 'null'
           description: unit of the metric
           example: '%'
-          nullable: true
         warning_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: warning high threshold
           example: 200
-          nullable: true
         critical_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: critical high threshold
           example: 400
-          nullable: true
         warning_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: warning low threshold
           example: 200
-          nullable: true
         critical_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: critical low threshold
           example: 400
-          nullable: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformancesData.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformancesData.yaml
@@ -26,13 +26,15 @@ properties:
           description: metric unit
           example: "%"
         min:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: min value
           example: "0"
         max:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: max value
           example: "100"
         ds_data:
@@ -44,10 +46,11 @@ properties:
               description: color of the line
               example: "#666600"
             ds_color_area:
-              type: string
+              type:
+                - string
+                - 'null'
               description: color of the area
               example: "#666600"
-              nullable: true
             ds_filled:
               type: boolean
               description: enables area filling
@@ -57,29 +60,33 @@ properties:
               description: indicates if the curve should be inverted
               example: true
             ds_legend:
-              type: string
+              type:
+                - string
+                - 'null'
               description: legend associated to the curve
               example: "#666600"
-              nullable: true
             ds_stack:
               type: boolean
               description: enable graph stacking
               example: false
             ds_order:
-              type: integer
+              type:
+                - integer
+                - 'null'
               description: display order
               example: 2
-              nullable: true
             ds_transparency:
-              type: number
+              type:
+                - number
+                - 'null'
               description: Curve transparency. Used to export the chart
               example: 30
-              nullable: true
             ds_color_line_mode:
-              type: integer
+              type:
+                - integer
+                - 'null'
               description: curve line color mode. Random or manual
               example: 1
-              nullable: true
         legend:
           type: string
           description: metric name in legend
@@ -89,23 +96,27 @@ properties:
           description: if the metric is stacked with other metrics
           example: 0
         warning_high_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: warning high threshold
           example: null
         critical_high_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: critical high threshold
           example: null
         warning_low_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: warning low threshold
           example: null
         critical_low_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: critical low threshold
           example: null
         ds_order:
@@ -115,34 +126,39 @@ properties:
         data:
           type: array
           items:
-            type: number
+            type:
+              - number
+              - 'null'
             format: float
-            nullable: true
             description: value of the metric
           example:
             - 1.0
             - null
             - 1.0
         last_value:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: last value
           example: 5.0
         average_value:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: average value
           example: 5.64
         minimum_value:
-          type: number
+          type:
+            - number
+            - 'null'
           format: float
-          nullable: true
           description: minimum value
           example: 1.0
         maximum_value:
-          type: number
+          type:
+            - number
+            - 'null'
           format: float
-          nullable: true
           description: maximum value
           example: 1.0
   times:

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsTop.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsTop.yaml
@@ -42,32 +42,38 @@ properties:
           description: "Current value of the metrics, use to sort the resources"
           example: 1.30
         warning_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured warning threshold
           example: 100
-          nullable: true
         critical_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured critical threshold
           example: 300
-          nullable: true
         warning_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured warning low threshold
           example: 100
-          nullable: true
         critical_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured critical low threshold
           example: 300
-          nullable: true
         max:
-          type: number
+          type:
+            - number
+            - 'null'
           description: max value of the metric
           example: 100,
-          nullable: true
         min:
-          type: number
+          type:
+            - number
+            - 'null'
           description: min value of the metric
           example: 0,
-          nullable: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.PartialUpdate.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.PartialUpdate.yaml
@@ -8,8 +8,9 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
@@ -29,16 +30,18 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10
 
   thumbnail:
     type: object
     properties:
       id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 1
       name:
         type: string

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Panel/DashboardPanel.IdOptional.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Panel/DashboardPanel.IdOptional.yaml
@@ -2,7 +2,8 @@ type: object
 
 properties:
   id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Dashboard panel ID"
     example: 1

--- a/centreon/doc/API/latest/onPremise/Configuration/GraphTemplate/Schema/FindGraphTemplatesResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/GraphTemplate/Schema/FindGraphTemplatesResponse.yaml
@@ -28,13 +28,15 @@ properties:
     type: object
     properties:
       lower_limit:
-        type: number
-        nullable: true
+        type:
+          - number
+          - 'null'
         description: "Lower limit of the grid"
         example: 115
       upper_limit:
-        type: number
-        nullable: true
+        type:
+          - number
+          - 'null'
         description: "Upper limit of the grid"
         example: 115
       is_upper_limit_sized_to_max:

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostRequest.yaml
@@ -18,38 +18,44 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -57,24 +63,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -107,7 +117,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -123,10 +135,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -134,10 +146,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about alerts for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -151,22 +164,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -177,8 +193,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -189,12 +206,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -205,10 +224,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -216,33 +236,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_activated:
     type: boolean
@@ -278,17 +304,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -300,7 +328,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostResponse.yaml
@@ -17,39 +17,45 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host template alias"
     example: "generic-active-host"
-    nullable: true
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -57,24 +63,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -107,7 +117,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -123,10 +135,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -134,10 +146,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -151,22 +164,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -177,8 +193,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -189,12 +206,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -205,10 +224,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -216,33 +236,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as the alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_activated:
     type: boolean
@@ -303,8 +329,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -315,7 +342,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/FindHostsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/FindHostsResponse.yaml
@@ -4,25 +4,20 @@ properties:
     type: integer
     description: "Host ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Host name"
     example: "Centreon-Server"
-    nullable: false
   alias:
     type: string
     description: "Host alias"
     example: ""
-    nullable: false
   address:
     type: string
     description: "IP or domain of the host"
     example: "127.0.0.1"
-    nullable: false
   monitoring_server:
     type: object
-    nullable: false
     properties:
       id:
         type: integer
@@ -47,15 +42,18 @@ properties:
           description: "Host template name"
           example: 'generic-host'
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
     default: 5
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -64,10 +62,10 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
     default: 1
-    nullable: true
   notification_timeperiod:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -78,8 +76,9 @@ properties:
         description: "Notification timeperiod name"
         example: "24x7"
   check_timeperiod:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -90,8 +89,9 @@ properties:
         description: "Check timeperiod name"
         example: "24x7"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -131,4 +131,3 @@ properties:
   is_activated:
     type: boolean
     description: "Indicates whether the host is activated or not"
-    nullable: false

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/GetHostResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/GetHostResponse.yaml
@@ -17,44 +17,51 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host alias"
     example: "generic-active-host"
-    nullable: true
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
       The value can be `1`, `2c` or `3`
     example: "2c"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 255
     description: "SNMP community string of the host"
     example: "public"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -62,23 +69,27 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
@@ -106,7 +117,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
       The value is the sum of all the values of the selected options.
@@ -119,19 +132,20 @@ properties:
       * NULL - (inheritance of its parent's value. If there is no parent, the values used will be: DOWN, UNREACHABLE, RECOVERY, FLAPPING and DOWNTIME_SCHEDULED)
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
       A value of 0 disables re-notifications of contacts about problems for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -143,20 +157,23 @@ properties:
       Only used when notification inheritance for hosts and services is set to vertical inheritance only.
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -166,8 +183,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -177,12 +195,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -192,10 +212,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -203,33 +224,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as the alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host comments"
   is_activated:
     type: boolean
@@ -290,8 +317,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
             If the macro.is_password property is set to true, macro.value will be set to null.
@@ -301,7 +329,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
@@ -17,38 +17,44 @@ properties:
     description: "Host alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -56,24 +62,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -106,7 +116,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -122,10 +134,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -133,10 +145,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about alerts for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -150,22 +163,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -176,8 +192,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -188,12 +205,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -204,10 +223,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -215,33 +235,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host comments"
   is_activated:
     type: boolean
@@ -277,17 +303,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -299,7 +327,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
@@ -37,8 +37,9 @@ post:
                   type: integer
                   description: "HTTP Status Code of the operation"
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
@@ -43,8 +43,9 @@ post:
                   description: "HTTP Status Code of the operation"
                   example: 204
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
                   example: null
     '404':
@@ -65,8 +66,9 @@ post:
                   description: "HTTP Status Code of the operation"
                   example: 404
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Host Group not found"
                   example: "Host Group not found"
     '401':

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
@@ -39,8 +39,9 @@ post:
                   type: integer
                   description: "HTTP Status Code of the operation"
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
@@ -6,30 +6,35 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host group"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   hosts:
-    type: array
-    nullable: true
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
     example: [1, 2, 3]
     items:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
@@ -6,14 +6,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -30,14 +32,16 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   hosts:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
@@ -10,14 +10,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -34,14 +36,16 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
@@ -6,14 +6,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -30,13 +32,15 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
@@ -6,31 +6,36 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host group"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   hosts:
-    type: array
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
-    nullable: true
     example: [1, 2, 3]
     items:
       type: integer

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
@@ -10,33 +10,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -44,24 +49,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -94,7 +103,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -110,10 +121,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -121,10 +132,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -138,22 +150,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -164,8 +179,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -176,12 +192,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -192,10 +210,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -203,33 +222,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   categories:
     type: array
@@ -256,17 +281,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -278,7 +305,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -13,29 +13,33 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -43,24 +47,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -93,7 +101,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -109,10 +119,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -120,10 +130,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -137,22 +148,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -163,8 +177,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -175,12 +190,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -191,10 +208,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -202,33 +220,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used in the alternative description of the icon image"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_locked:
     type: boolean
@@ -276,8 +300,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -288,7 +313,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/FindHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/FindHostTemplateResponse.yaml
@@ -13,29 +13,33 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -43,24 +47,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -93,7 +101,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -109,10 +119,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -120,10 +130,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -137,22 +148,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -163,8 +177,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -175,12 +190,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -191,10 +208,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -202,33 +220,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used in the alternative description of the icon image"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_locked:
     type: boolean

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
@@ -13,28 +13,32 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -42,23 +46,27 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
@@ -86,7 +94,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
       The value is the sum of all the values of the selected options.
@@ -99,19 +109,20 @@ properties:
       * NULL - (inheritance of its parent's value. If there is no parent, the values used will be: DOWN, UNREACHABLE, RECOVERY, FLAPPING and DOWNTIME_SCHEDULED)
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -123,20 +134,23 @@ properties:
       Only used when notification inheritance for hosts and services is set to vertical inheritance only.
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -146,8 +160,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -157,12 +172,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -172,10 +189,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -183,33 +201,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used in the alternative description of the icon image"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_locked:
     type: boolean
@@ -249,8 +273,9 @@ properties:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "Macro ID"
           example: 1
         name:
@@ -258,8 +283,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
             If macro.is_password property is set to true and macro.value will be set to null.
@@ -269,7 +295,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -12,17 +12,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -34,8 +36,9 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"
   categories:
@@ -64,33 +67,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -98,24 +106,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -148,7 +160,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -164,10 +178,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -175,10 +189,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -192,22 +207,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -218,8 +236,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -230,12 +249,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -246,10 +267,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -257,31 +279,37 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaRequest.yaml
@@ -3,10 +3,8 @@ required: ['directory', 'data']
 properties:
   directory:
     type: string
-    nullable: false
     description: "Directory where the file will be created"
   data:
     type: string
     format: binary
-    nullable: false
     description: "File content"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaResponse.yaml
@@ -6,20 +6,18 @@ properties:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           example: 1
         filename:
           type: string
-          nullable: false
           example: "centreon_logo.jpg"
         directory:
           type: string
-          nullable: false
           example: "logos"
         md5:
           type: string
-          nullable: false
           example: "f7d5fc06a33946703054046c7174bbf4"
   errors:
     type: array
@@ -30,14 +28,11 @@ properties:
           type: string
           description: "file name of the media"
           example: "old_logo.jpg"
-          nullable: false
         directory:
           type: string
           description: "Destination directory"
           example: "logos"
-          nullable: false
         reason:
           type: string
           description: "Reason for error"
           example: "Media already exists"
-          nullable: false

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindImageFoldersResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindImageFoldersResponse.yaml
@@ -4,19 +4,19 @@ properties:
     type: integer
     description: "ID of the image folder"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Name of the image folder"
     example: "my-logos"
-    nullable: false
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "image folder alias"
     example: "logos"
-    nullable: true
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "image folder comment"
     example: "Those are my beautiful logos"
-    nullable: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindMediasResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindMediasResponse.yaml
@@ -4,19 +4,15 @@ properties:
     type: integer
     description: "Media ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Media filename"
     example: "logo.png"
-    nullable: false
   directory:
     type: string
     description: "Media directory"
     example: "logos"
-    nullable: false
   url:
     type: string
     description: "Media URL"
     example: "/centreon/img/media/logo.png"
-    nullable: false

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/GetMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/GetMediaResponse.yaml
@@ -3,21 +3,16 @@ type: object
 properties:
   id:
     type: integer
-    nullable: false
     example: 1
   filename:
     type: string
-    nullable: false
     example: "centreon_logo.jpg"
   directory:
     type: string
-    nullable: false
     example: "logos"
   md5:
     type: string
-    nullable: false
     example: "f7d5fc06a33946703054046c7174bbf4"
   comment:
     type: string
-    nullable: false
     example: "Company logo"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaRequest.yaml
@@ -4,5 +4,4 @@ properties:
   data:
     type: string
     format: binary
-    nullable: false
     description: "File content"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaResponse.yaml
@@ -1,18 +1,16 @@
 type: object
 properties:
   id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     example: 1
   filename:
     type: string
-    nullable: false
     example: "centreon_logo.jpg"
   directory:
     type: string
-    nullable: false
     example: "logos"
   md5:
     type: string
-    nullable: false
     example: "f7d5fc06a33946703054046c7174bbf4"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/DeleteServices.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/DeleteServices.yaml
@@ -37,8 +37,9 @@ post:
                   type: integer
                   description: "HTTP Status Code of the operation"
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceRequest.yaml
@@ -9,25 +9,29 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -36,24 +40,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,7 +70,6 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   active_check_enabled:
     type: integer
     description: |
@@ -111,8 +119,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -120,10 +129,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this service - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID."
     minimum: 1
-    nullable: true
     example: 1
   notification_type:
     type: integer
@@ -145,23 +155,26 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this service."
-    nullable: true
   freshness_checked:
     type: integer
     description: |
@@ -172,9 +185,10 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   freshness_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this service."
-    nullable: true
   flap_detection_enabled:
     type: integer
     description: |
@@ -185,13 +199,15 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   low_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this service."
-    nullable: true
   high_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this service."
-    nullable: true
   event_handler_enabled:
     type: integer
     description: |
@@ -202,10 +218,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   event_handler_command_args:
     type: array
@@ -214,42 +231,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   is_activated:
     type: boolean
     description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/DeployServiceResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/DeployServiceResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/FindServicesResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/FindServicesResponse.yaml
@@ -16,20 +16,24 @@ allOf:
           $ref: 'simpleEntity.yaml'
       service_template:
         description: "Service template linked to this service."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       check_timeperiod:
         description: "Time period of the check command."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       notification_timeperiod:
         description: "Time period of the notification command."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       severity:
         description: "Severity linked to this service."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       categories:
         type: array
         description: "Service categories associated with this service."
@@ -54,14 +58,17 @@ allOf:
               type: string
               example: 'host-name'
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -69,7 +76,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/GetServiceResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/GetServiceResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
@@ -9,25 +9,29 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -36,24 +40,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,7 +70,6 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   active_check_enabled:
     type: integer
     description: |
@@ -111,8 +119,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -120,10 +129,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this service - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID."
     minimum: 1
-    nullable: true
     example: 1
   notification_type:
     type: integer
@@ -145,23 +155,26 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this service."
-    nullable: true
   freshness_checked:
     type: integer
     description: |
@@ -172,9 +185,10 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   freshness_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this service."
-    nullable: true
   flap_detection_enabled:
     type: integer
     description: |
@@ -185,13 +199,15 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   low_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this service."
-    nullable: true
   high_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this service."
-    nullable: true
   event_handler_enabled:
     type: integer
     description: |
@@ -202,10 +218,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   event_handler_command_args:
     type: array
@@ -214,42 +231,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   is_activated:
     type: boolean
     description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/macro.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupRequest.yaml
@@ -10,13 +10,15 @@ properties:
     description: "Service group alias"
     example: "service-group"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographical coordinates used by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Service group description"
     example: "Example description"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupResponse.yaml
@@ -13,13 +13,15 @@ properties:
     description: "Service group alias"
     example: "service-group"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Service group description"
     example: "example comment"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Service template alias."
         example: "generic-service"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service template comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service template."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service template."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Service template alias."
         example: "generic-service"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service template comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,14 +132,16 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the states of the service for which notifications should be sent out.
 
@@ -150,23 +160,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service template."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -177,9 +190,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -190,13 +204,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -207,10 +223,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -219,42 +236,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service template."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
@@ -9,20 +9,23 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service template comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -31,24 +34,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -56,7 +64,6 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   active_check_enabled:
     type: integer
     description: |
@@ -106,8 +113,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -115,10 +123,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this service - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID."
     minimum: 1
-    nullable: true
     example: 1
   notification_type:
     type: integer
@@ -140,23 +149,26 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this service template."
-    nullable: true
   freshness_checked:
     type: integer
     description: |
@@ -167,9 +179,10 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   freshness_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this service."
-    nullable: true
   flap_detection_enabled:
     type: integer
     description: |
@@ -180,13 +193,15 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   low_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this service."
-    nullable: true
   high_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this service."
-    nullable: true
   event_handler_enabled:
     type: integer
     description: |
@@ -197,10 +212,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   event_handler_command_args:
     type: array
@@ -209,42 +225,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -9,20 +9,23 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service template comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -102,8 +105,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -135,15 +139,17 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
@@ -188,10 +194,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: null
   event_handler_command_args:
     type: array
@@ -200,42 +207,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/macro.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Users/Schema/CurrentParameters.Get.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Users/Schema/CurrentParameters.Get.yaml
@@ -26,8 +26,9 @@ properties:
     example: Europe/Paris
 
   locale:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: Locale of the current user
     example: en_US
 
@@ -63,14 +64,16 @@ properties:
     default: compact
 
   default_page:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: Default page for the current user
     example: '/main.php?p=60901'
 
   dashboard:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       global_user_role:
         type: string

--- a/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/Metric.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/Metric.yaml
@@ -7,30 +7,37 @@ properties:
   unit:
     type: string
   current_value:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   warning_high_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   warning_low_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   critical_high_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   critical_low_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   min:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   max:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Links.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Links.yaml
@@ -4,74 +4,87 @@ properties:
     type: object
     properties:
       configuration:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "configuration uri"
         example: "/centreon/main.php?p=60101&o=c&host_id=11"
       logs:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "logs uri"
         example: "/centreon/main.php?p=20301&h=11"
       reporting:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "reporting uri"
         example: "/centreon/main.php?p=307&host=11"
   endpoints:
     type: object
     properties:
       details:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource details endpoint"
         example: "/centreon/api/latest/monitoring/resources/hosts/11"
       timeline:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource timeline endpoint"
         example: "/centreon/api/latest/monitoring/hosts/11/timeline"
       status_graph:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource status graph endpoint"
         example: null
       performance_graph:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource performance graph endpoint"
         example: null
       acknowledgement:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "current resource acknowledgement endpoint"
         example: "/centreon/api/latest/monitoring/hosts/11/acknowledgements?limit=1"
       downtime:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "current resource downtimes endpoint"
         example: "/centreon/api/latest/monitoring/hosts/11/downtimes?search=%7B%22%24and%22:%5B%7B%22start_time%22:%7B%22%24lt%22:1599655905%7D,%22end_time%22:%7B%22%24gt%22:1599655905%7D,%220%22:%7B%22%24or%22:%7B%22is_cancelled%22:%7B%22%24neq%22:1%7D,%22deletion_time%22:%7B%22%24gt%22:1599655905%7D%7D%7D%7D%5D%7D"
       notification_policy:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "current resource notification policy endpoint"
         example: "/centreon/api/latest/configurations/hosts/11/notification-policy"
       check:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Endpoint dedicated for checks (forced_check payload entry set to false)"
         example: "/centreon/api/latest/monitoring/hosts/17/services/23/check"
       forced_check:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Endpoint dedicated for checks (forced_check payload entry set to true)"
         example: "/centreon/api/latest/monitoring/hosts/17/services/23/check"
   externals:
     type: object
     properties:
       action_url:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "URL that can be used to provide more actions to be performed on the resource"
         example: "http://mediawiki/resource/name"
       notes:

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Notes.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Notes.yaml
@@ -1,13 +1,16 @@
-type: object
-nullable: true
+type:
+  - object
+  - 'null'
 properties:
   url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "URL that can be used to provide more information on the resource"
     example: "http://mediawiki/resource/name"
   label:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Note that can be used to describe the note url"
     example: "How to turn back on the server"

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceHostDetail.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceHostDetail.yaml
@@ -30,8 +30,9 @@ properties:
     description: "FQDN of the Host Resource"
     example: "localhost|127.0.0.1"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Alias given to the Host Resource"
     example: "central"
   status:
@@ -121,16 +122,18 @@ properties:
     description: "Indicates whether the check script is active or not"
     example: true
   parent:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
         description: "ID of the parent"
         example: 12
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       name:
         type: string
@@ -165,12 +168,14 @@ properties:
         description: "Name of the host category"
         example: "All-Cpu-Services"
       configuration_uri:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Internal URI to reach category configuration"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -208,8 +213,9 @@ properties:
             description: "URL of the icon"
             example: "baseUri/ppm/dog.png"
   acknowledgement:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -245,9 +251,10 @@ properties:
         description: "Short description of the acknowledgement"
         example: "Acknowledged by admin"
       deletion_time:
-        type: string
+        type:
+          - string
+          - 'null'
         format: date-time
-        nullable: true
         description: "Date of the request for cancellation of the acknowledgement (ISO8601)"
       entry_time:
         type: string
@@ -286,18 +293,21 @@ properties:
       type: object
       properties:
         start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled start date of the downtime (ISO8601)"
         end_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled end date of the downtime (ISO8601)"
         actual_start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Actual start date of the downtime (ISO8601)"
         id:
@@ -309,13 +319,15 @@ properties:
           format: date-time
           description: "Date of the request to create the downtime (ISO8601)"
         author_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "ID of the contact who requested the downtime"
           example: 3
         author_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Name of the contact who requested the downtime"
           example: "admin"
         host_id:
@@ -331,19 +343,22 @@ properties:
           description: "Indicates whether the downtime has been cancelled or not"
           example: false
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Comment of set on the downtime"
           example: "Downtime set by admin"
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: "Date of cancellation of downtime (ISO8601)"
           example: null
         duration:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "Downtime duration in seconds"
           example: 7200
         internal_id:
@@ -359,38 +374,45 @@ properties:
           description: "Indicates whether the downtime has started"
           example: true
   timezone:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Timezone configured on the Host resource"
     example: 'Europe/Paris'
   duration:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last status change"
     example: "2h 3m"
   next_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Scheduled date for the next check (ISO8601)"
   last_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last check (ISO8601)"
   last_time_with_no_issue:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last time Host Resource was UP (ISO8601)"
   last_status_change:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last status change (ISO8601)"
   last_notification:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last notification sent (ISO8601)"
   tries:
@@ -404,30 +426,35 @@ properties:
         type: object
         properties:
           configuration:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "configuration uri"
             example: "/centreon/main.php?p=60101&o=c&host_id=11"
           logs:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "logs uri"
             example: "/centreon/main.php?p=20301&h=11"
           reporting:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "reporting uri"
             example: "/centreon/main.php?p=307&host=11"
       endpoints:
         type: object
         properties:
           notification_policy:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Host resource notification policy endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/202/notification-policy"
           timeline:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "resource timeline endpoint"
             example: "/centreon/api/latest/monitoring/hosts/11/timeline"

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceLightened.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceLightened.yaml
@@ -18,13 +18,15 @@ properties:
     description: "ID of the resource"
     example: 12
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Resource alias"
     example: null
   fqdn:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Resource fqdn"
     example: null
   links:
@@ -34,8 +36,9 @@ properties:
     description: "Monitoring Server from which is monitored the Resource"
     example: "Central"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -65,53 +68,63 @@ properties:
     description: "Indicates whether resource is in flapping"
     example: false
   percent_state_change:
-    type: number
-    nullable: true
+    type:
+      - number
+      - 'null'
     description: "Percentage of state change"
     example: "10.4"
   duration:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last status change"
     example: "2h 3m"
   last_status_change:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Date of the last status change (ISO8601)"
   last_time_with_no_issue:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Date of the last status change (ISO8601)"
   tries:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Number of check tries"
     example: "3/3 (H)"
   last_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last check"
     example: "1h 45m"
   information:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Output of the resource"
     example: "OK - Ping is ok"
   has_active_checks_enabled:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether active checks are enabled"
     example: true
   has_passive_checks_enabled:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether passive checks are enabled"
     example: true
   performance_data:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Performance data result of the check sent"
     example: "rta=0.025ms;200.000;400.000;0; rtmax=0.061ms;;;; rtmin=0.015ms;;;; pl=0%;20;50;0;100 "
   is_notification_enabled:
@@ -119,8 +132,9 @@ properties:
     description: "Indicates if notifications are enabled for the resource"
     example: false
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       type:
         type: string

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceServiceDetail.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceServiceDetail.yaml
@@ -148,8 +148,9 @@ properties:
         description: "Name of the service group"
         example: "All-Cpu-Services"
       configuration_uri:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Internal URI to reach group configuration"
   categories:
     type: object
@@ -164,12 +165,14 @@ properties:
         description: "Name of the service category"
         example: "All-Cpu-Services"
       configuration_uri:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Internal URI to reach category configuration"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -207,8 +210,9 @@ properties:
             description: "URL of the icon"
             example: "baseUri/ppm/dog.png"
   acknowledgement:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -244,9 +248,10 @@ properties:
         description: "Short description of the acknowledgement"
         example: "Acknowledged by admin"
       deletion_time:
-        type: string
+        type:
+          - string
+          - 'null'
         format: date-time
-        nullable: true
         description: "Date of the request for cancellation of the acknowledgement (ISO8601)"
       entry_time:
         type: string
@@ -289,18 +294,21 @@ properties:
         - service_id
       properties:
         start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled start date of the downtime (ISO8601)"
         end_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled end date of the downtime (ISO8601)"
         actual_start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Actual start date of the downtime (ISO8601)"
         id:
@@ -312,13 +320,15 @@ properties:
           format: date-time
           description: "Date of the request to create the downtime (ISO8601)"
         author_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "ID of the contact who requested the downtime"
           example: 3
         author_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Name of the contact who requested the downtime"
           example: "admin"
         host_id:
@@ -334,19 +344,22 @@ properties:
           description: "Indicates whether the downtime has been cancelled or not"
           example: false
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Comment of set on the downtime"
           example: "Downtime set by admin"
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: "Date of cancellation of downtime (ISO8601)"
           example: null
         duration:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "Downtime duration in seconds"
           example: 7200
         internal_id:
@@ -362,33 +375,39 @@ properties:
           description: "Indicates whether the downtime has started"
           example: true
   duration:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last status change"
     example: "2h 3m"
   next_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Scheduled date for the next check (ISO8601)"
   last_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last check (ISO8601)"
   last_time_with_no_issue:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last time Host Resource was UP (ISO8601)"
   last_status_change:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last status change (ISO8601)"
   last_notification:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last notification sent (ISO8601)"
   tries:
@@ -402,40 +421,47 @@ properties:
         type: object
         properties:
           configuration:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Redirection link to Service resource configuration page"
             example: "/centreon/main.php?p=60201&o=c&service_id=1533"
           logs:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Redirection link to Service resource logs pre-filtered page"
             example: "centreon/main.php?p=20301&svc=202_1533"
           reporting:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Redirection link to Service resource reporting pre-filtered page"
             example: "/centreon/main.php?p=30702&period=yesterday&start=&end=&host_id=202&item=1533"
       endpoints:
         type: object
         properties:
           notification_policy:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource notification policy endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/202/services/1533/notification-policy"
           timeline:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource timeline endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/202/services/1533/timeline"
           status_graph:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource status graph endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/14/services/26/metrics/status"
           performance_graph:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource performance graph endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/14/services/26/metrics/performance"


### PR DESCRIPTION
Convert 3.0 nullable to 3.1 null-union types across the latest/** fragments (335 files) and inline schemas in centreon-api.yaml: type+nullable -> type: [X, 'null'], $ref/allOf+nullable -> anyOf, nullable enums gain null, nullable:false removed. centreon-api.yaml now passes redocly lint with 0 errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>