### PR TITLE
enh(openapi): migrate the cloud API doc to 3.1 with the bare /api URL model and security

### DIFF
--- a/centreon/doc/API/centreon-cloud-api.yaml
+++ b/centreon/doc/API/centreon-cloud-api.yaml
@@ -1,6 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Centreon Web RestAPI for Cloud
+  version: '25.10'
   description: |
 
     <blockquote style="
@@ -37,7 +38,7 @@ externalDocs:
   description: You can contact us on our community platform The Watch
   url: 'https://thewatch.centreon.com/'
 servers:
-  - url: '{protocol}://{server}:{port}/centreon/api/{version}'
+  - url: '{protocol}://{server}:{port}/centreon'
     variables:
       protocol:
         enum:
@@ -51,9 +52,6 @@ servers:
       port:
         default: '80'
         description: "Port used by HTTP server"
-      version:
-        default: latest
-        description: "Version of the API"
 tags:
   - name: Host
   - name: Host group
@@ -62,44 +60,68 @@ tags:
   - name: Resource Access Management
   - name: Service
   - name: Service template
+security:
+  -
+    Token: []
+  -
+    Cookie: []
 paths:
-  /administration/resource-access/rules:
+  /api/latest/administration/resource-access/rules:
     $ref: "./latest/Cloud/Administration/ResourceAccessManagement/AddAndFindRules.yaml"
-  /administration/resource-access/rules/{rule_id}:
+  /api/latest/administration/resource-access/rules/{rule_id}:
     $ref: "./latest/Cloud/Administration/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml"
-  /administration/resource-access/rules/_delete:
+  /api/latest/administration/resource-access/rules/_delete:
     $ref: "./latest/Cloud/Administration/ResourceAccessManagement/DeleteRules.yaml"
-  /configuration/hosts:
+  /api/latest/configuration/hosts:
     $ref: './latest/Cloud/Configuration/Host/AddAndFindHosts.yaml'
-  /configuration/hosts/{host_id}:
+  /api/latest/configuration/hosts/{host_id}:
     $ref: './latest/Cloud/Configuration/Host/GetAndPartialUpdateHost.yaml'
-  /configuration/hosts/groups:
+  /api/latest/configuration/hosts/groups:
     $ref: './latest/Cloud/Configuration/HostGroup/AddAndFindHostGroups.yaml'
-  /configuration/hosts/groups/{hostgroup_id}:
+  /api/latest/configuration/hosts/groups/{hostgroup_id}:
     $ref: './latest/Cloud/Configuration/HostGroup/GetAndUpdateHostGroup.yaml'
-  /configuration/hosts/templates:
+  /api/latest/configuration/hosts/templates:
     $ref: './latest/Cloud/Configuration/HostTemplate/AddAndFindHostTemplates.yaml'
-  /configuration/hosts/templates/{host_template_id}:
+  /api/latest/configuration/hosts/templates/{host_template_id}:
     $ref: './latest/Cloud/Configuration/HostTemplate/GetAndPartialUpdateHostTemplate.yaml'
-  /configuration/hosts/{host_id}/services/deploy:
+  /api/latest/configuration/hosts/{host_id}/services/deploy:
     $ref: './latest/Cloud/Configuration/Service/DeployServices.yaml'
-  /configuration/services:
+  /api/latest/configuration/services:
     $ref: "./latest/Cloud/Configuration/Service/AddAndFindServices.yaml"
-  /configuration/services/{service_id}:
+  /api/latest/configuration/services/{service_id}:
     $ref: "./latest/Cloud/Configuration/Service/GetAndPartialUpdateService.yaml"
-  /configuration/services/templates:
+  /api/latest/configuration/services/templates:
     $ref: "./latest/Cloud/Configuration/ServiceTemplate/AddAndFindServiceTemplates.yaml"
-  /configuration/services/templates/{service_template_id}:
+  /api/latest/configuration/services/templates/{service_template_id}:
     $ref: "./latest/Cloud/Configuration/ServiceTemplate/PartialUpdateServiceTemplate.yaml"
-  /configuration/notifications:
+  /api/latest/configuration/notifications:
     $ref: "./latest/Cloud/Configuration/Notification/Notifications.yaml"
-  /configuration/notifications/_delete:
+  /api/latest/configuration/notifications/_delete:
     $ref: "./latest/Cloud/Configuration/Notification/DeleteNotifications.yaml"
-  /configuration/notifications/{notification_id}:
+  /api/latest/configuration/notifications/{notification_id}:
     $ref: "./latest/Cloud/Configuration/Notification/Notification.yaml"
-  /configuration/notifications/resources:
+  /api/latest/configuration/notifications/resources:
     $ref: "./latest/Cloud/Configuration/Notification/FindNotifiableResources.yaml"
-  /configuration/notifications/{notification_id}/rules:
+  /api/latest/configuration/notifications/{notification_id}/rules:
     $ref: "./latest/Cloud/Configuration/Notification/FindNotifiableRule.yaml"
-  /configuration/notifications/contact_groups:
+  /api/latest/configuration/notifications/contact_groups:
     $ref: "./latest/Cloud/Configuration/Notification/FindNotifiableContactGroups.yaml"
+components:
+  securitySchemes:
+    Token:
+      description: |
+        The use of the API requires a security token.
+
+        To retrieve it, you will need to authenticate yourself with your login credentials.
+
+        The token will be deleted if it has not been used for more than one hour.
+      type: apiKey
+      name: X-AUTH-TOKEN
+      in: header
+    Cookie:
+      description: |
+        If you have already connected on the Centreon web application, you can reused the PHPSESSID cookie.
+        The cookie will be valid as long as the connection to Centreon is maintained.
+      type: apiKey
+      name: PHPSESSID
+      in: cookie


### PR DESCRIPTION
centreon-cloud-api.yaml: relabel to 3.1.0; prefix the 20 legacy paths with /api/latest and change the server base to {...}/centreon; add Token/Cookie securitySchemes + a root security requirement and info.version. Now lints with 0 errors.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>