### PR TITLE
fix(ci): gate promote-docker-to-ghcr on on-prem releases and resolve poller image tag from previous on-prem major on cloud

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2000,7 +2000,8 @@ jobs:
       github.event_name != 'workflow_dispatch' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      needs.get-environment.outputs.is_cloud == 'false'
     runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read

--- a/centreon/install-poller/src/commands/docker.sh
+++ b/centreon/install-poller/src/commands/docker.sh
@@ -114,7 +114,7 @@ function _generateDotEnv() {
   else
     case "${tag_stability}" in
     stable)
-      image_tag="${major}"
+      image_tag="$(_pollerImageMajor)"
       ;;
     unstable)
       image_tag="develop"
@@ -126,10 +126,10 @@ function _generateDotEnv() {
       # release one. Force --stability testing-hotfix for the other, or pass
       # the exact validated <major>.<minor>.<patch> semver retag via --tag
       # once known (after promote-docker-tag has run for that patch).
-      image_tag="release-${major}-next"
+      image_tag="release-$(_pollerImageMajor)-next"
       ;;
     testing-hotfix)
-      image_tag="hotfix-${major}-next"
+      image_tag="hotfix-$(_pollerImageMajor)-next"
       ;;
     esac
   fi
@@ -169,6 +169,39 @@ EOF
 
   consoleInfo ".env written"
   logInfo ".env written"
+}
+
+# Whether a Centreon major version (e.g. 26.10) is an on-prem release.
+# On-prem majors always end in .10; anything else is a cloud release. Same
+# heuristic as get-environment.yml's cloud/on-prem detection and
+# uses_internal_repo() in centreon/unattended.sh (mirrored in
+# _usesInternalRepo, src/vm/packages.sh) — shared here so both the Docker and
+# VM install paths classify a major the same way.
+function _isOnPremMajor() {
+  [[ "${1}" == *.10 ]]
+}
+
+# The on-prem major this release's containerized pollers come from. On-prem
+# majors are used as-is. A cloud major pulls the nearest not-later on-prem
+# major, floored at 26.10 (MON-192897: no containerized poller exists before
+# that release). MON-208333.
+#
+# Unlike _usesInternalRepo (VM/RPM path), this doesn't just switch the
+# registry at the same major: RPM/DEB packages ARE published for cloud majors
+# (to an internal repo, per .github/actions/promote-to-stable), but poller
+# container images are only ever published for on-prem majors — so a cloud
+# major has to resolve to a *different*, older major here.
+function _pollerImageMajor() {
+  if _isOnPremMajor "${major}"; then
+    echo "${major}"
+    return
+  fi
+  local year=$((10#${major%%.*}))
+  local month=$((10#${major##*.}))
+  local onprem_year=${year}
+  [ "${month}" -lt 10 ] && onprem_year=$((year - 1))
+  [ "${onprem_year}" -lt 26 ] && onprem_year=26
+  printf "%02d.10" "${onprem_year}"
 }
 
 # Registry + repo (no tag) for one of the 5 poller component images, per

--- a/centreon/install-poller/src/commands/vm.sh
+++ b/centreon/install-poller/src/commands/vm.sh
@@ -28,8 +28,10 @@ function runVmInstall() {
     echo ""
     consoleTitle "Existing installation detected (major: ${installed_major:-unknown}):"
 
-    if [ -n "${installed_major}" ] && [ "${installed_major}" != "${major}" ]; then
-      consoleInfo "Major version change: ${installed_major} → ${major}"
+    local repo_major
+    repo_major=$(_vmRepoMajor)
+    if [ -n "${installed_major}" ] && [ "${installed_major}" != "${repo_major}" ]; then
+      consoleInfo "Major version change: ${installed_major} → ${repo_major}"
     fi
     _vmUpdateRepo
 

--- a/centreon/install-poller/src/vm/packages.sh
+++ b/centreon/install-poller/src/vm/packages.sh
@@ -90,22 +90,42 @@ function _vmInstallPowertools() {
   esac
 }
 
+# The major to resolve VM package repo URLs against. For the stable channel, a
+# cloud major resolves to the previous on-prem major (same as
+# _pollerImageMajor for the Docker image tag, src/commands/docker.sh) so a
+# real customer install never needs internal repo access — RPM/DEB packages
+# for a cloud major are only ever published internally. testing/unstable stay
+# pinned to the actual major being validated: QA needs the real cloud
+# candidate build, not an older on-prem stand-in. MON-208333.
+# FORCE_STABILITY (hidden --stability flag) overrides STABILITY here, to
+# pull from the testing/unstable channel for a major baked as "stable" whose
+# packages aren't promoted to the stable channel yet. MON-208554.
+function _vmRepoMajor() {
+  if [ "${FORCE_STABILITY:-${STABILITY}}" = "stable" ]; then
+    _pollerImageMajor
+  else
+    echo "${major}"
+  fi
+}
+
 # Mirrors uses_internal_repo() in centreon/unattended.sh.
 function _usesInternalRepo() {
-  [ "${major##*.}" != "10" ]
+  ! _isOnPremMajor "$(_vmRepoMajor)"
 }
 
 function _centreonRpmRepoUrl() {
+  local repo_major
+  repo_major=$(_vmRepoMajor)
   if _usesInternalRepo; then
-    echo "https://packages.centreon.com/rpm-standard-internal/${major}/el${_EL_MAJOR:-9}/centreon-${major}-internal.repo"
+    echo "https://packages.centreon.com/rpm-standard-internal/${repo_major}/el${_EL_MAJOR:-9}/centreon-${repo_major}-internal.repo"
   else
-    echo "https://packages.centreon.com/rpm-standard/${major}/el${_EL_MAJOR:-9}/centreon-${major}.repo"
+    echo "https://packages.centreon.com/rpm-standard/${repo_major}/el${_EL_MAJOR:-9}/centreon-${repo_major}.repo"
   fi
 }
 
 # Safe to call repeatedly (e.g. re-run with an install.sh built for a
 # different stability). FORCE_STABILITY (hidden --stability flag) overrides
-# STABILITY here. MON-208554.
+# STABILITY here, same rationale as _vmRepoMajor above. MON-208554.
 function _vmConfigureRepoChannels() {
   local effective_stability="${FORCE_STABILITY:-${STABILITY}}"
   consoleInfo "Configuring Centreon repository channel for stability: ${effective_stability}"
@@ -146,6 +166,8 @@ function _vmConfigureRepoChannels() {
   else
     local codename
     codename=$(lsb_release -sc)
+    local repo_major
+    repo_major=$(_vmRepoMajor)
     local apt_root="apt-standard"
     _usesInternalRepo && apt_root="apt-standard-internal"
 
@@ -153,29 +175,29 @@ function _vmConfigureRepoChannels() {
           /etc/apt/sources.list.d/centreon-testing.list \
           /etc/apt/sources.list.d/centreon-unstable.list
 
-    echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-stable main" \
+    echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-stable main" \
       | tee /etc/apt/sources.list.d/centreon-stable.list > /dev/null
 
     case "${effective_stability}" in
     testing-release)
       # Isolate from testing-hotfix (MON-208554), same rationale as the dnf case above.
-      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-testing-release main" \
+      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-testing-release main" \
         | tee /etc/apt/sources.list.d/centreon-testing.list > /dev/null
       ;;
     testing-hotfix)
-      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-testing-hotfix main" \
+      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-testing-hotfix main" \
         | tee /etc/apt/sources.list.d/centreon-testing.list > /dev/null
       ;;
     testing | unstable)
       {
-        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-testing-hotfix main"
-        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-testing-release main"
+        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-testing-hotfix main"
+        echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-testing-release main"
       } | tee /etc/apt/sources.list.d/centreon-testing.list > /dev/null
       ;;
     esac
 
     if [ "${effective_stability}" = "unstable" ]; then
-      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${major}-unstable main" \
+      echo "deb https://packages.centreon.com/${apt_root}/ ${codename}-${repo_major}-unstable main" \
         | tee /etc/apt/sources.list.d/centreon-unstable.list > /dev/null
     fi
 
@@ -184,7 +206,7 @@ function _vmConfigureRepoChannels() {
 }
 
 function _vmInstallRepo() {
-  logInfo "Adding Centreon ${major} repository (stability: ${FORCE_STABILITY:-${STABILITY}})"
+  logInfo "Adding Centreon $(_vmRepoMajor) repository (stability: ${FORCE_STABILITY:-${STABILITY}})"
 
   if [ "${_PKG_COMMAND}" = "apt" ]; then
     consoleInfo "Adding Centreon repository (Debian)"
@@ -225,13 +247,15 @@ function _vmInstallPackages() {
 }
 
 function _vmUpdateRepo() {
+  local repo_major
+  repo_major=$(_vmRepoMajor)
   local effective_stability="${FORCE_STABILITY:-${STABILITY}}"
-  consoleInfo "Updating Centreon repository to ${major} (stability: ${effective_stability})"
-  logInfo "Updating Centreon repository to ${major}, stability=${effective_stability}"
+  consoleInfo "Updating Centreon repository to ${repo_major} (stability: ${effective_stability})"
+  logInfo "Updating Centreon repository to ${repo_major}, stability=${effective_stability}"
 
   if [ "${_PKG_COMMAND}" = "dnf" ]; then
     rm -f /etc/yum.repos.d/centreon-*.repo
-    commandExitOnError "Cannot add Centreon ${major} repository" \
+    commandExitOnError "Cannot add Centreon ${repo_major} repository" \
       dnf config-manager --add-repo "$(_centreonRpmRepoUrl)"
     _vmConfigureRepoChannels
     dnf clean all


### PR DESCRIPTION
## Description
Backport of #11509 and #11513 to `dev-26.10.x`.

Cloud releases must not publish poller images to ghcr.io, and `install-poller` must resolve poller image tags/repos (Docker and VM/RPM/DEB) from the previous on-prem major when generating an install script for a cloud platform:
- Gate the `promote-docker-to-ghcr` job on `needs.get-environment.outputs.is_cloud == 'false'` in `web.yml`, so only on-prem `YY.10.x` stable releases publish/move ghcr.io poller image tags.
- Add `_pollerImageMajor()` / `_isOnPremMajor()` in `install-poller/src/commands/docker.sh` so a cloud install's generated `.env` resolves `TAG` from the previous on-prem major instead of its own (non-existent) major.
- Add `_vmRepoMajor()` in `install-poller/src/vm/packages.sh` (used by `_usesInternalRepo`, `_centreonRpmRepoUrl`, the DEB `sources.list` construction, and the VM upgrade message in `commands/vm.sh`) so the same fix applies to VM/RPM/DEB installs on the stable channel.

These conflicted with the `dev-26.10.x`-only hidden `--registry`/`--tag`/`--stability` overrides (MON-208554/MON-208664, #11528) already on this branch; resolved by keeping those overrides and layering the previous-on-prem-major resolution on top, so the merged `docker.sh`/`vm.sh`/`packages.sh` now match `develop` exactly.

Ref: MON-208473

**Fixes** MON-208473

## Type of change
- [x] Patch fixing an issue (non-breaking change)

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.10.x
- [ ] master

## How this pull request can be tested ?
Same testing procedure as #11509 and #11513.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).