### PR TITLE
fix(logging): never let a failed log write abort the request

### DIFF
--- a/centreon/src/Adaptation/Log/Logger.php
+++ b/centreon/src/Adaptation/Log/Logger.php
@@ -27,6 +27,7 @@ use Adaptation\Log\Adapter\MonologAdapter;
 use Adaptation\Log\Channel\LogChannelInterface;
 use Adaptation\Log\Exception\LoggerException;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
 
 final readonly class Logger implements LoggerInterface
@@ -51,44 +52,49 @@ final readonly class Logger implements LoggerInterface
 
     public function emergency(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->emergency($message, $context);
+        $this->log(LogLevel::EMERGENCY, $message, $context);
     }
 
     public function alert(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->alert($message, $context);
+        $this->log(LogLevel::ALERT, $message, $context);
     }
 
     public function critical(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->critical($message, $context);
+        $this->log(LogLevel::CRITICAL, $message, $context);
     }
 
     public function error(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->error($message, $context);
+        $this->log(LogLevel::ERROR, $message, $context);
     }
 
     public function warning(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->warning($message, $context);
+        $this->log(LogLevel::WARNING, $message, $context);
     }
 
     public function notice(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->notice($message, $context);
+        $this->log(LogLevel::NOTICE, $message, $context);
     }
 
     public function info(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->info($message, $context);
+        $this->log(LogLevel::INFO, $message, $context);
     }
 
     public function debug(\Stringable|string $message, array $context = []): void
     {
-        $this->logger->debug($message, $context);
+        $this->log(LogLevel::DEBUG, $message, $context);
     }
 
+    /**
+     * Single exit point for every severity helper above: a handler that fails to
+     * write (unwritable file, full disk) must not abort the caller's request.
+     * @param mixed $level
+     */
     public function log($level, \Stringable|string $message, array $context = []): void
     {
         try {

--- a/centreon/tests/php/Adaptation/Log/LoggerTest.php
+++ b/centreon/tests/php/Adaptation/Log/LoggerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+use Adaptation\Log\Logger;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+/**
+ * Build the facade backed by a recording logger. The constructor is private, so the spy
+ * is wired through reflection — this keeps the production API free of any test-only seam.
+ *
+ * @param null|Throwable $failWith when set, the spy throws it on every write
+ *
+ * @return array{0: Logger, 1: object{records: list<array{level: string, message: string, context: array<string, mixed>}>}}
+ */
+function loggerWithSpy(?Throwable $failWith = null): array
+{
+    $spy = new class ($failWith) extends AbstractLogger {
+        /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+        public array $records = [];
+
+        public function __construct(private readonly ?Throwable $failWith = null)
+        {
+        }
+
+        /**
+         * @param array<string, mixed> $context
+         * @param mixed $level
+         */
+        public function log($level, string|Stringable $message, array $context = []): void
+        {
+            if ($this->failWith instanceof Throwable) {
+                throw $this->failWith;
+            }
+
+            $this->records[] = [
+                'level' => is_scalar($level) ? (string) $level : '',
+                'message' => (string) $message,
+                'context' => $context,
+            ];
+        }
+    };
+
+    $reflection = new ReflectionClass(Logger::class);
+    /** @var Logger $facade */
+    $facade = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('logger')->setValue($facade, $spy);
+
+    return [$facade, $spy];
+}
+
+/**
+ * The severity helpers each name their own level constant, and a copy-paste slip is
+ * invisible at runtime: the stream handler is mounted at INFO, so an error() demoted to
+ * debug() makes real errors vanish, and a debug() promoted to error() floods production.
+ */
+it('emits each severity helper at its own level', function (string $method, string $expectedLevel): void {
+    [$facade, $spy] = loggerWithSpy();
+
+    $facade->{$method}('a message', ['key' => 'value']);
+
+    expect($spy->records)->toHaveCount(1)
+        ->and($spy->records[0]['level'])->toBe($expectedLevel)
+        ->and($spy->records[0]['message'])->toBe('a message')
+        ->and($spy->records[0]['context'])->toBe(['key' => 'value']);
+})->with([
+    ['emergency', LogLevel::EMERGENCY],
+    ['alert', LogLevel::ALERT],
+    ['critical', LogLevel::CRITICAL],
+    ['error', LogLevel::ERROR],
+    ['warning', LogLevel::WARNING],
+    ['notice', LogLevel::NOTICE],
+    ['info', LogLevel::INFO],
+    ['debug', LogLevel::DEBUG],
+]);
+
+/**
+ * A handler that cannot write — unwritable file, full disk — must not take the caller
+ * down with it: a batch loop logging its own failures would otherwise die mid-batch and
+ * never render its page.
+ */
+it('swallows a handler that throws instead of aborting the caller', function (string $method): void {
+    [$facade] = loggerWithSpy(new RuntimeException('disk full'));
+
+    expect(function () use ($facade, $method): void {
+        $facade->{$method}('a message');
+    })->not->toThrow(RuntimeException::class);
+})->with(['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug']);
+
+it('swallows a handler that throws when log() is called directly', function (): void {
+    [$facade] = loggerWithSpy(new RuntimeException('disk full'));
+
+    expect(function () use ($facade): void {
+        $facade->log(LogLevel::ERROR, 'a message');
+    })->not->toThrow(RuntimeException::class);
+});
+
+it('passes the context through untouched', function (): void {
+    [$facade, $spy] = loggerWithSpy();
+    $context = ['id' => 42, 'nested' => ['a' => 1], 'exception' => new RuntimeException('boom')];
+
+    $facade->error('a message', $context);
+
+    expect($spy->records[0]['context'])->toBe($context);
+});
+
+it('keeps log() emitting the level it is given', function (): void {
+    [$facade, $spy] = loggerWithSpy();
+
+    $facade->log(LogLevel::WARNING, 'a message');
+
+    expect($spy->records[0]['level'])->toBe(LogLevel::WARNING);
+});

--- a/centreon/tests/php/Adaptation/Log/LoggerTest.php
+++ b/centreon/tests/php/Adaptation/Log/LoggerTest.php
@@ -113,6 +113,28 @@ it('swallows a handler that throws when log() is called directly', function (): 
     })->not->toThrow(RuntimeException::class);
 });
 
+/**
+ * Swallowing must still leave a trace: a catch block reduced to an empty swallow would
+ * pass every test above while making logging failures invisible. Pin the error_log
+ * fallback so that regression cannot slip through.
+ */
+it('records the failure through error_log when the handler throws', function (): void {
+    [$facade] = loggerWithSpy(new RuntimeException('disk full'));
+
+    $errorLog = tempnam(sys_get_temp_dir(), 'logger-test-');
+    $previous = ini_set('error_log', $errorLog);
+
+    try {
+        $facade->error('a message');
+        $logged = file_get_contents($errorLog);
+    } finally {
+        ini_set('error_log', $previous);
+        unlink($errorLog);
+    }
+
+    expect($logged)->toContain('disk full');
+});
+
 it('passes the context through untouched', function (): void {
     [$facade, $spy] = loggerWithSpy();
     $context = ['id' => 42, 'nested' => ['a' => 1], 'exception' => new RuntimeException('boom')];

--- a/centreon/tests/php/Core/ActionLog/Domain/Model/ActionLogTest.php
+++ b/centreon/tests/php/Core/ActionLog/Domain/Model/ActionLogTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+use Core\ActionLog\Domain\Model\ActionLog;
+
+/**
+ * Administration > Logs turns AVAILABLE_OBJECT_TYPES into positional option values:
+ * viewLogs.php renders each array index as the <option value> and maps the submitted
+ * index back through the same array. That index is persisted in the user's stored
+ * search, so inserting a type anywhere but at the end silently reinterprets every
+ * saved filter as a different object type.
+ *
+ * Pinned as literals rather than constant names on purpose: two constants share the
+ * value 'host', so only the values and their positions describe the invariant.
+ */
+it('keeps the object types in their positional order', function (): void {
+    expect(ActionLog::AVAILABLE_OBJECT_TYPES)->toBe([
+        'command',
+        'timeperiod',
+        'contact',
+        'contactgroup',
+        'host',
+        'hostgroup',
+        'service',
+        'servicegroup',
+        'traps',
+        'escalation',
+        'host dependency',
+        'hostgroup dependency',
+        'service dependency',
+        'servicegroup dependency',
+        'poller',
+        'engine',
+        'broker',
+        'resources',
+        'meta',
+        'access group',
+        'menu access',
+        'resource access',
+        'action access',
+        'manufacturer',
+        'hostcategories',
+        'servicecategories',
+    ]);
+});


### PR DESCRIPTION
## Description

Salvages the standalone `Logger` hardening from the abandoned **Connectors modernization** (#11031). It fixes code that already lives on `dev-26.10.x` and does not depend on the abandoned feature.

Backport of #11452 — scoped to the logging fix and its tests (the listing/form framework, host categories endpoints and i18n parts of the original salvage targeted code that does not exist on this branch and were not part of the merged fix).

### Fix

- **`fix(logging)`** — the `Logger` severity helpers (`error()`, `debug()`, ...) called the Monolog handler directly, unguarded: a handler that fails to write (unwritable file, full disk) aborted the caller's request. They now delegate to the already-guarded `log()`, whose `try/catch` falls back to `error_log()`, so a logging failure can never abort the request. This also removes an inconsistency where `error()` propagated while `log(LogLevel::ERROR, ...)` — its PSR-3 equivalent — did not.

### Tests

- **`LoggerTest`** — asserts each of the 8 severity helpers emits at its own level with message/context passthrough, and that a throwing handler is swallowed (the request is not aborted) for every helper and for `log()` directly.
- **`ActionLogTest`** — pins the positional order of `ActionLog::AVAILABLE_OBJECT_TYPES`: Administration > Logs persists saved filters by array index, so a misplaced insertion would silently reinterpret every saved filter. Literal values (not constant names) are asserted because `OBJECT_TYPE_HOST` and `OBJECT_TYPE_HOST_TEMPLATE` both equal `host`.

## How to test

- `composer pest -- tests/php/Adaptation/Log tests/php/Core/ActionLog` — all green.
- Review that the 8 severity helpers route through `log()`, and that a handler exception is caught and reported via `error_log` rather than propagating out of the logging call.

## Links

### Jira ticket

Resolves: [MON-208760](https://centreon.atlassian.net/browse/MON-208760)

### PR Github

- Backports: #11452
- Relates to: #11031 — the abandoned connectors modernization this PR salvages from


[MON-208760]: https://centreon.atlassian.net/browse/MON-208760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ