### PR TITLE
fix(api): make /api/latest alias extensible by modules

### DIFF
--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/CoreLegacyApiAliasOperations.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/CoreLegacyApiAliasOperations.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\ApiPlatform\Routing;
+
+/**
+ * Core monorepo operations that keep their backward-compatible /api/latest alias.
+ */
+final class CoreLegacyApiAliasOperations implements LegacyApiAliasOperationProviderInterface
+{
+    public function getOperationNames(): array
+    {
+        return [
+            '_api_/configuration/agent-configurations/installation-command/{pollerId}_get',
+            '_api_/configuration/commands_get_collection',
+            '_api_/configuration/commands_post',
+            '_api_/configuration/commands/_duplicate_post',
+            '_api_/configuration/commands/{id}_get',
+            '_api_/configuration/commands/{id}_patch',
+            '_api_/configuration/commands/{id}_delete',
+            '_api_/configuration/connectors_get_collection',
+            '_api_/configuration/connectors/{id}_get',
+            '_api_/configuration/global-macros_get_collection',
+            '_api_/configuration/plugins_get_collection',
+            '_api_/configuration/plugins/{plugin_name}_get',
+            '_api_/configuration/pollers_post',
+            '_api_/configuration/pollers/installation-command/{id}_get',
+            '_api_/configuration/services/categories_post',
+            '_api_/configuration/standard-macros_get_collection',
+            '_api_/platform/updates_post',
+        ];
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiAliasOperationProviderInterface.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiAliasOperationProviderInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\ApiPlatform\Routing;
+
+/**
+ * Contributes API Platform operation names that must keep a backward-compatible /api/latest alias.
+ *
+ * The core provides its own implementation; any module may ship one too. Every service implementing
+ * this interface is collected by {@see LegacyApiPrefixAliasLoader} through the {@see self::TAG} tag
+ * (applied automatically by the new kernel's autoconfiguration), so a module extends the allowlist
+ * without touching core code.
+ */
+interface LegacyApiAliasOperationProviderInterface
+{
+    /**
+     * Autoconfiguration tag collecting every provider for the legacy alias loader.
+     */
+    public const TAG = 'app.legacy_api_alias_operation_provider';
+
+    /**
+     * Allowlist operation names (the route default `_api_operation_name`) rather than resources: a
+     * resource also carries the item operations API Platform generates on its own (/pollers/{id},
+     * /global_macros/{id}, ...), which never existed under /api/latest and must not be aliased there.
+     *
+     * @return list<string>
+     */
+    public function getOperationNames(): array;
+}

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoader.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoader.php
@@ -23,59 +23,58 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\ApiPlatform\Routing;
 
-use ApiPlatform\Symfony\Routing\ApiLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Duplicates the routes of already-migrated API Platform operations under the legacy /api/latest
  * prefix, for backward compatibility with clients still calling that prefix.
+ *
+ * The allowlist of operations to alias is contributed by {@see LegacyApiAliasOperationProviderInterface}
+ * services (core plus any module), so a module keeps its released endpoints reachable under
+ * /api/latest without touching this loader.
  */
 final readonly class LegacyApiPrefixAliasLoader implements RouteLoaderInterface
 {
-    /**
-     * Allowlisted per operation rather than per resource: a resource also carries the item
-     * operations API Platform generates on its own (/pollers/{id}, /global_macros/{id}, ...),
-     * which never existed under /api/latest and must not be aliased there.
-     *
-     * @var list<string>
-     */
-    private const LEGACY_ALIAS_OPERATION_NAMES = [
-        '_api_/configuration/agent-configurations/installation-command/{pollerId}_get',
-        '_api_/configuration/commands_get_collection',
-        '_api_/configuration/commands_post',
-        '_api_/configuration/commands/_duplicate_post',
-        '_api_/configuration/commands/{id}_get',
-        '_api_/configuration/commands/{id}_patch',
-        '_api_/configuration/commands/{id}_delete',
-        '_api_/configuration/connectors_get_collection',
-        '_api_/configuration/connectors/{id}_get',
-        '_api_/configuration/global-macros_get_collection',
-        '_api_/configuration/plugins_get_collection',
-        '_api_/configuration/plugins/{plugin_name}_get',
-        '_api_/configuration/pollers_post',
-        '_api_/configuration/pollers/installation-command/{id}_get',
-        '_api_/configuration/services/categories_post',
-        '_api_/configuration/standard-macros_get_collection',
-        '_api_/platform/updates_post',
-    ];
+    /** @var list<string> */
+    private array $allowlist;
 
+    /**
+     * @param iterable<LegacyApiAliasOperationProviderInterface> $operationProviders
+     */
     public function __construct(
         #[Autowire(service: 'api_platform.route_loader')]
-        private ApiLoader $apiLoader,
+        private LoaderInterface $apiLoader,
+        #[AutowireIterator(LegacyApiAliasOperationProviderInterface::TAG)]
+        iterable $operationProviders,
     ) {
+        $operationNames = [];
+        foreach ($operationProviders as $provider) {
+            foreach ($provider->getOperationNames() as $operationName) {
+                $operationNames[] = $operationName;
+            }
+        }
+
+        $this->allowlist = array_values(array_unique($operationNames));
     }
 
     public function __invoke(): RouteCollection
     {
         $aliasedRoutes = new RouteCollection();
 
-        foreach ($this->apiLoader->load('.', 'api_platform') as $name => $route) {
+        // api_platform.route_loader (ApiPlatform's ApiLoader) always returns a RouteCollection;
+        // LoaderInterface::load() only widens the declared return to mixed.
+        $apiRoutes = $this->apiLoader->load('.', 'api_platform');
+        \assert($apiRoutes instanceof RouteCollection);
+
+        foreach ($apiRoutes as $name => $route) {
             $operationName = $route->getDefault('_api_operation_name');
 
             // Keep auxiliary/meta routes (docs, entrypoint, genid, jsonld context)
-            if ($operationName !== null && ! in_array($operationName, self::LEGACY_ALIAS_OPERATION_NAMES, true)) {
+            if ($operationName !== null && ! in_array($operationName, $this->allowlist, true)) {
                 continue;
             }
 

--- a/centreon/src/App/Shared/Infrastructure/Symfony/Kernel.php
+++ b/centreon/src/App/Shared/Infrastructure/Symfony/Kernel.php
@@ -26,6 +26,7 @@ namespace App\Shared\Infrastructure\Symfony;
 use App\Shared\Application\Command\AsCommandHandler;
 use App\Shared\Application\Query\AsQueryHandler;
 use App\Shared\Domain\Event\AsEventHandler;
+use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiAliasOperationProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -87,6 +88,9 @@ final class Kernel extends BaseKernel
         $container->registerAttributeForAutoconfiguration(AsEventHandler::class, static function (ChildDefinition $definition): void {
             $definition->addTag('messenger.message_handler', ['bus' => 'event.bus']);
         });
+
+        $container->registerForAutoconfiguration(LegacyApiAliasOperationProviderInterface::class)
+            ->addTag(LegacyApiAliasOperationProviderInterface::TAG);
     }
 
     /**

--- a/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
@@ -23,8 +23,11 @@ declare(strict_types=1);
 
 namespace Tests\App\Shared\Infrastructure\ApiPlatform\Routing;
 
+use App\Shared\Infrastructure\ApiPlatform\Routing\CoreLegacyApiAliasOperations;
+use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiAliasOperationProviderInterface;
 use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiPrefixAliasLoader;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
@@ -70,9 +73,9 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
 
     public function testOnlyAllowlistedOperationsAppearInTheLegacyAlias(): void
     {
-        $allowlist = new \ReflectionClassConstant(LegacyApiPrefixAliasLoader::class, 'LEGACY_ALIAS_OPERATION_NAMES');
-        /** @var list<string> $allowlistedOperations */
-        $allowlistedOperations = $allowlist->getValue();
+        // In the test kernel only the core provider is registered (no module), so the aliased
+        // operations must all come from the core allowlist.
+        $allowlistedOperations = (new CoreLegacyApiAliasOperations())->getOperationNames();
         self::assertNotEmpty($allowlistedOperations);
 
         $routes = $this->getRouteCollection();
@@ -91,9 +94,41 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
                 $operationName,
                 $allowlistedOperations,
                 "Route \"{$name}\" is prefixed /api/latest but its operation ({$operationName}) "
-                . 'is not on LegacyApiPrefixAliasLoader::LEGACY_ALIAS_OPERATION_NAMES.',
+                . 'is not contributed by any LegacyApiAliasOperationProviderInterface.',
             );
         }
+    }
+
+    /**
+     * A module extends the /api/latest allowlist purely by shipping a
+     * LegacyApiAliasOperationProviderInterface service (auto-tagged by the new kernel). This is the
+     * regression fix for MON-208750: released module endpoints must keep their /api/latest alias.
+     */
+    public function testModuleContributedProviderExtendsTheLegacyAlias(): void
+    {
+        $routes = new RouteCollection();
+        $routes->add('core_op', $this->apiRoute('/configuration/commands', '_api_/configuration/commands_get_collection'));
+        $routes->add('module_op', $this->apiRoute('/bam/configuration/business-activities', '_api_/bam/configuration/business-activities_get_collection'));
+        $routes->add('generated_op', $this->apiRoute('/pollers/{id}', '_api_/pollers/{id}_get'));
+        $routes->add('api_doc', $this->apiRoute('/docs', null));
+
+        $apiLoader = $this->createMock(LoaderInterface::class);
+        $apiLoader->method('load')->willReturn($routes);
+
+        $loader = new LegacyApiPrefixAliasLoader($apiLoader, [
+            new CoreLegacyApiAliasOperations(),
+            $this->providerFor('_api_/bam/configuration/business-activities_get_collection'),
+        ]);
+
+        $aliased = ($loader)();
+
+        $moduleRoute = $aliased->get('legacy_module_op');
+
+        self::assertNotNull($aliased->get('legacy_core_op'), 'A core-listed operation must be aliased.');
+        self::assertNotNull($moduleRoute, 'A module-contributed operation must be aliased.');
+        self::assertNotNull($aliased->get('legacy_api_doc'), 'Meta routes (no operation) are always aliased.');
+        self::assertNull($aliased->get('legacy_generated_op'), 'An operation no provider lists must not be aliased.');
+        self::assertSame('/api/latest/bam/configuration/business-activities', $moduleRoute->getPath());
     }
 
     public function testAuxiliaryDocumentationRoutesAreDuplicatedRegardlessOfOperations(): void
@@ -127,5 +162,27 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
         }
 
         return null;
+    }
+
+    private function apiRoute(string $path, ?string $operationName): Route
+    {
+        return new Route($path, $operationName !== null ? ['_api_operation_name' => $operationName] : []);
+    }
+
+    private function providerFor(string ...$operationNames): LegacyApiAliasOperationProviderInterface
+    {
+        return new class (array_values($operationNames)) implements LegacyApiAliasOperationProviderInterface {
+            /**
+             * @param list<string> $operationNames
+             */
+            public function __construct(private readonly array $operationNames)
+            {
+            }
+
+            public function getOperationNames(): array
+            {
+                return $this->operationNames;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Description

Since #11078 moved API Platform resources from `/api/latest` to bare `/api`, `LegacyApiPrefixAliasLoader` restored backward compatibility only for a **hardcoded list of core operations**. Released **module** endpoints had no way to register, so their previously-shipped `/api/latest` routes returned 404 — breaking clients still calling that prefix (BAM is the only module exposing App API Platform resources today, but the gap is generic).

This makes the allowlist **extensible by modules**:

- New `LegacyApiAliasOperationProviderInterface` — a module implements it to declare the operations that must keep their `/api/latest` alias.
- The new kernel auto-tags every implementation (`registerForAutoconfiguration`), so a module contributes purely by shipping a class — no core change per module.
- `CoreLegacyApiAliasOperations` holds the core operations (moved out of the loader constant).
- `LegacyApiPrefixAliasLoader` merges the core provider plus every module-declared one (`#[AutowireIterator]`). It now depends on `LoaderInterface` instead of the `final` `ApiLoader` (same injected `api_platform.route_loader` service), which also makes it unit-testable.

The BAM side ships its provider in a companion PR on `centreon-modules`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Ticket

MON-208750 — regression introduced by #11078 (MON-208648).

## How to test

- `composer run test:new:integration -- --filter 'LegacyApiPrefixAliasLoaderTest'` — covers: core operation keeps its `/api/latest` alias, generated item operations are not aliased, only provider-declared operations appear under `/api/latest`, and a **module-contributed provider extends** the alias.
- CS/rector/PHPStan (src + tests)/Deptrac all pass on the App scope.

## Backport

To be backported to `dev-26.10.x` together with #11078 (MON-208648).
