### PR TITLE
fix(configuration): salvage standalone fixes and tests from the host listing migration

### DIFF
--- a/centreon/phpstan.legacy.test.neon
+++ b/centreon/phpstan.legacy.test.neon
@@ -15,6 +15,9 @@ parameters:
         - tests/phpstan_stubs/legacy.stub
         - tests/php/bootstrap.php
         - tests/php/polyfill.php
+        # Legacy helpers: required explicitly by their consumers, so they are
+        # outside the Composer classmap and unknown to the analysis otherwise.
+        - www/include/common/common-Func.php
 
     paths:
         - tests/php/Centreon

--- a/centreon/tests/e2e/features/Hosts/03-host-template-basics-operations.feature
+++ b/centreon/tests/e2e/features/Hosts/03-host-template-basics-operations.feature
@@ -21,3 +21,16 @@ Feature: HostTemplateBasicsOperations
   Scenario: Deletion of a host template
     When the user deletes the configured host template
     Then the deleted host template is not visible anymore on the host template page
+
+  # Cloud: identical
+  Scenario: Duplicating a host template does not multiply its service templates
+    Given a host template with shared service templates is configured
+    When the user duplicates that host template and its copy
+    Then each copy carries exactly the service templates of its source
+
+  # Cloud: identical
+  Scenario: A duplication whose generated name is already taken creates nothing
+    Given a host template with shared service templates is configured
+    And a host template already carries the name the copy would take
+    When the user duplicates that host template
+    Then no duplicate host template row was created

--- a/centreon/tests/e2e/features/Hosts/03-host-template-basics-operations/index.ts
+++ b/centreon/tests/e2e/features/Hosts/03-host-template-basics-operations/index.ts
@@ -233,3 +233,115 @@ Then(
       .should('not.exist');
   }
 );
+
+const dupSource = 'dup-src-template';
+const dupSibling = 'dup-sibling-template';
+const sharedServices = ['dup-svc-a', 'dup-svc-b'];
+
+const templateRelationCount = (name: string): Cypress.Chainable =>
+  cy
+    .requestOnDatabase({
+      database: 'centreon',
+      query:
+        'SELECT COUNT(*) AS total FROM host_service_relation hsr ' +
+        'JOIN host h ON h.host_id = hsr.host_host_id ' +
+        `WHERE h.host_name = '${name}'`
+    })
+    .then(([rows]) => cy.wrap(Number(rows[0].total), { log: false }));
+
+const duplicateTemplateRow = (name: string): void => {
+  cy.visit(PAGES.configuration.hostsTemplatesLegacy);
+  cy.wait('@getTimeZone');
+  // Exact-text match: a copy's name contains its source's name, so a substring
+  // lookup would tick whichever of the two the listing renders first.
+  cy.getIframeBody()
+    .find('a')
+    .filter((_, el) => el.textContent?.trim() === name)
+    .closest('tr')
+    .find('div.md-checkbox.md-checkbox-inline')
+    .click();
+  cy.getIframeBody()
+    .find('select')
+    .eq(0)
+    .invoke(
+      'attr',
+      'onchange',
+      "javascript: { setO(this.form.elements['o1'].value); submit(); }"
+    );
+  cy.getIframeBody().find('select').eq(0).select('Duplicate');
+  cy.wait('@getTimeZone');
+};
+
+Given('a host template with shared service templates is configured', () => {
+  // Two host templates sharing the same service templates: the sharing is what
+  // made the old duplication relate each service twice on the copy.
+  [dupSource, dupSibling].forEach((name) => {
+    cy.executeActionViaClapi({
+      bodyContent: {
+        action: 'ADD',
+        object: 'HTPL',
+        // HTPL shares the HOST signature: name;alias;address;template;instance;
+        // hostgroup — all six fields are expected, empty ones included.
+        values: `${name};${name};;;;`
+      }
+    });
+  });
+  sharedServices.forEach((svc) => {
+    cy.executeActionViaClapi({
+      bodyContent: { action: 'ADD', object: 'STPL', values: `${svc};${svc};` }
+    });
+    [dupSource, dupSibling].forEach((tpl) => {
+      cy.executeActionViaClapi({
+        bodyContent: {
+          action: 'ADDHOSTTEMPLATE',
+          object: 'STPL',
+          values: `${svc};${tpl}`
+        }
+      });
+    });
+  });
+});
+
+When('the user duplicates that host template and its copy', () => {
+  duplicateTemplateRow(dupSource);
+  duplicateTemplateRow(`${dupSource}_1`);
+});
+
+Then('each copy carries exactly the service templates of its source', () => {
+  templateRelationCount(dupSource).then((source) => {
+    expect(source, 'source relation count').to.equal(sharedServices.length);
+    templateRelationCount(`${dupSource}_1`).then((firstCopy) => {
+      expect(firstCopy, 'first copy relation count').to.equal(source);
+    });
+    templateRelationCount(`${dupSource}_1_1`).then((secondCopy) => {
+      expect(secondCopy, 'copy-of-copy relation count').to.equal(source);
+    });
+  });
+});
+
+Given('a host template already carries the name the copy would take', () => {
+  cy.executeActionViaClapi({
+    bodyContent: {
+      action: 'ADD',
+      object: 'HTPL',
+      values: `${dupSource}_1;${dupSource}_1;;;;`
+    }
+  });
+});
+
+When('the user duplicates that host template', () => {
+  duplicateTemplateRow(dupSource);
+});
+
+Then('no duplicate host template row was created', () => {
+  cy.requestOnDatabase({
+    database: 'centreon',
+    query: `SELECT COUNT(*) AS total FROM host WHERE host_name = '${dupSource}_1'`
+  }).then(([rows]) => {
+    expect(Number(rows[0].total), 'rows carrying the taken name').to.equal(1);
+  });
+  // The skipped copy must not have attached relations to the name holder either.
+  templateRelationCount(`${dupSource}_1`).then((count) => {
+    expect(count, 'relations on the pre-existing template').to.equal(0);
+  });
+});

--- a/centreon/tests/e2e/features/Hosts/03-host-template-basics-operations/index.ts
+++ b/centreon/tests/e2e/features/Hosts/03-host-template-basics-operations/index.ts
@@ -242,10 +242,7 @@ const templateRelationCount = (name: string): Cypress.Chainable =>
   cy
     .requestOnDatabase({
       database: 'centreon',
-      query:
-        'SELECT COUNT(*) AS total FROM host_service_relation hsr ' +
-        'JOIN host h ON h.host_id = hsr.host_host_id ' +
-        `WHERE h.host_name = '${name}'`
+      query: `SELECT COUNT(*) AS total FROM host_service_relation hsr JOIN host h ON h.host_id = hsr.host_host_id WHERE h.host_name = '${name}'`
     })
     .then(([rows]) => cy.wrap(Number(rows[0].total), { log: false }));
 

--- a/centreon/tests/e2e/features/Hosts/05-massive-change-hosts/index.ts
+++ b/centreon/tests/e2e/features/Hosts/05-massive-change-hosts/index.ts
@@ -2,6 +2,8 @@ import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { INTERCEPTORS } from 'e2e/fixtures/shared/constants/interceptors';
 import { PAGES } from 'e2e/fixtures/shared/constants/pages';
 
+const hostNames = ['host2', 'host3', 'host4'];
+
 const checkHostsProperties = (hostName) => {
   cy.getIframeBody().contains(hostName).click();
   cy.waitForElementInIframe('#main-content', 'input[name="host_name"]');
@@ -43,27 +45,27 @@ Given('an admin user is logged in a Centreon server', () => {
 });
 
 Given('several hosts have been created with mandatory properties', () => {
-  cy.addHost({
-    hostGroup: 'Linux-Servers',
-    name: 'host2',
-    template: 'generic-host'
-  }).applyPollerConfiguration();
-  cy.addHost({
-    hostGroup: 'Linux-Servers',
-    name: 'host3',
-    template: 'generic-host'
-  }).applyPollerConfiguration();
-  cy.addHost({
-    hostGroup: 'Linux-Servers',
-    name: 'host4',
-    template: 'generic-host'
-  }).applyPollerConfiguration();
+  hostNames.forEach((name) => {
+    cy.addHost({
+      hostGroup: 'Linux-Servers',
+      name,
+      template: 'generic-host'
+    }).applyPollerConfiguration();
+  });
 });
 
 When('the user has applied "Mass Change" operation on several hosts', () => {
   cy.visit(PAGES.configuration.hostsLegacy);
   cy.wait('@getTimeZone');
-  cy.getIframeBody().find('div.md-checkbox.md-checkbox-inline').eq(0).click();
+  // Tick the fixture rows by name, never the header check-all: that box selects
+  // every row on the page, so the mass change silently rewrote the platform's
+  // own hosts (Centreon-Server included) along with the three under test.
+  hostNames.forEach((name) => {
+    cy.getIframeBody()
+      .contains('tr', name)
+      .find('div.md-checkbox.md-checkbox-inline')
+      .click();
+  });
   cy.getIframeBody().find('select[name="o1"]').select('Mass Change');
   cy.wait('@getTimeZone');
   cy.getIframeBody().find('span[id="select2-host_location-container"]').click();
@@ -82,9 +84,11 @@ When('the user has applied "Mass Change" operation on several hosts', () => {
 });
 
 Then('all the selected hosts are updated with the same values', () => {
+  // Wait on the next host's listing link rather than a hard-coded host_id:
+  // the ids depend on what the dataset already holds.
   checkHostsProperties('host2');
-  cy.waitForElementInIframe('#main-content', 'a[href*="host_id=16"]');
+  cy.waitForElementInIframe('#main-content', 'a:contains("host3")');
   checkHostsProperties('host3');
-  cy.waitForElementInIframe('#main-content', 'a[href*="host_id=17"]');
+  cy.waitForElementInIframe('#main-content', 'a:contains("host4")');
   checkHostsProperties('host4');
 });

--- a/centreon/tests/e2e/features/Hosts/06-show-disabled-hosts-services/index.ts
+++ b/centreon/tests/e2e/features/Hosts/06-show-disabled-hosts-services/index.ts
@@ -51,7 +51,13 @@ Given('a host with configured services', () => {
 Given('the host is disabled', () => {
   cy.visit(PAGES.configuration.hostsLegacy);
   cy.wait('@getTimeZone');
-  cy.getIframeBody().find('img[alt="Disabled"]').eq(1).click();
+  // Disable the fixture host's own row: a positional eq(1) picks whichever row
+  // the listing happens to render second, so a dataset change would disable the
+  // wrong host while the assertions keep reading this one.
+  cy.getIframeBody()
+    .contains('tr', services.serviceOk.host)
+    .find('img[alt="Disabled"]')
+    .click();
   cy.exportConfig();
 });
 

--- a/centreon/tests/e2e/features/Hosts/08-disable-fileds-on-blocked-hostTemplate/index.ts
+++ b/centreon/tests/e2e/features/Hosts/08-disable-fileds-on-blocked-hostTemplate/index.ts
@@ -127,12 +127,12 @@ Then('the fields are all frozen', () => {
     isInputFreezed(name);
   });
   // Click on the "Relations" tab
-  cy.getIframeBody().contains('a', 'Notification').click();
+  cy.getIframeBody().contains('a', 'Relations').click();
   // Click outside the form
   cy.get('body').click(0, 0);
   // Check that the "Linked Service Templates" field is freezed
   cy.getIframeBody().find('select[name="host_svTpls[]"]').should('be.disabled');
-  // Check that the "Linked Service Templates" field is freezed
+  // Check that the "Linked Host Categories" field is freezed
   cy.getIframeBody().find('select[name="host_hcs[]"]').should('be.disabled');
   // Click on the "Data Processing" tab
   cy.getIframeBody().contains('a', 'Data Processing').click();

--- a/centreon/tests/e2e/features/Hosts/09-host-template-configuration/index.ts
+++ b/centreon/tests/e2e/features/Hosts/09-host-template-configuration/index.ts
@@ -47,30 +47,18 @@ Then('the user configures the host', () => {
 Then('the user can configure directly its parent template', () => {
   cy.getIframeBody()
     .find('img[title="Edit template"]')
-    .then(($el) => {
-      cy.window().then((win) => {
-        // Get the hostId and build the correct URL
-        const hostId = $el.siblings('select').val();
-        if (hostId !== '' && hostId !== undefined && hostId !== null) {
-          // Use relative URL to avoid hardcoding protocol and port
-          const baseUrl = win.location.origin;
-          const path = '/centreon/main.php';
-          const params = new URLSearchParams({
-            p: '60103',
-            o: 'c',
-            // biome-ignore lint/style/useNamingConvention: <explanation>
-            host_id: hostId.toString(),
-            min: '1'
-          });
-
-          // Perform redirection in the same tab
-          win.location.href = `${baseUrl}${path}?${params.toString()}`;
-        } else {
-          // Handle the case when no parent template is selected
-          cy.log('No parent template found to edit');
-          throw new Error('No parent template found to edit');
-        }
-      });
+    .then((el) => {
+      // Navigate with cy.visit rather than driving win.location: Cypress then
+      // owns the page load and the next wait cannot race the navigation.
+      const templateId = el.siblings('select').val();
+      if (
+        templateId === '' ||
+        templateId === undefined ||
+        templateId === null
+      ) {
+        throw new Error('No parent template found to edit');
+      }
+      cy.visit(`/centreon/main.php?p=60103&o=c&min=1&host_id=${templateId}`);
     });
   cy.waitForElementInIframe('#main-content', `input[name="host_name"]`);
   cy.getIframeBody().find('input[name="host_name"]').click();

--- a/centreon/tests/e2e/features/Hosts/10-host-listing-acl.feature
+++ b/centreon/tests/e2e/features/Hosts/10-host-listing-acl.feature
@@ -1,0 +1,39 @@
+@REQ_MON-207948
+Feature: Host listing access control
+  As a Centreon user with a restricted resource ACL
+  I want the hosts listing and its write actions to stay within my ACL
+  So that I cannot read or change a host that was not granted to me
+
+  Background:
+    Given two hosts exist and only one of them is granted to non-admin users
+
+  # Cloud: identical
+  Scenario: The listing only shows the granted host
+    Given the non-admin user is logged in
+    When the user opens the hosts listing
+    Then only the granted host is listed
+
+  # Cloud: identical
+  Scenario: A disable posted for a host outside the ACL changes nothing
+    Given the non-admin user is logged in
+    When the user posts a disable for the host it was not granted
+    Then the activation of that host is unchanged
+
+  # Cloud: identical
+  Scenario: A bulk disable only changes hosts inside the ACL
+    Given the non-admin user is logged in
+    When the user posts a bulk disable for both hosts
+    Then the granted host is disabled
+    And the activation of that host is unchanged
+
+  # Cloud: identical
+  Scenario: A mass change only carries hosts inside the ACL
+    Given the non-admin user is logged in
+    When the user opens a mass change for both hosts
+    Then only the granted host is carried into the mass change
+
+  # Cloud: identical
+  Scenario: A read-only user cannot bulk disable at all
+    Given the read-only user is logged in
+    When the user posts a bulk disable for the granted host
+    Then the granted host is still enabled

--- a/centreon/tests/e2e/features/Hosts/10-host-listing-acl/index.ts
+++ b/centreon/tests/e2e/features/Hosts/10-host-listing-acl/index.ts
@@ -1,0 +1,218 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { INTERCEPTORS } from 'fixtures/shared/constants/interceptors';
+import { PAGES } from 'fixtures/shared/constants/pages';
+
+import { ActionClapi } from '../../../commons';
+
+const grantedHost = 'host-acl-granted';
+const deniedHost = 'host-acl-denied';
+
+// The listing page (inside the iframe) both renders the rows and dispatches the
+// bulk actions the legacy form posts back to it.
+const listingPageUrl = '/centreon/main.get.php?p=60101';
+
+/**
+ * Read the activation flag straight from the database. A quiet page proves
+ * nothing on its own — what matters is that no write happened, and only the row
+ * can say that.
+ */
+const hostActivation = (name: string): Cypress.Chainable =>
+  cy
+    .requestOnDatabase({
+      database: 'centreon',
+      query: `SELECT host_id, host_activate FROM host WHERE host_name = '${name}'`
+    })
+    .then(([rows]) => {
+      if (rows.length === 0) {
+        throw new Error(`Host ${name} not found`);
+      }
+
+      return cy.wrap(rows[0], { log: false });
+    });
+
+/**
+ * A valid token, scraped from the listing form the caller is entitled to see.
+ * Using a real one is the point: with an invalid token the action would be
+ * refused for that reason and the ACL filter would never be reached.
+ */
+const legacyCsrfToken = (): Cypress.Chainable => {
+  cy.visit(PAGES.configuration.hostsLegacy);
+  cy.wait('@getTimeZone');
+
+  return cy
+    .getIframeBody()
+    .find('form[name="form"] input[name="centreon_token"]')
+    .invoke('val');
+};
+
+const postBulkDisable = (hostIds: Array<number>): void => {
+  legacyCsrfToken().then((token) => {
+    const body: Record<string, string> = {
+      centreon_token: String(token),
+      o: 'mu'
+    };
+    hostIds.forEach((id) => {
+      body[`select[${id}]`] = '1';
+    });
+    cy.request({
+      body,
+      failOnStatusCode: false,
+      form: true,
+      method: 'POST',
+      url: listingPageUrl
+    })
+      // A 200 proves the request reached host.php, so an unchanged activation
+      // state means the ACL filter dropped the id, not an incidental failure.
+      .its('status')
+      .should('eq', 200);
+  });
+};
+
+beforeEach(() => {
+  cy.startContainers();
+  cy.intercept({
+    method: 'GET',
+    url: INTERCEPTORS.api.navigation_list
+  }).as('getNavigationList');
+  cy.intercept({
+    method: 'GET',
+    url: INTERCEPTORS.pages.time_zone
+  }).as('getTimeZone');
+});
+
+afterEach(() => {
+  cy.stopContainers();
+});
+
+Given(
+  'two hosts exist and only one of them is granted to non-admin users',
+  () => {
+    cy.loginByTypeOfUser({ jsonName: 'admin', loginViaApi: false });
+
+    [grantedHost, deniedHost].forEach((name) => {
+      cy.addHost({
+        hostGroup: 'Linux-Servers',
+        name,
+        template: 'generic-host'
+      });
+    });
+
+    // The ACL resource grants the first host only. RELOAD rebuilds centreon_acl,
+    // which is what every ACL-scoped query below actually reads — without it the
+    // grants exist in the configuration and nowhere the pages can see them.
+    cy.fixture('resources/clapi/config-ACL/hosts-acl-user.json').then(
+      (actions: Array<ActionClapi>) => {
+        actions.forEach((action) => {
+          cy.executeActionViaClapi({ bodyContent: action });
+        });
+      }
+    );
+
+    cy.logout();
+  }
+);
+
+Given('the non-admin user is logged in', () => {
+  cy.loginByTypeOfUser({ jsonName: 'hosts-acl-user', loginViaApi: false });
+});
+
+Given('the read-only user is logged in', () => {
+  cy.loginByTypeOfUser({ jsonName: 'hosts-acl-ro-user', loginViaApi: false });
+});
+
+When('the user opens the hosts listing', () => {
+  cy.visit(PAGES.configuration.hostsLegacy);
+  cy.wait('@getTimeZone');
+  cy.waitForElementInIframe('#main-content', `a:contains("${grantedHost}")`);
+});
+
+Then('only the granted host is listed', () => {
+  cy.getIframeBody().find(`a:contains("${grantedHost}")`).should('exist');
+  cy.getIframeBody().find(`a:contains("${deniedHost}")`).should('not.exist');
+});
+
+When('the user posts a disable for the host it was not granted', () => {
+  hostActivation(deniedHost).then((host) => {
+    cy.wrap(host.host_activate, { log: false }).as('activationBefore');
+
+    legacyCsrfToken().then((token) => {
+      cy.request({
+        body: {
+          centreon_token: String(token),
+          host_id: String(host.host_id),
+          o: 'u'
+        },
+        failOnStatusCode: false,
+        form: true,
+        method: 'POST',
+        url: listingPageUrl
+      })
+        .its('status')
+        .should('eq', 200);
+    });
+  });
+});
+
+Then('the activation of that host is unchanged', () => {
+  cy.get('@activationBefore').then((before) => {
+    hostActivation(deniedHost).then((after) => {
+      expect(String(after.host_activate)).to.equal(String(before));
+    });
+  });
+});
+
+When('the user posts a bulk disable for both hosts', () => {
+  hostActivation(grantedHost).then((granted) => {
+    cy.wrap(granted.host_activate, { log: false }).as(
+      'grantedActivationBefore'
+    );
+    hostActivation(deniedHost).then((denied) => {
+      cy.wrap(denied.host_activate, { log: false }).as('activationBefore');
+
+      // Include one granted host as a control proving that the dispatcher ran,
+      // while the denied host proves that its selection was narrowed by the ACL.
+      postBulkDisable([granted.host_id, denied.host_id]);
+    });
+  });
+});
+
+Then('the granted host is disabled', () => {
+  cy.get('@grantedActivationBefore').then((before) => {
+    expect(String(before), 'the host was enabled to begin with').to.equal('1');
+    hostActivation(grantedHost).then((after) => {
+      expect(String(after.host_activate)).to.equal('0');
+    });
+  });
+});
+
+When('the user opens a mass change for both hosts', () => {
+  hostActivation(grantedHost).then((granted) => {
+    cy.wrap(granted.host_id, { log: false }).as('grantedHostId');
+    hostActivation(deniedHost).then((denied) => {
+      cy.visit(
+        `${PAGES.configuration.hostsLegacy}&o=mc&select=${granted.host_id},${denied.host_id}`
+      );
+      cy.wait('@getTimeZone');
+    });
+  });
+});
+
+Then('only the granted host is carried into the mass change', () => {
+  cy.get('@grantedHostId').then((grantedHostId) => {
+    cy.getIframeBody()
+      .find('input[name="select"]')
+      .should('have.value', String(grantedHostId));
+  });
+});
+
+When('the user posts a bulk disable for the granted host', () => {
+  hostActivation(grantedHost).then((granted) => {
+    postBulkDisable([granted.host_id]);
+  });
+});
+
+Then('the granted host is still enabled', () => {
+  hostActivation(grantedHost).then((after) => {
+    expect(String(after.host_activate)).to.equal('1');
+  });
+});

--- a/centreon/tests/e2e/features/Hosts/10-host-listing-acl/index.ts
+++ b/centreon/tests/e2e/features/Hosts/10-host-listing-acl/index.ts
@@ -1,6 +1,6 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import { INTERCEPTORS } from 'fixtures/shared/constants/interceptors';
-import { PAGES } from 'fixtures/shared/constants/pages';
+import { INTERCEPTORS } from 'e2e/fixtures/shared/constants/interceptors';
+import { PAGES } from 'e2e/fixtures/shared/constants/pages';
 
 import { ActionClapi } from '../../../commons';
 

--- a/centreon/tests/e2e/features/Hosts/10-host-listing-acl/index.ts
+++ b/centreon/tests/e2e/features/Hosts/10-host-listing-acl/index.ts
@@ -48,6 +48,7 @@ const legacyCsrfToken = (): Cypress.Chainable => {
 const postBulkDisable = (hostIds: Array<number>): void => {
   legacyCsrfToken().then((token) => {
     const body: Record<string, string> = {
+      // biome-ignore lint/style/useNamingConvention: legacy API POST field must stay snake_case
       centreon_token: String(token),
       o: 'mu'
     };
@@ -138,7 +139,9 @@ When('the user posts a disable for the host it was not granted', () => {
     legacyCsrfToken().then((token) => {
       cy.request({
         body: {
+          // biome-ignore lint/style/useNamingConvention: legacy API POST field must stay snake_case
           centreon_token: String(token),
+          // biome-ignore lint/style/useNamingConvention: legacy API POST field must stay snake_case
           host_id: String(host.host_id),
           o: 'u'
         },

--- a/centreon/tests/e2e/features/Macros/01-hosts-macros/index.ts
+++ b/centreon/tests/e2e/features/Macros/01-hosts-macros/index.ts
@@ -9,6 +9,22 @@ const clickToAddHost = () => {
   cy.waitForElementInIframe('#main-content', 'input[name="host_name"]');
 };
 
+/**
+ * A multi-select keeps its dropdown open after a pick, and its overlay swallows
+ * the next click — which is the one meant for the control underneath (this ate
+ * the first of the two macro-add clicks with no error from Cypress). Close it
+ * and prove it is gone before moving on.
+ */
+const pickAclResourceGroup = (): void => {
+  cy.getIframeBody().find('input[placeholder="ACL Resource Groups"]').click();
+  cy.getIframeBody().contains('div', 'user-ACLGROUP').click();
+  // select2 drops the placeholder from its search field once a value is held,
+  // so the field cannot be re-queried by placeholder here. Any mousedown
+  // outside the widget closes the dropdown: a neutral text field does.
+  cy.getIframeBody().find('input[name="host_name"]').click();
+  cy.getIframeBody().find('.select2-container--open').should('not.exist');
+};
+
 before(() => {
   cy.startContainers();
   cy.setUserTokenApiV1().executeCommandsViaClapi(
@@ -59,8 +75,7 @@ When('the non-admin user fills in all mandatory fields', () => {
     .find('input[name="host_address"]')
     .clear()
     .type(hostMacros.default_host.address);
-  cy.getIframeBody().find('input[placeholder="ACL Resource Groups"]').click();
-  cy.getIframeBody().contains('div', 'user-ACLGROUP').click();
+  pickAclResourceGroup();
 });
 
 When('the non-admin user adds one normal macro and one password macro', () => {
@@ -356,8 +371,7 @@ When(
       .find('input[name="host_address"]')
       .clear()
       .type(hostMacros.default_host.address);
-    cy.getIframeBody().find('input[placeholder="ACL Resource Groups"]').click();
-    cy.getIframeBody().contains('div', 'user-ACLGROUP').click();
+    pickAclResourceGroup();
     cy.getIframeBody().find('#template_add').click();
     cy.getIframeBody().find('span[role="presentation"]').eq(1).click();
     cy.getIframeBody().find(`div[title="${hostTemplate}"]`).click();

--- a/centreon/tests/e2e/fixtures/resources/clapi/config-ACL/hosts-acl-user.json
+++ b/centreon/tests/e2e/fixtures/resources/clapi/config-ACL/hosts-acl-user.json
@@ -1,0 +1,97 @@
+[
+    {
+        "action": "ADD",
+        "object": "CONTACT",
+        "values": "hosts-acl-user;hosts-acl-user;hosts-acl-user@centreon.test;Centreon!2021User;0;1;en_US;local"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLGROUP",
+        "values": "hosts-ACLGROUP;hosts-ACLGROUP"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLMENU",
+        "values": "hosts-ACLMENU;hosts-ACLMENU"
+    },
+    {
+        "action": "GRANTRW",
+        "object": "ACLMENU",
+        "values": "hosts-ACLMENU;1;Configuration"
+    },
+    {
+        "action": "ADDMENU",
+        "object": "ACLGROUP",
+        "values": "hosts-ACLGROUP;hosts-ACLMENU"
+    },
+    {
+        "action": "SETCONTACT",
+        "object": "ACLGROUP",
+        "values": "hosts-ACLGROUP;hosts-acl-user"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLRESOURCE",
+        "values": "name=hosts-ACLRESOURCE;acl_group=hosts-ACLGROUP"
+    },
+    {
+        "action": "ADDRESOURCE",
+        "object": "ACLGROUP",
+        "values": "hosts-ACLGROUP;name=hosts-ACLRESOURCE"
+    },
+    {
+        "action": "GRANT_HOST",
+        "object": "ACLRESOURCE",
+        "values": "name=hosts-ACLRESOURCE;host-acl-granted"
+    },
+    {
+        "action": "ADD",
+        "object": "CONTACT",
+        "values": "hosts-acl-ro-user;hosts-acl-ro-user;hosts-acl-ro-user@centreon.test;Centreon!2021User;0;1;en_US;local"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLGROUP",
+        "values": "hosts-ro-ACLGROUP;hosts-ro-ACLGROUP"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLMENU",
+        "values": "hosts-ro-ACLMENU;hosts-ro-ACLMENU"
+    },
+    {
+        "action": "GRANTRO",
+        "object": "ACLMENU",
+        "values": "hosts-ro-ACLMENU;1;Configuration"
+    },
+    {
+        "action": "ADDMENU",
+        "object": "ACLGROUP",
+        "values": "hosts-ro-ACLGROUP;hosts-ro-ACLMENU"
+    },
+    {
+        "action": "SETCONTACT",
+        "object": "ACLGROUP",
+        "values": "hosts-ro-ACLGROUP;hosts-acl-ro-user"
+    },
+    {
+        "action": "ADD",
+        "object": "ACLRESOURCE",
+        "values": "name=hosts-ro-ACLRESOURCE;acl_group=hosts-ro-ACLGROUP"
+    },
+    {
+        "action": "ADDRESOURCE",
+        "object": "ACLGROUP",
+        "values": "hosts-ro-ACLGROUP;name=hosts-ro-ACLRESOURCE"
+    },
+    {
+        "action": "GRANT_HOST",
+        "object": "ACLRESOURCE",
+        "values": "name=hosts-ro-ACLRESOURCE;host-acl-granted"
+    },
+    {
+        "action": "RELOAD",
+        "object": "ACL",
+        "values": ""
+    }
+]

--- a/centreon/tests/e2e/fixtures/users/hosts-acl-ro-user.json
+++ b/centreon/tests/e2e/fixtures/users/hosts-acl-ro-user.json
@@ -1,0 +1,4 @@
+{
+  "login": "hosts-acl-ro-user",
+  "password": "Centreon!2021User"
+}

--- a/centreon/tests/e2e/fixtures/users/hosts-acl-user.json
+++ b/centreon/tests/e2e/fixtures/users/hosts-acl-user.json
@@ -1,0 +1,4 @@
+{
+  "login": "hosts-acl-user",
+  "password": "Centreon!2021User"
+}

--- a/centreon/tests/php/www/include/common/CsrfTokenPurgeTest.php
+++ b/centreon/tests/php/www/include/common/CsrfTokenPurgeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+// The legacy helpers live outside the Composer classmap.
+require_once __DIR__ . '/../../../../../www/include/common/common-Func.php';
+
+beforeEach(function (): void {
+    $_SESSION['x-centreon-token'] = [];
+    $_SESSION['x-centreon-token-generated-at'] = [];
+});
+
+afterEach(function (): void {
+    unset($_SESSION['x-centreon-token'], $_SESSION['x-centreon-token-generated-at']);
+});
+
+it('drops an expired token from both structures', function (): void {
+    $_SESSION['x-centreon-token'] = ['fresh-token', 'old-token'];
+    $_SESSION['x-centreon-token-generated-at'] = [
+        'fresh-token' => time(),
+        'old-token' => time() - (16 * 60),
+    ];
+
+    purgeOutdatedCSRFTokens();
+
+    expect(array_values($_SESSION['x-centreon-token']))->toBe(['fresh-token']);
+    expect($_SESSION['x-centreon-token-generated-at'])->toHaveKey('fresh-token');
+    expect($_SESSION['x-centreon-token-generated-at'])->not->toHaveKey('old-token');
+});
+
+it('keeps a live token when an expired entry is missing from the token list', function (): void {
+    // The regression this pins: the two structures can drift apart, and a loose
+    // array_search then returns false — unset(...[false]) deleted index 0, a
+    // token that may well be live.
+    $_SESSION['x-centreon-token'] = ['live-token'];
+    $_SESSION['x-centreon-token-generated-at'] = [
+        'live-token' => time(),
+        'ghost-token' => time() - (16 * 60),
+    ];
+
+    purgeOutdatedCSRFTokens();
+
+    expect($_SESSION['x-centreon-token'])->toBe(['live-token']);
+    expect($_SESSION['x-centreon-token-generated-at'])->not->toHaveKey('ghost-token');
+});
+
+it('leaves fresh tokens untouched', function (): void {
+    $_SESSION['x-centreon-token'] = ['a', 'b'];
+    $_SESSION['x-centreon-token-generated-at'] = ['a' => time(), 'b' => time() - 60];
+
+    purgeOutdatedCSRFTokens();
+
+    expect($_SESSION['x-centreon-token'])->toBe(['a', 'b']);
+});

--- a/centreon/www/include/common/common-Func.php
+++ b/centreon/www/include/common/common-Func.php
@@ -1801,9 +1801,14 @@ function purgeOutdatedCSRFTokens()
         $elapsedTime = time() - $value;
 
         if ($elapsedTime > (15 * 60)) {
-            $tokenKey = array_search((string) $key, $_SESSION['x-centreon-token']);
-            unset($_SESSION['x-centreon-token'][$tokenKey], $_SESSION['x-centreon-token-generated-at'][(string) $key]);
-
+            // Strict, and guarded: a loose search returns false for a token missing
+            // from the list, and unset(...[false]) then deletes index 0 — a live
+            // token. Reachable whenever the two structures drift apart.
+            $tokenKey = array_search((string) $key, $_SESSION['x-centreon-token'], true);
+            if ($tokenKey !== false) {
+                unset($_SESSION['x-centreon-token'][$tokenKey]);
+            }
+            unset($_SESSION['x-centreon-token-generated-at'][(string) $key]);
         }
     }
 }

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -30,6 +30,8 @@ require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
 use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger as AdaptationLogger;
 use App\Kernel;
 use Centreon\Domain\Log\Logger;
 use Core\ActionLog\Domain\Model\ActionLog;
@@ -458,13 +460,29 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
             continue;
         }
         $row['host_id'] = null;
-        $dupCount = filter_var($nbrDup[$key] ?? 0, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+        // Bound 0..999 server-side (the listing input's maxlength="3" is
+        // client-only) so a forged dupNbr cannot drive unbounded duplication.
+        $dupCount = filter_var(
+            $nbrDup[$key] ?? 0,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 0, 'max_range' => 999]]
+        );
         if ($dupCount === false) {
+            AdaptationLogger::create(LogChannelEnum::WEB)->warning(
+                'Host duplication skipped: invalid duplication count',
+                ['sourceHostId' => (int) $key, 'submitted' => $nbrDup[$key] ?? null]
+            );
+
             continue;
         }
         $originalHostName = $row['host_name'];
+        $skippedNames = [];
+        $skippedTotal = 0;
         for ($i = 1; $i <= $dupCount; $i++) {
             $hostName = null;
+            // Reset per copy: after a skipped name, a stale id from the previous
+            // iteration would replay the ACL update below for the wrong copy.
+            $maxId = null;
             foreach ($row as $key2 => $value2) {
                 $value2 = is_int($value2) ? (string) $value2 : $value2;
                 if ($key2 == 'host_name') {
@@ -478,7 +496,12 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
                     $fields['host_name'] = $hostName;
                 }
             }
-            if (hasHostNameNeverUsed($hostName)) {
+            // The name has to be free among BOTH hosts and templates. Host templates
+            // duplicate through this same function — hostTemplateModel.php requires
+            // this file and calls multipleHostInDB() — and they carry
+            // host_register = '0', so a host-only check never sees the template copy
+            // it has just made.
+            if (hasHostNameNeverUsed($hostName) && hasHostTemplateNeverUsed($hostName)) {
                 $columns = array_keys($row);
                 $placeholders = array_map(fn ($col) => ':' . $col, $columns);
                 $insertHostQuery = 'INSERT INTO host (' . implode(', ', $columns) . ') VALUES (' . implode(', ', $placeholders) . ')';
@@ -537,51 +560,53 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
                     } elseif (file_exists($path . '../service/DB-Func.php')) {
                         require_once $path . '../configObject/service/DB-Func.php';
                     }
-                    $hostInf = $maxId;
-                    $serviceArr = [];
-                    $serviceNbr = [];
-                    // Get all Services link to the Host
-                    $svcRelStatement = $pearDB->prepare('SELECT DISTINCT service_service_id FROM host_service_relation WHERE host_host_id = :hostId');
-                    $svcRelStatement->bindValue(':hostId', (int) $key, PDO::PARAM_INT);
-                    $svcRelStatement->execute();
-                    $dbResult = $svcRelStatement;
-                    $countStatement = $pearDB->prepare(
-                        'SELECT COUNT(*)
-                        FROM host_service_relation
-                        WHERE service_service_id = :service_service_id'
-                    );
-                    $insertStatement = $pearDB->prepare(
-                        'INSERT INTO host_service_relation
-                        VALUES (NULL, NULL, :host_id, NULL, :service_service_id)'
-                    );
-                    while ($service = $dbResult->fetch()) {
-                        // If the Service is link with several Host, we keep this property and don't duplicate it,
-                        // just create a new relation with the new Host
-                        $countStatement->bindValue(
-                            ':service_service_id',
-                            (int) $service['service_service_id'],
-                            PDO::PARAM_INT
+                    // Register Host -> Duplicate the Service list
+                    if ($row['host_register'] == 1) {
+                        $hostInf = $maxId;
+                        $serviceArr = [];
+                        $serviceNbr = [];
+                        // Get all Services link to the Host
+                        $svcRelStatement = $pearDB->prepare('SELECT DISTINCT service_service_id FROM host_service_relation WHERE host_host_id = :hostId');
+                        $svcRelStatement->bindValue(':hostId', (int) $key, PDO::PARAM_INT);
+                        $svcRelStatement->execute();
+                        $dbResult = $svcRelStatement;
+                        $countStatement = $pearDB->prepare(
+                            'SELECT COUNT(*)
+                            FROM host_service_relation
+                            WHERE service_service_id = :service_service_id'
                         );
-                        $countStatement->execute();
-                        $mulHostSv = $countStatement->fetch(PDO::FETCH_ASSOC);
-                        if ($mulHostSv['COUNT(*)'] > 1) {
-                            $insertStatement->bindValue(':host_id', (int) $maxId, PDO::PARAM_INT);
-                            $insertStatement->bindValue(
+                        $insertStatement = $pearDB->prepare(
+                            'INSERT INTO host_service_relation
+                            VALUES (NULL, NULL, :host_id, NULL, :service_service_id)'
+                        );
+                        while ($service = $dbResult->fetch()) {
+                            // If the Service is link with several Host, we keep this property and don't duplicate it,
+                            // just create a new relation with the new Host
+                            $countStatement->bindValue(
                                 ':service_service_id',
                                 (int) $service['service_service_id'],
                                 PDO::PARAM_INT
                             );
-                            $insertStatement->execute();
-                        } else {
-                            $serviceArr[$service['service_service_id']] = $service['service_service_id'];
-                            $serviceNbr[$service['service_service_id']] = 1;
+                            $countStatement->execute();
+                            $mulHostSv = $countStatement->fetch(PDO::FETCH_ASSOC);
+                            if ($mulHostSv['COUNT(*)'] > 1) {
+                                $insertStatement->bindValue(':host_id', (int) $maxId, PDO::PARAM_INT);
+                                $insertStatement->bindValue(
+                                    ':service_service_id',
+                                    (int) $service['service_service_id'],
+                                    PDO::PARAM_INT
+                                );
+                                $insertStatement->execute();
+                            } else {
+                                $serviceArr[$service['service_service_id']] = $service['service_service_id'];
+                                $serviceNbr[$service['service_service_id']] = 1;
+                            }
                         }
-                    }
-                    // Register Host -> Duplicate the Service list
-                    if ($row['host_register'] == 1) {
                         multipleServiceInDB($serviceArr, $serviceNbr, $hostInf, 0);
                     } else {
-                        // Host Template -> Link to the existing Service Template List
+                        // Host Template -> Link to the existing Service Template List. Do not
+                        // reintroduce the host branch's COUNT(*) > 1 insert before this loop: a
+                        // service template shared by several hosts would be related twice.
                         $svcTplStatement = $pearDB->prepare('SELECT DISTINCT service_service_id FROM host_service_relation WHERE host_host_id = :hostId');
                         $svcTplStatement->bindValue(':hostId', (int) $key, PDO::PARAM_INT);
                         $svcTplStatement->execute();
@@ -805,10 +830,25 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
                         object_name: $hostName,
                         action_type: ActionLog::ACTION_TYPE_ADD
                     );
+                } else {
+                    // Insert returned no id (misconfigured AUTO_INCREMENT): no copy
+                    // was created, so account for it like a skipped name.
+                    ++$skippedTotal;
+                    if (count($skippedNames) < 20) {
+                        $skippedNames[] = $hostName ?? '(unnamed)';
+                    }
+                }
+            } else {
+                // Aggregated, not logged per name: one record per colliding name
+                // would multiply disk writes within the duplication loop.
+                ++$skippedTotal;
+                if (count($skippedNames) < 20) {
+                    $skippedNames[] = $hostName ?? '(unnamed)';
                 }
             }
-            // if all duplication names are already used, next value is never set
-            if (isset($maxId)) {
+            // Falsy covers both "no insert this round" (null) and the insert
+            // branch's own rejected lastInsertId of 0.
+            if ($maxId) {
                 $centreon->user->access->updateACL([
                     'type' => 'HOST',
                     'id' => $maxId,
@@ -816,6 +856,19 @@ function multipleHostInDB($hosts = [], $nbrDup = [])
                     'duplicate_host' => (int) $key,
                 ]);
             }
+        }
+
+        if ($skippedTotal > 0) {
+            // The page reloads unchanged, so this is the operator's only clue
+            // about the copies that never appeared.
+            AdaptationLogger::create(LogChannelEnum::WEB)->warning(
+                'Host duplication skipped: generated name already taken by a host or host template, or the insert returned no id',
+                [
+                    'sourceHostId' => (int) $key,
+                    'names' => $skippedNames,
+                    'skippedTotal' => $skippedTotal,
+                ]
+            );
         }
     }
     CentreonACL::duplicateHostAcl($hostAcl);

--- a/centreon/www/include/configuration/configObject/host/host.php
+++ b/centreon/www/include/configuration/configObject/host/host.php
@@ -19,6 +19,9 @@
  *
  */
 
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+
 if (! isset($centreon)) {
     exit();
 }
@@ -94,6 +97,70 @@ $hgs = $acl->getHostGroupAclConf(null, 'broker');
 $aclHostString = $acl->getHostsString('ID', $dbmon);
 $aclPollerString = $acl->getPollerString();
 
+/**
+ * Narrow a host selection to the ids the caller may write, once page write
+ * access is confirmed. The topology check upstream admits read-only access and
+ * the write branches took their ids from the request gated by the CSRF token
+ * alone, so every write path routes its selection through here: the bulk
+ * selection once above the switch, the single-id branches on their own id. A
+ * mixed selection acts on the granted part rather than failing whole.
+ *
+ * Reads $acl, $centreon, $dbmon and $p from global scope; $p is this page's
+ * topology id (the write check is $acl->page($p)).
+ *
+ * @param array<int, mixed> $selection Host ids as keys, as getSelectOption() returns
+ *
+ * @return array<int, mixed>
+ */
+function keepWritableHosts(array $selection): array
+{
+    global $acl, $dbmon, $centreon, $p;
+
+    if ($selection === []) {
+        return [];
+    }
+
+    if ($acl->page($p) != 1) {
+        Logger::create(LogChannelEnum::WEB)->warning(
+            'Hosts page: bulk action refused, no write access',
+            ['userId' => (int) $centreon->user->get_id(), 'pageId' => $p]
+        );
+
+        return [];
+    }
+
+    if ($centreon->user->admin) {
+        return $selection;
+    }
+
+    $granted = array_flip(array_filter(array_map(
+        'intval',
+        explode(',', (string) $acl->getHostsString('ID', $dbmon, false))
+    )));
+    $writable = array_intersect_key($selection, $granted);
+
+    if (count($writable) !== count($selection)) {
+        // Log the refused ids: they tell a misconfigured ACL apart from probing.
+        $refusedIds = array_slice(array_keys(array_diff_key($selection, $granted)), 0, 20);
+        Logger::create(LogChannelEnum::WEB)->warning(
+            'Hosts page: bulk action narrowed to the caller ACL',
+            [
+                'userId' => (int) $centreon->user->get_id(),
+                'submitted' => count($selection),
+                'granted' => count($writable),
+                'refusedIds' => $refusedIds,
+            ]
+        );
+    }
+
+    return $writable;
+}
+
+// formHost.php runs its mass-change loop on the presence of the submitMC field
+// rather than on $o, so a request declaring any other action still reaches it.
+// Filtering once here covers every branch instead of each one guarding itself.
+$select = keepWritableHosts(is_array($select) ? $select : []);
+
 switch ($o) {
     case HOST_ADD:
     case HOST_WATCH:
@@ -105,7 +172,8 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            enableHostInDB($host_id);
+            // Route the single id through the same ACL guard as the bulk branches.
+            enableHostInDB(null, keepWritableHosts($host_id ? [$host_id => '1'] : []));
         } else {
             unvalidFormMessage();
         }
@@ -115,7 +183,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            enableHostInDB(null, $select ?? []);
+            enableHostInDB(null, $select);
         } else {
             unvalidFormMessage();
         }
@@ -125,7 +193,8 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            disableHostInDB($host_id);
+            // Route the single id through the same ACL guard as the bulk branches.
+            disableHostInDB(null, keepWritableHosts($host_id ? [$host_id => '1'] : []));
         } else {
             unvalidFormMessage();
         }
@@ -135,7 +204,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            disableHostInDB(null, $select ?? []);
+            disableHostInDB(null, $select);
         } else {
             unvalidFormMessage();
         }
@@ -145,7 +214,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            multipleHostInDB($select ?? [], $dupNbr);
+            multipleHostInDB($select, $dupNbr);
         } else {
             unvalidFormMessage();
         }
@@ -168,7 +237,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            applytpl(array_keys($select) ?? []);
+            applytpl(array_keys($select));
         } else {
             unvalidFormMessage();
         }


### PR DESCRIPTION
## Description

Salvages the standalone bug fixes and test improvements from the abandoned host listing migration [#10059](https://github.com/centreon/centreon/pull/10059) (the pages are being rebuilt on React + API Platform). Each fix corrects a defect that exists in code still served on `dev-24.10.x` today; the abandoned migration code itself is excluded.

Backport of #11449, scoped to the three legacy PHP files below and the tests.

> **Backport notes**
> - The `Commands` spec repairs from #11449 target the "Used by hosts/services" scenarios, which only exist on `develop` (they rely on `searchForCommandsByName` / the `check_updated` fixture, absent here); they are dropped from this backport.
> - Bulk deletion keeps this branch's native `deleteHostInDB(...)` (the newer `deleteHostInApi(...)` does not exist on 24.10); the ACL protection is unchanged since `$select` is already narrowed by `keepWritableHosts()` upstream of the switch.
> - Added the two `use Adaptation\Log\...` imports in `DB-Func.php` that the aggregated-skip logging needs — they pre-existed on the newer branches but not here.

### Fixes — PHP

- **Host/template duplication** (`host/DB-Func.php`):
  - Duplicating a host **template** related its service templates twice, compounding with each copy (3 → 4 → 6 rows): the host-branch `host_service_relation` gathering ran unconditionally before the template branch also linked them. The gathering/insert loop now lives inside the `host_register == 1` branch, so a template only takes the template path.
  - The name-uniqueness guard only checked hosts (`hasHostNameNeverUsed`), so a template copy colliding with an existing **template** name was inserted anyway — templates duplicate through this same function and carry `host_register = '0'`. It now also checks `hasHostTemplateNeverUsed`.
  - `dupNbr` is bounded 0..999 server-side (the listing input's `maxlength="3"` is client-only), so a forged value cannot drive unbounded duplication.
  - A skipped copy no longer replays the previous copy's ACL update (`$maxId` reset per copy; truthy guard rejects a `lastInsertId` of 0).
  - Every silent skip is surfaced: a name collision, an invalid `dupNbr`, and an insert returning no id are all logged (aggregated and capped) so the operator has an explanation for copies that never appeared.
- **Bulk actions ACL** (`host/host.php`): the write branches (enable/disable/duplicate/delete/apply-template/mass-change) checked the CSRF token but never the caller's page-level write access nor the posted host ids — any authenticated user with the page could act on hosts outside their ACL. A single `keepWritableHosts()` filter now narrows every selection (bulk, single-id and mass-change) to the caller's ACL, with an admin bypass and a fail-closed empty result when the page is read-only; refused ids are logged (capped).
- **CSRF token purge** (`common-Func.php`): `purgeOutdatedCSRFTokens()` ran `unset($list[array_search(...)])` with a loose, unchecked search — a token missing from the list returned `false`, and `unset($list[false])` deleted index 0, a possibly-live token. The search is now strict and guarded.

### Tests

- **Unit (Pest)** — `CsrfTokenPurgeTest` (3 tests) pins the purge contract, including the exact regression: a token absent from the list must not delete the live index-0 token. Registered to PHPStan via `phpstan.legacy.test.neon` `scanFiles` (the file is outside the classmap).
- **e2e — new coverage** — `Hosts/10-host-listing-acl`: a restricted user's single and bulk disable, a mass-change, and a read-only refusal are all narrowed to the caller's ACL, with the outcome read back from the database and each denial paired with a positive control; the disable requests assert a 200 so an unchanged activation state can only mean the ACL filter dropped the id. `Hosts/03`: a template duplication carries exactly its source's service relations over two rounds, and a name clash creates nothing.
- **e2e — repairs to existing specs** (the defects are live on the branch's own specs): `Hosts/05` mass-changed **every host on the platform** via the header check-all instead of the three fixtures; `Hosts/08` clicked the Notification tab while asserting Relations-tab fields; `Hosts/06` disabled a host through an unscoped positional click; `Hosts/09` drove navigation through `win.location.href`; `Macros/01` lost a click to a select2 left open.

## How to test

- `cd centreon && php vendor/bin/pest tests/php/www/include/common/CsrfTokenPurgeTest.php` — 3 tests green.
- **Template duplication** (covered by the two `Hosts/03` scenarios): duplicate a host template with shared service templates twice — each copy carries the source's relation count (before the fix: 3 → 4 → 6); duplicating onto an existing template name creates nothing.
- **Bulk-action ACL** (covered by `Hosts/10`): as a non-admin, POST a single/bulk disable (`o=u`/`o=mu`) or a mass-change for a host outside your ACL — the request answers 200 but the host's activation state is unchanged (the id was filtered out); a read-only user's bulk action is a no-op.

## Links

### Jira ticket

Resolves: [MON-208759](https://centreon.atlassian.net/browse/MON-208759)

### PR Github

- Backports: #11449
- Relates to: #10059 — the abandoned host listing migration this PR salvages from.


[MON-208759]: https://centreon.atlassian.net/browse/MON-208759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ