### PR TITLE
fix(poller): return the right URL for a new poller

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
@@ -25,6 +25,7 @@ namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\NotExposed;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model;
 use App\MonitoringConfiguration\Domain\Security\PollerPermissionEnum;
@@ -35,6 +36,7 @@ use App\Shared\Domain\Logging\Attribute\Sensitive;
 #[ApiResource(
     shortName: 'Poller',
     operations: [
+        new NotExposed(uriTemplate: '/configuration/pollers/{id}'),
         new Post(
             uriTemplate: '/configuration/pollers',
             processor: CreatePollerProcessor::class,

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ResourcePollerTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ResourcePollerTransformer.php
@@ -36,11 +36,11 @@ final readonly class ResourcePollerTransformer implements TransformerInterface
     public function transform(mixed $from): PollerResource
     {
         return new PollerResource(
-            id: $from->id()->value,
             name: $from->name->value,
             pollerType: $from->pollerType->value,
             address: $from->address->value,
             centralAddress: $from->centralAddress?->value,
+            id: $from->id()->value,
             uid: (string) $from->uid->value,
             gorgoneCommunicationType: $this->communicationTypeToString($from->gorgoneConfiguration->communicationType),
         );

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
@@ -101,6 +101,18 @@ final class CreatePollerProcessorTest extends ApiTestCase
         self::assertArrayHasKey('installation_command', $responseData);
         self::assertNotNull($responseData['installation_command']);
 
+        // The created poller's IRI and Location must carry the configuration prefix: a
+        // NotExposed item operation pins them to /configuration/pollers/{id}, not the
+        // non-existent bare /pollers/{id} API Platform would otherwise generate.
+        self::assertArrayHasKey('@id', $responseData);
+        $iri = $responseData['@id'];
+        self::assertIsString($iri);
+        self::assertStringContainsString('/configuration/pollers/', $iri);
+        self::assertStringContainsString(
+            '/configuration/pollers/',
+            $response->getHeaders()['location'][0] ?? '',
+        );
+
         $poller = $repository->findOneByName(new PollerName($name));
         self::assertNotNull($poller);
     }

--- a/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
@@ -54,17 +54,46 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
     {
         $routes = $this->getRouteCollection();
 
-        // API Platform derives this item operation from PollerResource to build IRIs, it is not
-        // an endpoint the legacy /api/latest prefix ever exposed.
-        $generatedOperation = '_api_/pollers/{id}{._format}_get';
+        // API Platform derives a NotExposed item operation for any resource that exposes no
+        // readable item GET, purely to build IRIs. Such an operation keeps the default
+        // short-name shape (_api_/<name>/{id}{._format}_get) — unlike a resource that pins an
+        // explicit uriTemplate — and the legacy /api/latest prefix never exposed it. Discover
+        // them instead of naming a resource, so the coverage survives any single one pinning
+        // its own uriTemplate later.
+        $generatedOperationNames = [];
+        foreach ($routes as $route) {
+            $operationName = $route->getDefault('_api_operation_name');
+            if (
+                is_string($operationName)
+                && preg_match('#^_api_/[^/]+/\{id\}\{\._format\}_get$#', $operationName) === 1
+                && str_starts_with($route->getPath(), '/api/')
+                && ! str_starts_with($route->getPath(), '/api/latest/')
+            ) {
+                $generatedOperationNames[$operationName] = true;
+            }
+        }
 
-        self::assertNotNull(
-            $this->findRouteByOperationAndPath($routes, $generatedOperation, '/api/pollers/{id}.{_format}'),
-            'The generated item operation is expected under /api, otherwise this test no longer covers anything.',
+        self::assertNotEmpty(
+            $generatedOperationNames,
+            'No API Platform auto-generated item operation found, otherwise this test no longer covers anything.',
         );
-        self::assertNull(
-            $this->findRouteByOperationAndPath($routes, $generatedOperation, '/api/latest/pollers/{id}.{_format}'),
-            'A generated item operation must not be duplicated under /api/latest.',
+
+        $aliasedUnderLegacy = [];
+        foreach ($routes as $route) {
+            $operationName = $route->getDefault('_api_operation_name');
+            if (
+                is_string($operationName)
+                && isset($generatedOperationNames[$operationName])
+                && str_starts_with($route->getPath(), '/api/latest/')
+            ) {
+                $aliasedUnderLegacy[$operationName] = $route->getPath();
+            }
+        }
+
+        self::assertSame(
+            [],
+            $aliasedUnderLegacy,
+            'Auto-generated item operations must not be duplicated under /api/latest.',
         );
     }
 


### PR DESCRIPTION
## Description

Split out of #11402 to keep the PullWSS fix scoped and independently backportable.

`POST /configuration/pollers` returned a `Location` header and `@id` pointing to `/api/latest/pollers/{id}` — a prefix that does not exist — instead of `/api/latest/configuration/pollers/{id}`. API Platform had derived a default `NotExposed` item operation from the resource short name because none was declared.

- Declare the `NotExposed` item operation explicitly with `uriTemplate: /configuration/pollers/{id}`, pinning the generated IRI to the configuration prefix (kept out of the OpenAPI document).
- Align `ResourcePollerTransformer` argument order with the resource constructor.
- Generalise `LegacyApiPrefixAliasLoaderTest` to discover generated item operations from the route collection instead of naming `PollerResource`, so the coverage holds now that this resource pins its own `uriTemplate`.

## How to test

1. `POST /centreon/api/latest/configuration/pollers` with a valid payload (any platform).
2. Inspect the response `Location` header and body `@id`:
   - Expected: `/centreon/api/latest/configuration/pollers/{id}`
   - Before this fix: `/centreon/api/latest/pollers/{id}` (a prefix that does not resolve).
3. Automated: `composer test:new` stays green, including `LegacyApiPrefixAliasLoaderTest`.

## Links

### Jira ticket

Resolves: [MON-208777](https://centreon.atlassian.net/browse/MON-208777)

### PR Github

- Relates to: #11402 — split out of it (same poller creation flow)


[MON-208777]: https://centreon.atlassian.net/browse/MON-208777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
