### PR TITLE
test(e2e): web: disable flaky poller configuration generation feature

### DIFF
--- a/centreon/tests/e2e/features/Poller-configuration/01-poller-configuration.feature
+++ b/centreon/tests/e2e/features/Poller-configuration/01-poller-configuration.feature
@@ -1,4 +1,4 @@
-@REQ_MON-22134
+@REQ_MON-22134 @ignore
 Feature: Generate poller configuration
   As a Centreon user
   I want to generate the poller configuration


### PR DESCRIPTION
Fixes: [MON-208813](https://centreon.atlassian.net/browse/MON-208813)

## Description

The e2e feature `Poller-configuration/01-poller-configuration` fails intermittently on `develop`, and increasingly often. The cause is not the test: during a configuration export, centreon-web posts its command to the Gorgone internal API on `http://127.0.0.1:8085` and the connection is refused, so the export either takes more than a minute or never completes. The analysis and the exception chain are documented in [MON-208775](https://centreon.atlassian.net/browse/MON-208775).

This PR adds the `@ignore` tag at the `Feature` level so the whole feature is skipped: `cypress:run` already runs with `--env tags='not @ignore'`. Nothing else changes — the scenarios and their Xray tags are untouched, so the test cases stay in the catalog and only their execution is suspended.

## Why disable rather than fix here

The defect is in the product path the test exercises, so it cannot be fixed from the test layer. Meanwhile the feature produces a red CI signal nobody can act on and encourages blind reruns, which is exactly what hides real regressions.

## Follow-up

Re-enabling is tracked by [MON-208815](https://centreon.atlassian.net/browse/MON-208815), blocked by [MON-208775](https://centreon.atlassian.net/browse/MON-208775). The tag must be removed as soon as the Gorgone availability fix lands on `develop`.

## How to test

- An e2e run on this branch reports `Generate poller configuration` as skipped, while the other `Poller-configuration` features still run.
- No other feature file is affected: the diff is a single tag on the first line.


[MON-208813]: https://centreon.atlassian.net/browse/MON-208813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-208775]: https://centreon.atlassian.net/browse/MON-208775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-208815]: https://centreon.atlassian.net/browse/MON-208815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ