### PR TITLE
fix(web): synchronised with the Monitoring parameters - backport #11502

### DIFF
--- a/centreon/www/front_src/src/Configuration/AdditionnalConnectors/Specs/Listing.tsx
+++ b/centreon/www/front_src/src/Configuration/AdditionnalConnectors/Specs/Listing.tsx
@@ -28,7 +28,7 @@ export default (): void => {
     });
     it('sends a listing request with the selected limit when the corresponding button is clicked', () => {
       cy.get('#Rows\\ per\\ page').click();
-      cy.contains(/^20$/).click();
+      cy.get('ul[role="listbox"]').contains(/^20$/).click();
 
       cy.waitForRequest('@getConnectors').then(({ request }) => {
         expect(JSON.parse(request.url.searchParams.get('limit'))).to.equal(20);

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/WidgetContext.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/WidgetContext.tsx
@@ -1,11 +1,11 @@
 import {
   type Acknowledgement,
   type Acl,
-  acknowledgementAtom,
   type Downtime,
-  downtimeAtom,
   type PlatformVersions,
   type User,
+  acknowledgementAtom,
+  downtimeAtom,
   userAtom
 } from '@centreon/ui-context';
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/WidgetContext.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/WidgetContext.tsx
@@ -1,4 +1,13 @@
-import type { Acl, PlatformVersions } from '@centreon/ui-context';
+import {
+  type Acknowledgement,
+  type Acl,
+  acknowledgementAtom,
+  type Downtime,
+  downtimeAtom,
+  type PlatformVersions,
+  type User,
+  userAtom
+} from '@centreon/ui-context';
 
 import { Provider, createStore } from 'jotai';
 import { equals } from 'ramda';
@@ -13,29 +22,46 @@ import {
 import type { OpenTicketContext } from './models';
 
 interface WidgetProviderProps {
+  acknowledgement: Acknowledgement;
   acl: Acl;
   children: ReactNode;
+  downtime: Downtime;
   isOnPublicPage: boolean;
   openTicketContext: OpenTicketContext;
   platform: PlatformVersions | null;
+  user: User;
 }
 
 export const WidgetProvider = ({
+  acknowledgement,
   acl,
   children,
+  downtime,
   isOnPublicPage,
   openTicketContext,
-  platform
+  platform,
+  user
 }: WidgetProviderProps): ReactElement => {
   const store = useMemo(() => {
     const newStore = createStore();
     newStore.set(aclLocalAtom, acl);
     newStore.set(isOnPublicPageLocalAtom, isOnPublicPage);
     newStore.set(platformLocalAtom, platform);
+    newStore.set(acknowledgementAtom, acknowledgement);
+    newStore.set(downtimeAtom, downtime);
+    newStore.set(userAtom, user);
     newStore.set(openTicketContextAtom, openTicketContext);
 
     return newStore;
-  }, [acl, isOnPublicPage, openTicketContext, platform]);
+  }, [
+    acl,
+    isOnPublicPage,
+    openTicketContext,
+    platform,
+    acknowledgement,
+    downtime,
+    user
+  ]);
 
   useEffect(() => {
     store.set(aclLocalAtom, acl);
@@ -48,6 +74,18 @@ export const WidgetProvider = ({
   useEffect(() => {
     store.set(platformLocalAtom, platform);
   }, [platform, store]);
+
+  useEffect(() => {
+    store.set(acknowledgementAtom, acknowledgement);
+  }, [acknowledgement, store]);
+
+  useEffect(() => {
+    store.set(downtimeAtom, downtime);
+  }, [downtime, store]);
+
+  useEffect(() => {
+    store.set(userAtom, user);
+  }, [user, store]);
 
   useEffect(() => {
     store.set(openTicketContextAtom, (prev) =>

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/index.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-resourcestable/src/index.tsx
@@ -1,7 +1,10 @@
 import {
+  acknowledgementAtom,
   aclAtom,
+  downtimeAtom,
   isOnPublicPageAtom,
-  platformVersionsAtom
+  platformVersionsAtom,
+  userAtom
 } from '@centreon/ui-context';
 
 import { useAtomValue } from 'jotai';
@@ -16,6 +19,9 @@ const Widget = (props: ResourcesTableProps): ReactElement => {
   const acl = useAtomValue(aclAtom);
   const platform = useAtomValue(platformVersionsAtom);
   const isOnPublicPage = useAtomValue(isOnPublicPageAtom);
+  const acknowledgement = useAtomValue(acknowledgementAtom);
+  const downtime = useAtomValue(downtimeAtom);
+  const user = useAtomValue(userAtom);
 
   const openTicketContext = useMemo(
     (): OpenTicketContext => ({
@@ -43,10 +49,13 @@ const Widget = (props: ResourcesTableProps): ReactElement => {
 
   return (
     <WidgetProvider
+      acknowledgement={acknowledgement}
       acl={acl}
+      downtime={downtime}
       isOnPublicPage={isOnPublicPage}
       openTicketContext={openTicketContext}
       platform={platform}
+      user={user}
     >
       <ResourcesTable {...props} />
     </WidgetProvider>


### PR DESCRIPTION
Backport of #11502 to dev-25.10.x.

## Summary
In WidgetContext.tsx, also seed acknowledgementAtom, downtimeAtom, and userAtom into the isolated store from the global store, mirroring them with a useEffect to stay in sync.

Note: this branch's WidgetContext.tsx does not carry the `// @ts-nocheck` present on develop (types are already enforced here), so the cherry-picked import was adapted to keep that stricter typing instead of reintroducing the ts-nocheck.