### PR TITLE
fix(web): Rule selection requirement ignored with ticket management ON

### DIFF
--- a/centreon/tests/e2e/features/Dashboards/16-status-chart-widget-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/16-status-chart-widget-configuration/index.ts
@@ -330,7 +330,8 @@ Then('the unit of the resources already displayed should be updated', () => {
       blueCssBackground
     ],
     ['50.0%', '8.3%', '16.7%', '33.3%'],
-    ['33.3%', '25.0%', '8.3%', '33.3%']
+    ['33.3%', '25.0%', '8.3%', '33.3%'],
+    ['41.7%']
   );
 });
 
@@ -366,7 +367,8 @@ Then('only the contents of the other widget are displayed', () => {
       blueCssBackground
     ],
     ['50.0%', '16.7%', '16.7%', '33.3%'],
-    ['33.3%', '8.3%', '8.3%', '33.3%']
+    ['33.3%', '8.3%', '8.3%', '33.3%'],
+    ['41.7%']
   );
 });
 

--- a/centreon/tests/e2e/features/Dashboards/commands.ts
+++ b/centreon/tests/e2e/features/Dashboards/commands.ts
@@ -450,7 +450,8 @@ Cypress.Commands.add(
     index: number,
     expectedColors: Array<string>,
     expectedValues: Array<string>,
-    alternativeValues: Array<string> = []
+    alternativeValues: Array<string> = [],
+    secondAlternativeValues: Array<string> = []
   ): Cypress.Chainable => {
     cy.get('[data-testid="Legend"] > *')
       .eq(index)
@@ -474,6 +475,10 @@ Cypress.Commands.add(
 
                   if (alternativeValues[i]) {
                     possibleValues.push(alternativeValues[i]);
+                  }
+
+                  if (secondAlternativeValues[i]) {
+                    possibleValues.push(secondAlternativeValues[i]);
                   }
 
                   expect(text.trim()).to.match(
@@ -709,7 +714,8 @@ declare global {
         index: number,
         expectedColors: Array<string>,
         expectedValue: Array<string>,
-        alternativeValues?: Array<string>
+        alternativeValues?: Array<string>,
+        secondAlternativeValues?: Array<string>
       ) => Cypress.Chainable;
       visitDashboard: (name: string) => Cypress.Chainable;
       visitDashboards: () => Cypress.Chainable;

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
@@ -40,6 +40,7 @@ import {
   WidgetPropertyProps,
   WidgetResourceType
 } from '../../models';
+import { checkHiddenCondition } from '../handleHiddenConditions';
 
 export const getProperty = <T>({ propertyName, obj }): T | undefined =>
   path<T>(['options', ...split('.', propertyName)], obj);
@@ -61,6 +62,8 @@ interface GetYupValidatorTypeProps {
     | 'required'
     | 'requireResourceType'
     | 'allowEmptyResources'
+    | 'isRequiredProperty'
+    | 'isSingleAutocomplete'
   >;
   t: TFunction;
 }
@@ -83,6 +86,27 @@ export const boundariesValidationSchema = object()
 
 const getResourcesValidation = (properties) => {
   return properties.required ? mixed().required() : mixed();
+};
+
+const isPropertyHidden = (properties, parentValues): boolean => {
+  const { hiddenCondition } = properties;
+
+  if (!hiddenCondition) {
+    return false;
+  }
+
+  const conditions = Array.isArray(hiddenCondition)
+    ? hiddenCondition
+    : [hiddenCondition];
+
+  return conditions.some((condition) =>
+    checkHiddenCondition({
+      featureFlags: null,
+      hasModule: true,
+      hiddenCondition: condition,
+      values: { [condition.target]: parentValues }
+    })
+  );
 };
 
 const getYupValidatorType = ({
@@ -201,6 +225,28 @@ const getYupValidatorType = ({
     [
       equals<FederatedWidgetOptionType>(FederatedWidgetOptionType.boundaries),
       always(boundariesValidationSchema)
+    ],
+    [
+      equals<FederatedWidgetOptionType>(
+        FederatedWidgetOptionType.connectedAutocomplete
+      ),
+      always(
+        (properties.isSingleAutocomplete ? object() : array()).test(
+          'connected-autocomplete-required',
+          t(labelRequired) as string,
+          (value, context) => {
+            if (!(properties.required || properties.isRequiredProperty)) {
+              return true;
+            }
+
+            if (isPropertyHidden(properties, context.parent)) {
+              return true;
+            }
+
+            return !(isNil(value) || isEmpty(value));
+          }
+        )
+      )
     ]
   ])(properties.type);
 
@@ -212,6 +258,8 @@ interface BuildValidationSchemaProps {
     | 'required'
     | 'requireResourceType'
     | 'allowEmptyResources'
+    | 'isRequiredProperty'
+    | 'isSingleAutocomplete'
   >;
   t: TFunction;
 }
@@ -225,7 +273,16 @@ export const buildValidationSchema = ({
     t
   });
 
-  return properties.required
+  if (
+    equals<FederatedWidgetOptionType>(
+      properties.type,
+      FederatedWidgetOptionType.connectedAutocomplete
+    )
+  ) {
+    return yupValidator;
+  }
+
+  return properties.required || properties.isRequiredProperty
     ? yupValidator.required(t(labelRequired) as string)
     : yupValidator;
 };

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.cypress.spec.tsx
@@ -264,6 +264,8 @@ const initializeAndMount = ({
   proceedNavigation;
   store: ReturnType<typeof createStore>;
 } => {
+  cy.cssDisableMotion();
+
   store.set(userAtom, {
     alias: 'admin',
     dashboard: {


### PR DESCRIPTION
Backport of #11507 to dev-25.10.x.

## Summary
You should not have been able to create the widget without selecting an Open Ticket rule (whether the module is installed or not does not change the behavior).