### PR TITLE
fix(web): Rule selection requirement ignored with ticket management ON

### DIFF
--- a/centreon/tests/e2e/features/Dashboards/commands.ts
+++ b/centreon/tests/e2e/features/Dashboards/commands.ts
@@ -354,7 +354,8 @@ Cypress.Commands.add(
     index: number,
     expectedColors: Array<string>,
     expectedValues: Array<string>,
-    alternativeValues: Array<string> = []
+    alternativeValues: Array<string> = [],
+    secondAlternativeValues: Array<string> = []
   ): Cypress.Chainable => {
     cy.get('[data-testid="Legend"] > *')
       .eq(index)
@@ -378,6 +379,10 @@ Cypress.Commands.add(
 
                   if (alternativeValues[i]) {
                     possibleValues.push(alternativeValues[i]);
+                  }
+
+                  if (secondAlternativeValues[i]) {
+                    possibleValues.push(secondAlternativeValues[i]);
                   }
 
                   expect(text.trim()).to.match(
@@ -607,7 +612,8 @@ declare global {
         index: number,
         expectedColors: Array<string>,
         expectedValue: Array<string>,
-        alternativeValues?: Array<string>
+        alternativeValues?: Array<string>,
+        secondAlternativeValues?: Array<string>
       ) => Cypress.Chainable;
       visitDashboard: (name: string) => Cypress.Chainable;
       visitDashboards: () => Cypress.Chainable;

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
@@ -64,10 +64,6 @@ interface GetYupValidatorTypeProps {
   t: TFunction;
 }
 
-const getResourcesValidation = (properties) => {
-  return properties.required ? mixed().required() : mixed();
-};
-
 const isPropertyHidden = (properties, parentValues): boolean => {
   const { hiddenCondition } = properties;
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
@@ -8,6 +8,7 @@ import {
   equals,
   includes,
   isEmpty,
+  isNil,
   pluck,
   split
 } from 'ramda';
@@ -36,6 +37,7 @@ import {
 import {
   type ShowInput,
   type WidgetDataResource,
+  type WidgetPropertyProps,
   WidgetResourceType
 } from '../../models';
 
@@ -57,9 +59,38 @@ const metricSchema = object().shape({
 });
 
 interface GetYupValidatorTypeProps {
-  properties: Pick<FederatedWidgetOption, 'defaultValue' | 'type'>;
+  properties: Pick<FederatedWidgetOption, 'defaultValue' | 'type'> &
+    Pick<WidgetPropertyProps, 'isRequiredProperty' | 'isSingleAutocomplete'>;
   t: TFunction;
 }
+
+const getResourcesValidation = (properties) => {
+  return properties.required ? mixed().required() : mixed();
+};
+
+const isPropertyHidden = (properties, parentValues): boolean => {
+  const { hiddenCondition } = properties;
+
+  if (!hiddenCondition) {
+    return false;
+  }
+
+  const conditions = Array.isArray(hiddenCondition)
+    ? hiddenCondition
+    : [hiddenCondition];
+
+  return conditions.some(({ target, method, when, matches }) => {
+    const values = { [target]: parentValues };
+
+    if (equals(method, 'isNil')) {
+      const formValue = path(when.split('.'), values);
+
+      return isEmpty(formValue) || isNil(formValue);
+    }
+
+    return equals(path(when.split('.'), values), matches);
+  });
+};
 
 const getYupValidatorType = ({
   t,
@@ -162,11 +193,34 @@ const getYupValidatorType = ({
     [
       equals<FederatedWidgetOptionType>(FederatedWidgetOptionType.tiles),
       always(number().min(1))
+    ],
+    [
+      equals<FederatedWidgetOptionType>(
+        FederatedWidgetOptionType.connectedAutocomplete
+      ),
+      always(
+        (properties.isSingleAutocomplete ? object() : array()).test(
+          'connected-autocomplete-required',
+          t(labelRequired) as string,
+          (value, context) => {
+            if (!(properties.required || properties.isRequiredProperty)) {
+              return true;
+            }
+
+            if (isPropertyHidden(properties, context.parent)) {
+              return true;
+            }
+
+            return !(isNil(value) || isEmpty(value));
+          }
+        )
+      )
     ]
   ])(properties.type);
 
 interface BuildValidationSchemaProps {
-  properties: Pick<FederatedWidgetOption, 'defaultValue' | 'type'>;
+  properties: Pick<FederatedWidgetOption, 'defaultValue' | 'type'> &
+    Pick<WidgetPropertyProps, 'isRequiredProperty' | 'isSingleAutocomplete'>;
   t: TFunction;
 }
 
@@ -179,7 +233,16 @@ export const buildValidationSchema = ({
     t
   });
 
-  return properties.required
+  if (
+    equals<FederatedWidgetOptionType>(
+      properties.type,
+      FederatedWidgetOptionType.connectedAutocomplete
+    )
+  ) {
+    return yupValidator;
+  }
+
+  return properties.required || properties.isRequiredProperty
     ? yupValidator.required(t(labelRequired) as string)
     : yupValidator;
 };

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Dashboard.cypress.spec.tsx
@@ -212,6 +212,8 @@ const initializeAndMount = ({
   proceedNavigation;
   store: ReturnType<typeof createStore>;
 } => {
+  cy.cssDisableMotion();
+
   const store = initializeWidgets();
 
   store.set(userAtom, {


### PR DESCRIPTION
Backport of #11507 to dev-24.10.x.

## Summary
You should not have been able to create the widget without selecting an Open Ticket rule (whether the module is installed or not does not change the behavior).

## Notes on this backport
`dev-24.10.x` predates the `handleHiddenConditions.ts` / `checkHiddenCondition` extraction and doesn't have the `boundaries` widget option type, so the fix to `utils.ts` was adapted rather than cherry-picked verbatim:
- Added a `connectedAutocomplete` case to `getYupValidatorType` and made `buildValidationSchema` account for `isRequiredProperty`, matching upstream.
- Ported a scoped `isPropertyHidden` helper (equals/isNil methods, matching the `Rule (ticket provider)` property's `hiddenCondition`) since the shared `checkHiddenCondition` util doesn't exist on this branch yet. Without it, the new required-validation would incorrectly block saving widgets whenever ticket management is OFF (since the rule field is hidden, but was about to become unconditionally required).
- Sourced `isRequiredProperty` / `isSingleAutocomplete` from `WidgetPropertyProps` (`../../models`) instead of `FederatedWidgetOption`, since only the former declares those fields on this branch.

The two e2e/cypress test tweaks from the original PR were only partially applicable:
- `Dashboard.cypress.spec.tsx`: kept the `cy.cssDisableMotion()` addition (command already exists on this branch).
- `16-status-chart-widget-configuration/index.ts`: left as-is — this branch's "Number" unit legend assertions use raw counts (e.g. `['3', '1', '1', '3', '2']`), not percentages, so the upstream `secondAlternativeValues: ['41.7%']` rounding-flake fix doesn't apply here.