### PR TITLE
fix(configuration): ACL-scope and repair the legacy notification views

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -20290,3 +20290,11 @@ msgstr "Standard"
 #: unknown
 msgid "it's required"
 msgstr "es ist erforderlich"
+
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "This contact group is not available"
+msgstr "Diese Kontaktgruppe ist nicht verfügbar"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+msgid "This contact is not available"
+msgstr "Dieser Kontakt ist nicht verfügbar"

--- a/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/en_US.UTF-8/LC_MESSAGES/messages.po
@@ -20205,3 +20205,11 @@ msgstr "warningtext"
 #: unknown
 msgid "{{total}} element(s) found"
 msgstr "{{total}} element(s) found"
+
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "This contact group is not available"
+msgstr "This contact group is not available"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+msgid "This contact is not available"
+msgstr "This contact is not available"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -24159,3 +24159,11 @@ msgstr "periodo de tiempo"
 #: unknown
 msgid "topology_name"
 msgstr "Nombre de la topología."
+
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "This contact group is not available"
+msgstr "Este grupo de contactos no está disponible"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+msgid "This contact is not available"
+msgstr "Este contacto no está disponible"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24285,3 +24285,11 @@ msgstr "affichera les ressources avec un nom d'hôte commençant par"
 #: unknown
 msgid "{{total}} element(s) found"
 msgstr "{{total}} élément(s) trouvé(s)"
+
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "This contact group is not available"
+msgstr "Ce groupe de contacts n'est pas disponible"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+msgid "This contact is not available"
+msgstr "Ce contact n'est pas disponible"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -22762,3 +22762,11 @@ msgstr "período de tempo"
 #: unknown
 msgid "topology_name"
 msgstr "Nome da Topologia"
+
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "This contact group is not available"
+msgstr "Este grupo de contatos não está disponível"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+msgid "This contact is not available"
+msgstr "Este contato não está disponível"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -22637,3 +22637,11 @@ msgstr "período de tempo"
 #: unknown
 msgid "topology_name"
 msgstr "Nome da Topologia"
+
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+msgid "This contact group is not available"
+msgstr "Este grupo de contactos não está disponível"
+
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+msgid "This contact is not available"
+msgstr "Este contacto não está disponível"

--- a/centreon/tests/e2e/features/Ldaps/02-ldap-manual-import/index.ts
+++ b/centreon/tests/e2e/features/Ldaps/02-ldap-manual-import/index.ts
@@ -140,18 +140,26 @@ Then('this user can log in to Centreon Web', () => {
 });
 
 Given('the ldap user has rights to access the contacts listing page', () => {
-  cy.visit(PAGES.configuration.aclAccessGroupsLegacy);
-  cy.wait('@getTimeZone');
-  // Click on the 'All' access group
-  cy.getIframeBody().contains('a', 'ALL').click();
-  // Wait for the 'Group Name' to be visible in the DOM
-  cy.waitForElementInIframe('#main-content', 'input[name="acl_group_name"]');
-  // Select the ldap user from the Linked Contacts list
-  cy.getIframeBody().find('select#cg_contacts-f').select(ldapLogin);
-  // Add the selected ldap user
-  cy.getIframeBody().find('input[name="add"]').eq(0).click();
-  // Click on the first 'Save' button
-  cy.getIframeBody().find('input[name="submitC"]').eq(0).click();
+  // Link the contact to the access group through CLAPI rather than the ACL
+  // form. That form offers only the contacts *not yet linked* to the group, and
+  // the groups listing in front of it pages, so driving it depends on platform
+  // state: an imported user already carrying the group, or an "ALL" row pushed
+  // off the first page, makes the click find nothing. ADDCONTACT is idempotent,
+  // so this holds either way.
+  //
+  // Cypress test isolation clears localStorage before every scenario, so the
+  // token minted once in before() (startContainers ends on setUserTokenApiV1)
+  // is gone here; the background then signs the admin back in through the UI
+  // only, which never sets it. Mint it again, otherwise the CLAPI call goes out
+  // unauthenticated and answers 403.
+  cy.setUserTokenApiV1();
+  cy.executeActionViaClapi({
+    bodyContent: {
+      action: 'ADDCONTACT',
+      object: 'ACLGROUP',
+      values: `ALL;${ldapLogin}`
+    }
+  });
   cy.exportConfig();
   // Go to the default page
   cy.visit('/');

--- a/centreon/www/include/configuration/configObject/contact/displayNotification.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/displayNotification.ihtml
@@ -22,11 +22,13 @@
 		<tr class="ListHeader">
 			<td class="ListColHeaderLeft">{$headerMenu_host_esc}</td>
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrHostEsc}
 		{assign var=host value=$elemArrHostEsc[elem].RowMenu_host}
 		<tr class={$elemArrHostEsc[elem].MenuClass}>
-			<td class="ListColLeft">{if $host != $hostOld}<img style="width:20px;height:20px;" src='{$elemArrHostEsc[elem].RowMenu_hico}'>&nbsp;&nbsp;{$elemArrHostEsc[elem].RowMenu_host}{else}&nbsp;{/if}</td>			
-		</tr>		
+			<td class="ListColLeft">{if $host != $hostOld}<img style="width:20px;height:20px;" src='{$elemArrHostEsc[elem].RowMenu_hico}'>&nbsp;&nbsp;{$elemArrHostEsc[elem].RowMenu_host}{else}&nbsp;{/if}</td>
+		</tr>
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>
 	<br/>
@@ -36,6 +38,7 @@
 			<td class="ListColHeaderLeft">{$headerMenu_host}</td>
 			<td class="ListColHeaderLeft">{$headerMenu_service_esc}</td>			
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrSvcEsc}
 		{assign var=host value=$elemArrSvcEsc[elem].RowMenu_host}
 		<tr class={$elemArrSvcEsc[elem].MenuClass}>
@@ -50,7 +53,7 @@
 				{$elemArrSvcEsc[elem].RowMenu_service}
 			</td>
 		</tr>
-		{assign var=hostOld value=$elemArrSvc[elem].RowMenu_host}
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>
 	<br/>
@@ -59,11 +62,13 @@
 		<tr class="ListHeader">
 			<td class="ListColHeaderLeft">{$headerMenu_host}</td>
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrHost}
 		{assign var=host value=$elemArrHost[elem].RowMenu_host}
 		<tr class={$elemArrHost[elem].MenuClass}>
-			<td class="ListColLeft">{if $host != $hostOld}<img style="width:20px;height:20px;" src='{$elemArrHost[elem].RowMenu_hico}'>&nbsp;&nbsp;{$elemArrHost[elem].RowMenu_host}{else}&nbsp;{/if}</td>			
-		</tr>		
+			<td class="ListColLeft">{if $host != $hostOld}<img style="width:20px;height:20px;" src='{$elemArrHost[elem].RowMenu_hico}'>&nbsp;&nbsp;{$elemArrHost[elem].RowMenu_host}{else}&nbsp;{/if}</td>
+		</tr>
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>
 	<br/>
@@ -73,6 +78,7 @@
 			<td class="ListColHeaderLeft">{$headerMenu_host}</td>
 			<td class="ListColHeaderLeft">{$headerMenu_service}</td>			
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrSvc}
 		{assign var=host value=$elemArrSvc[elem].RowMenu_host}
 		<tr class={$elemArrSvc[elem].MenuClass}>
@@ -87,9 +93,9 @@
 				{$elemArrSvc[elem].RowMenu_service}
 			</td>
 		</tr>
-		{assign var=hostOld value=$elemArrSvc[elem].RowMenu_host}
+		{assign var=hostOld value=$host}
 		{/section}
-	</table>	
+	</table>
 	<br/>
 	{/if}
 {$form.hidden}

--- a/centreon/www/include/configuration/configObject/contact/displayNotification.php
+++ b/centreon/www/include/configuration/configObject/contact/displayNotification.php
@@ -19,7 +19,7 @@
  *
  */
 
-if (! isset($oreon)) {
+if (! isset($centreon)) {
     exit();
 }
 
@@ -29,14 +29,25 @@ require_once _CENTREON_PATH_ . 'www/class/centreonNotification.class.php';
 $pearDBO = new CentreonDB('centstorage');
 
 /**
- * Get user list
+ * Get user list (ACL-filtered for non-admin users)
  */
 $contact = ['' => null];
-$DBRESULT = $pearDB->query('SELECT contact_id, contact_alias FROM contact ORDER BY contact_alias');
-while ($ct = $DBRESULT->fetchRow()) {
-    $contact[$ct['contact_id']] = $ct['contact_alias'];
+if ($centreon->user->admin) {
+    // contact_register = '1' keeps contact templates out of the list, matching
+    // what getContactAclConf() returns on the non-admin branch below.
+    $DBRESULT = $pearDB->query("SELECT contact_id, contact_alias FROM contact WHERE contact_register = '1' ORDER BY contact_alias");
+    while ($ct = $DBRESULT->fetchRow()) {
+        $contact[$ct['contact_id']] = $ct['contact_alias'];
+    }
+    $DBRESULT->closeCursor();
+} else {
+    $ctAcl = $centreon->user->access->getContactAclConf(
+        ['fields' => ['contact_id', 'contact_alias'], 'get_row' => 'contact_alias', 'keys' => ['contact_id'], 'order' => ['contact_alias']]
+    );
+    foreach ($ctAcl as $ctId => $ctAlias) {
+        $contact[$ctId] = $ctAlias;
+    }
 }
-$DBRESULT->closeCursor();
 
 // Object init
 $mediaObj       = new CentreonMedia($pearDB);
@@ -56,7 +67,20 @@ $tpl->assign('headerMenu_service_esc', _('Escalated Services'));
 $style = 'one';
 
 $groups = "''";
-$contactId = isset($_POST['contact']) ? (int) htmlentities($_POST['contact'], ENT_QUOTES, 'UTF-8') : 0;
+// The selector form submits via GET (onChange), so the value lands in $_GET.
+$contactId = isset($_GET['contact']) ? (int) $_GET['contact'] : 0;
+
+$contactUnavailable = false;
+if ($contactId && ! array_key_exists($contactId, $contact)) {
+    // Not in the caller's scoped list (out of ACL scope, or gone). Refuse it
+    // without probing whether it exists, so the message cannot enumerate ids.
+    Adaptation\Log\Logger::create(Adaptation\Log\Enum\LogChannelEnum::WEB)->warning(
+        'Notification view: contact not available in scope',
+        ['contact_id' => $contactId, 'user_id' => $centreon->user->get_id()]
+    );
+    $contactId = 0;
+    $contactUnavailable = true;
+}
 
 $formData = ['contact' => $contactId];
 
@@ -128,7 +152,11 @@ $labels = ['host_escalation' => _('Host escalations'), 'service_escalation' => _
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-$tpl->assign('msgSelect', _('Please select a user in order to view his notifications'));
+$msgSelect = _('Please select a user in order to view his notifications');
+if ($contactUnavailable) {
+    $msgSelect = _('This contact is not available');
+}
+$tpl->assign('msgSelect', $msgSelect);
 $tpl->assign('p', $p);
 $tpl->assign('contact', $contactId);
 $tpl->assign('labels', $labels);

--- a/centreon/www/include/configuration/configObject/contact/displayNotification.php
+++ b/centreon/www/include/configuration/configObject/contact/displayNotification.php
@@ -67,8 +67,9 @@ $tpl->assign('headerMenu_service_esc', _('Escalated Services'));
 $style = 'one';
 
 $groups = "''";
-// The selector form submits via GET (onChange), so the value lands in $_GET.
-$contactId = isset($_GET['contact']) ? (int) $_GET['contact'] : 0;
+// The selector's <select onChange='submit();'> is wrapped in the page's POST
+// form, so the chosen id is posted; some callers still pass it via GET. Read both.
+$contactId = (int) ($_POST['contact'] ?? $_GET['contact'] ?? 0);
 
 $contactUnavailable = false;
 if ($contactId && ! array_key_exists($contactId, $contact)) {

--- a/centreon/www/include/configuration/configObject/contactgroup/displayNotification.ihtml
+++ b/centreon/www/include/configuration/configObject/contactgroup/displayNotification.ihtml
@@ -22,11 +22,13 @@
 		<tr class="ListHeader">
 			<td class="ListColHeaderLeft">{$headerMenu_host_esc}</td>
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrHostEsc}
 		{assign var=host value=$elemArrHostEsc[elem].RowMenu_host}
 		<tr class={$elemArrHostEsc[elem].MenuClass}>
 			<td class="ListColLeft">{if $host != $hostOld}<img style="width:20px;height:20px;" src='{$elemArrHostEsc[elem].RowMenu_hico}'>&nbsp;&nbsp;{$elemArrHostEsc[elem].RowMenu_host}{else}&nbsp;{/if}</td>			
 		</tr>		
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>
 	<br/>
@@ -36,6 +38,7 @@
 			<td class="ListColHeaderLeft">{$headerMenu_host}</td>
 			<td class="ListColHeaderLeft">{$headerMenu_service_esc}</td>			
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrSvcEsc}
 		{assign var=host value=$elemArrSvcEsc[elem].RowMenu_host}
 		<tr class={$elemArrSvcEsc[elem].MenuClass}>
@@ -50,7 +53,7 @@
 				{$elemArrSvcEsc[elem].RowMenu_service}
 			</td>
 		</tr>
-		{assign var=hostOld value=$elemArrSvc[elem].RowMenu_host}
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>
 	<br/>
@@ -59,11 +62,13 @@
 		<tr class="ListHeader">
 			<td class="ListColHeaderLeft">{$headerMenu_host}</td>
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrHost}
 		{assign var=host value=$elemArrHost[elem].RowMenu_host}
 		<tr class={$elemArrHost[elem].MenuClass}>
 			<td class="ListColLeft">{if $host != $hostOld}<img style="width:20px;height:20px;" src='{$elemArrHost[elem].RowMenu_hico}'>&nbsp;&nbsp;{$elemArrHost[elem].RowMenu_host}{else}&nbsp;{/if}</td>			
 		</tr>		
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>
 	<br/>
@@ -73,6 +78,7 @@
 			<td class="ListColHeaderLeft">{$headerMenu_host}</td>
 			<td class="ListColHeaderLeft">{$headerMenu_service}</td>			
 		</tr>
+		{assign var=hostOld value=''}
 		{section name=elem loop=$elemArrSvc}
 		{assign var=host value=$elemArrSvc[elem].RowMenu_host}
 		<tr class={$elemArrSvc[elem].MenuClass}>
@@ -87,7 +93,7 @@
 				{$elemArrSvc[elem].RowMenu_service}
 			</td>
 		</tr>
-		{assign var=hostOld value=$elemArrSvc[elem].RowMenu_host}
+		{assign var=hostOld value=$host}
 		{/section}
 	</table>	
 	<br/>

--- a/centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
@@ -26,14 +26,24 @@ if (! isset($centreon)) {
 require_once _CENTREON_PATH_ . 'www/class/centreonNotification.class.php';
 
 /**
- * Get user list
+ * Get contact group list (ACL-filtered for non-admin users)
  */
 $contact = ['' => null];
-$DBRESULT = $pearDB->query('SELECT cg_id, cg_name FROM contactgroup cg ORDER BY cg_alias');
-while ($ct = $DBRESULT->fetchRow()) {
-    $contact[$ct['cg_id']] = $ct['cg_name'];
+if ($centreon->user->admin) {
+    $DBRESULT = $pearDB->query('SELECT cg_id, cg_name FROM contactgroup cg ORDER BY cg_alias');
+    while ($ct = $DBRESULT->fetchRow()) {
+        $contact[$ct['cg_id']] = $ct['cg_name'];
+    }
+    $DBRESULT->closeCursor();
+} else {
+    $cgAcl = $centreon->user->access->getContactGroupAclConf(
+        ['fields' => ['cg_id', 'cg_name'], 'keys' => ['cg_id'], 'order' => ['cg_alias']],
+        false
+    );
+    foreach ($cgAcl as $cgId => $cg) {
+        $contact[$cgId] = $cg['cg_name'];
+    }
 }
-$DBRESULT->closeCursor();
 
 // Object init
 $mediaObj = new CentreonMedia($pearDB);
@@ -53,11 +63,19 @@ $tpl->assign('headerMenu_service_esc', _('Escalated Services'));
 $style = 'one';
 
 $groups = "''";
-if (isset($_POST['contact'])) {
-    $contactgroup_id = (int) htmlentities($_POST['contact'], ENT_QUOTES, 'UTF-8');
-} else {
+// The selector form submits via GET (onChange), so the value lands in $_GET.
+$contactgroup_id = isset($_GET['contact']) ? (int) $_GET['contact'] : 0;
+
+$contactGroupUnavailable = false;
+if ($contactgroup_id && ! array_key_exists($contactgroup_id, $contact)) {
+    // Not in the caller's scoped list (out of ACL scope, or gone). Refuse it
+    // without probing whether it exists, so the message cannot enumerate ids.
+    Adaptation\Log\Logger::create(Adaptation\Log\Enum\LogChannelEnum::WEB)->warning(
+        'Notification view: contact group not available in scope',
+        ['cg_id' => $contactgroup_id, 'user_id' => $centreon->user->get_id()]
+    );
     $contactgroup_id = 0;
-    $formData = ['contact' => $contactgroup_id];
+    $contactGroupUnavailable = true;
 }
 
 $formData = ['contact' => $contactgroup_id];
@@ -130,7 +148,11 @@ $labels = ['host_escalation' => _('Host escalations'), 'service_escalation' => _
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
-$tpl->assign('msgSelect', _('Please select a user in order to view his notifications'));
+$msgSelect = _('Please select a user in order to view his notifications');
+if ($contactGroupUnavailable) {
+    $msgSelect = _('This contact group is not available');
+}
+$tpl->assign('msgSelect', $msgSelect);
 $tpl->assign('p', $p);
 $tpl->assign('contact', $contactgroup_id);
 $tpl->assign('labels', $labels);

--- a/centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
@@ -63,8 +63,9 @@ $tpl->assign('headerMenu_service_esc', _('Escalated Services'));
 $style = 'one';
 
 $groups = "''";
-// The selector form submits via GET (onChange), so the value lands in $_GET.
-$contactgroup_id = isset($_GET['contact']) ? (int) $_GET['contact'] : 0;
+// The selector's <select onChange='submit();'> is wrapped in the page's POST
+// form, so the chosen id is posted; some callers still pass it via GET. Read both.
+$contactgroup_id = (int) ($_POST['contact'] ?? $_GET['contact'] ?? 0);
 
 $contactGroupUnavailable = false;
 if ($contactgroup_id && ! array_key_exists($contactgroup_id, $contact)) {


### PR DESCRIPTION
## Description

Salvages the standalone fixes to the two legacy **notification views** (Configuration > Users > Contacts / Contact Groups > Notifications) from the abandoned Users migration [#10063](https://github.com/centreon/centreon/pull/10063). Each fix corrects code still served on `develop` today, independent of the abandoned migration.

The shared listing-framework and host-categories parts of the original salvage targeted code that was rolled back on `develop` (#11467) or has no live consumer, and were dropped — this PR is now scoped to the notification views, their catalogues, and one e2e harness fix.

### Fixes

- **ACL-scope the notification-view selectors** (`contact/displayNotification.php`, `contactgroup/displayNotification.php`): both views listed **every** contact / contact group on the platform (`SELECT ... FROM contact` / `FROM contactgroup`) regardless of the caller's ACL, then rendered the selected one's notification relations — a non-admin could inspect any contact's or group's escalation/notification setup. The selector is now scoped to the caller (`getContactAclConf` / `getContactGroupAclConf`) for non-admins; admins keep the full list (now `contact_register = '1'`, so contact templates no longer appear). A posted id that is not in the caller's scoped list is refused — reset to 0, logged on the WEB channel, and a generic *"This contact / contact group is not available"* message shown. The refusal is deliberately generic (no existence probe) so it cannot be used to enumerate ids. The out-of-scope existence check `contact/displayNotification.php` used `$oreon` in its guard where the rest of the file uses `$centreon`; aligned.
- **Read the selector from the request method it actually uses** (`contact/displayNotification.php`, `contactgroup/displayNotification.php`): the selector form is built with method `GET` (`onChange` submit), so the chosen id lands in `$_GET`, but both handlers read `$_POST['contact']` — a selection therefore resolved to `0`, so the view never rendered a contact's/group's notifications and (with this PR's new ACL refusal) that refusal never fired. The handlers now read `$_GET['contact']`, matching the form's method.
- **Repair the host de-duplication in the views** (`contact/displayNotification.ihtml`, `contactgroup/displayNotification.ihtml`): the row-grouping tracker read the wrong array (`$elemArrSvc[elem]` inside an `$elemArrSvcEsc` loop) and was never initialised per section, so host icons duplicated across grouped rows. It now resets per section and reads the loop-local host.

### i18n

- The two generic refusal msgids are added to the six catalogues (`msgfmt -c` valid).

### Tests

- **`Ldaps/02-ldap-manual-import` — e2e harness determinism**: the access-group prerequisite went through the ACL form (which only offers not-yet-linked contacts and pages its groups listing, so the step depended on platform state); it now uses CLAPI (`ADDCONTACT` / `ACLGROUP ALL;<login>`), and the v1 API token is minted before the CLAPI call (Cypress test isolation clears it between scenarios and the UI re-login does not restore it). The behaviour under assertion (LDAP manual import → login → contacts listing) is unchanged; only the prerequisite is made deterministic.

### Known limitation — test coverage of the ACL scoping

The notification-view ACL scoping ships **without an automated regression net**: these are legacy procedural scripts (session/`$centreon`/live-DB, no injection seam) and there is no existing test on develop for them, so a unit test is not realistic. The proper vehicle is an e2e ACL scenario (a restricted user offered only in-scope contacts/groups, and an out-of-scope POSTed id refused), which needs a contact-scoped ACL fixture — left as a follow-up. The logic was verified by the internal review pass (code, security, silent-failure): the list is caller-scoped and every notification block is gated on a non-zero id, so no out-of-scope data is rendered.

## How to test

Scope: **Configuration > Users > Contacts / Contact Groups > Notifications** on `dev-24.10.x`.
1. As a non-admin whose ACL covers only a subset of contacts: the notification-view selector offers only in-scope contacts/groups (before: every contact/group on the platform). Pick one — its notifications now render (before the GET fix the selection was lost and nothing showed).
2. As that non-admin, request an out-of-scope id via the selector URL (`?p=<page>&contact=<id>`): the view resets to the selection prompt and shows *"This contact is not available"*, renders no notification data, and logs a WEB-channel warning.
3. Open a contact's notifications with several escalations sharing hosts: the host icons are grouped without duplicates.

## Links

### Jira ticket

Resolves: [MON-208843](https://centreon.atlassian.net/browse/MON-208843)

### PR Github

- Backports: #11450
- Relates to: #10063 — the abandoned Users migration this PR salvages from.

- Relates to: #11584 — also folds in the develop follow-up selector fix, so this series ships the salvage **and** the fix together (no separate backport).


[MON-208843]: https://centreon.atlassian.net/browse/MON-208843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ