### PR TITLE
fix(poller): create pollers in pullwss mode and announce them to Gorgone

### DIFF
--- a/centreon/config.new/services/test/monitoring_configuration.php
+++ b/centreon/config.new/services/test/monitoring_configuration.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+use App\MonitoringConfiguration\Domain\Service\GorgoneNodesSynchronizer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Tests\App\MonitoringConfiguration\Infrastructure\Double\FakeGorgoneNodesSynchronizer;
+
+/*
+ * Test-env service bindings for the App\MonitoringConfiguration module.
+ * New App\MonitoringConfiguration test doubles belong here.
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    // Without this double, every poller creation in the API test suite boots the legacy
+    // kernel and opens a real connection to the Gorgone API. The failure is swallowed by
+    // design, so the suite stays green while depending on an out-of-process host.
+    $services->set(GorgoneNodesSynchronizer::class, FakeGorgoneNodesSynchronizer::class)
+        ->public();
+};

--- a/centreon/deptrac_bc.yaml
+++ b/centreon/deptrac_bc.yaml
@@ -76,3 +76,7 @@ parameters:
             - Core\Common\Application\VaultEligibilityService
         App\Security\Infrastructure\Security\Legacy\LegacyTokenApiAuthenticatorWrapper:
             - Security\TokenAPIAuthenticator
+        App\MonitoringConfiguration\Infrastructure\Legacy\LegacyGorgoneNodesSynchronizer:
+            - Centreon\Domain\Gorgone\Command\NodesSync
+            - Centreon\Domain\Gorgone\GorgoneException
+            - Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface

--- a/centreon/deptrac_hexa.yaml
+++ b/centreon/deptrac_hexa.yaml
@@ -72,3 +72,7 @@ parameters:
             - Core\Common\Application\VaultEligibilityService
         App\Security\Infrastructure\Security\Legacy\LegacyTokenApiAuthenticatorWrapper:
             - Security\TokenAPIAuthenticator
+        App\MonitoringConfiguration\Infrastructure\Legacy\LegacyGorgoneNodesSynchronizer:
+            - Centreon\Domain\Gorgone\Command\NodesSync
+            - Centreon\Domain\Gorgone\GorgoneException
+            - Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface

--- a/centreon/src/App/MonitoringConfiguration/Domain/Exception/GorgoneNodesSyncFailedException.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Exception/GorgoneNodesSyncFailedException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Exception;
+
+/**
+ * Gorgone did not accept a command. Distinct from a wiring or configuration error, which
+ * must keep propagating: only this one is safe for a caller to absorb.
+ */
+final class GorgoneNodesSyncFailedException extends \RuntimeException
+{
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Service/GorgoneNodesSynchronizer.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Service/GorgoneNodesSynchronizer.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Service;
+
+use App\MonitoringConfiguration\Domain\Exception\GorgoneNodesSyncFailedException;
+
+interface GorgoneNodesSynchronizer
+{
+    /**
+     * Ask Gorgone to re-read its node list from the database.
+     *
+     * Not scoped to a single poller: Gorgone reloads every node at once. Callers must invoke
+     * it once the poller rows are committed — Gorgone reads the database on its own
+     * connection and would otherwise miss the new node.
+     *
+     * Returns once Gorgone has accepted the request, not once the reload has happened: the
+     * reload is asynchronous and its outcome is not observable from here.
+     *
+     * @throws GorgoneNodesSyncFailedException when Gorgone refuses the command or is unreachable
+     */
+    public function synchronize(): void;
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessor.php
@@ -30,11 +30,14 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
+use App\MonitoringConfiguration\Domain\Exception\GorgoneNodesSyncFailedException;
 use App\MonitoringConfiguration\Domain\Exception\PollerAlreadyExistsException;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
+use App\MonitoringConfiguration\Domain\Service\GorgoneNodesSynchronizer;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Dto\CreatePollerInput;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\PollerResource;
 use App\MonitoringConfiguration\Infrastructure\CentralUrlFactory;
@@ -42,7 +45,9 @@ use App\MonitoringConfiguration\Infrastructure\PollerInstallationCommandFactory;
 use App\Security\Infrastructure\Security\CredentialUser;
 use App\Shared\Application\Command\CommandBus;
 use App\Shared\Domain\Repository\EngineSecretsRepository;
+use App\Shared\Infrastructure\Logging\ExceptionFormatter;
 use App\Shared\Infrastructure\TransformerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
@@ -64,6 +69,9 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         private PollerRepository $pollerRepository,
         private PollerTokenRepository $pollerTokenRepository,
         private EngineSecretsRepository $engineSecretsRepository,
+        private GorgoneNodesSynchronizer $gorgoneNodesSynchronizer,
+        #[Autowire(service: 'monolog.logger.poller-install')]
+        private LoggerInterface $logger,
         private CentralUrlFactory $centralUrlFactory,
         #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
         private bool $isCloudPlatform = false,
@@ -95,9 +103,10 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
             address: new PollerAddress($data->address),
             creatorId: $credentialUser->credential->userId->value,
             centralAddress: $centralAddress,
-            gorgoneCommunicationType: $this->isCloudPlatform
-                ? GorgoneCommunicationTypeEnum::PullWss
-                : GorgoneCommunicationTypeEnum::ZMQ,
+            // Both install.sh paths (vm and docker) always provision the gorgone pullwss
+            // module, on-premise as well as on Cloud, so the persisted communication type
+            // must match. ZMQ stays available through the legacy poller wizard.
+            gorgoneCommunicationType: GorgoneCommunicationTypeEnum::PullWss,
         );
 
         $token = $this->pollerTokenRepository->getValidPollerTokenByName($data->pollerTokenName);
@@ -106,6 +115,10 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
 
         $model = $this->commandBus->execute($command);
         Assert::isInstanceOf($model, Poller::class);
+
+        // Not from a PollerCreated handler: those run inside the create-poller transaction,
+        // and Gorgone reads the database on its own connection.
+        $this->synchronizeGorgoneNodes($model->id(), $model->name);
 
         // Use the normalized value, not the raw input: the stored poller and the
         // returned command must match what GET /installation-command/{id} generates.
@@ -122,5 +135,31 @@ final readonly class CreatePollerProcessor implements ProcessorInterface
         $resource->installationCommand = $factory->generate();
 
         return $resource;
+    }
+
+    /**
+     * Fire-and-forget: the poller is already committed, so a Gorgone outage must not fail the
+     * creation. There is no automatic retry — the only re-sync paths are manual operator
+     * actions — so the record has to carry the consequence and the remedy.
+     *
+     * Logged at error level on the dedicated poller-install channel, where an operator
+     * troubleshooting an unmonitored poller looks — not buried in web.log.
+     * Only GorgoneNodesSyncFailedException is absorbed; a wiring error still propagates.
+     */
+    private function synchronizeGorgoneNodes(PollerId $pollerId, PollerName $pollerName): void
+    {
+        try {
+            $this->gorgoneNodesSynchronizer->synchronize();
+        } catch (GorgoneNodesSyncFailedException $exception) {
+            $this->logger->error(
+                'Poller created but not announced to the Central: re-save it from the legacy poller form to retry',
+                [
+                    'poller_id' => $pollerId->value,
+                    'poller_name' => $pollerName->value,
+                    'source' => 'poller_api',
+                    'exception' => ExceptionFormatter::format($exception),
+                ]
+            );
+        }
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Legacy/LegacyGorgoneNodesSynchronizer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Legacy/LegacyGorgoneNodesSynchronizer.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Legacy;
+
+use App\MonitoringConfiguration\Domain\Exception\GorgoneNodesSyncFailedException;
+use App\MonitoringConfiguration\Domain\Service\GorgoneNodesSynchronizer;
+use App\Shared\Infrastructure\Legacy\LegacyContainer;
+use Centreon\Domain\Gorgone\Command\NodesSync;
+use Centreon\Domain\Gorgone\GorgoneException;
+use Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * Resolves the legacy Gorgone client per call, never in the constructor: LegacyContainer boots
+ * the legacy kernel on first use and is only spared by its #[Lazy] proxy.
+ */
+final readonly class LegacyGorgoneNodesSynchronizer implements GorgoneNodesSynchronizer
+{
+    public function __construct(
+        private LegacyContainer $legacyContainer,
+    ) {
+    }
+
+    public function synchronize(): void
+    {
+        // Resolution and assertion stay outside the try: a missing or mistyped legacy service
+        // is a wiring error, and callers absorbing GorgoneNodesSyncFailedException must not
+        // absorb that too.
+        $gorgoneService = $this->legacyContainer->get(GorgoneServiceInterface::class);
+        Assert::isInstanceOf($gorgoneService, GorgoneServiceInterface::class);
+
+        try {
+            $gorgoneService->send(new NodesSync());
+        } catch (GorgoneException $exception) {
+            throw new GorgoneNodesSyncFailedException(
+                'Gorgone did not accept the nodes sync command',
+                previous: $exception,
+            );
+        }
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorGorgoneSyncTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorGorgoneSyncTest.php
@@ -24,13 +24,11 @@ declare(strict_types=1);
 namespace Tests\App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
 
 use ApiPlatform\Metadata\Post;
-use App\MonitoringConfiguration\Application\Command\CreatePollerCommand;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\BrokerInformation;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\CentralAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\ConnectorConfiguration;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\EngineInformation;
-use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneConfiguration;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
@@ -40,6 +38,8 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\TrapConfiguration;
+use App\MonitoringConfiguration\Domain\Exception\GorgoneNodesSyncFailedException;
+use App\MonitoringConfiguration\Domain\Exception\PollerAlreadyExistsException;
 use App\MonitoringConfiguration\Domain\Model\PollerToken;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Domain\Repository\PollerTokenRepository;
@@ -55,88 +55,117 @@ use App\Shared\Application\Command\CommandBus;
 use App\Shared\Domain\Collection;
 use App\Shared\Domain\Repository\EngineSecretsRepository;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Tests\App\MonitoringConfiguration\Infrastructure\Double\FakeGorgoneNodesSynchronizer;
 
-final class CreatePollerProcessorCommunicationTypeTest extends TestCase
+final class CreatePollerProcessorGorgoneSyncTest extends TestCase
 {
-    public function testCloudPlatformUsesPullWss(): void
+    private FakeGorgoneNodesSynchronizer $synchronizer;
+
+    /** @var int calls counted while the create-poller command was being handled */
+    private int $synchronizeCallsDuringCommand = 0;
+
+    protected function setUp(): void
     {
-        $capturedCommand = null;
-        $processor = $this->buildProcessor(isCloudPlatform: true, capturedCommand: $capturedCommand);
-
-        $processor->process(
-            $this->buildInput(),
-            new Post(),
-        );
-
-        self::assertInstanceOf(CreatePollerCommand::class, $capturedCommand);
-        self::assertSame(GorgoneCommunicationTypeEnum::PullWss, $capturedCommand->gorgoneCommunicationType);
+        $this->synchronizer = new FakeGorgoneNodesSynchronizer();
     }
 
-    public function testOnPremPlatformAlsoUsesPullWss(): void
+    public function testItSynchronizesGorgoneNodesOncePerCreation(): void
     {
-        $capturedCommand = null;
-        $processor = $this->buildProcessor(isCloudPlatform: false, capturedCommand: $capturedCommand);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
 
-        $processor->process(
-            $this->buildInput(),
-            new Post(),
-        );
+        $this->buildProcessor($logger)->process($this->buildInput(), new Post());
 
-        self::assertInstanceOf(CreatePollerCommand::class, $capturedCommand);
-        self::assertSame(GorgoneCommunicationTypeEnum::PullWss, $capturedCommand->gorgoneCommunicationType);
-    }
-
-    public function testCentralAddressIsPassedToCommand(): void
-    {
-        $capturedCommand = null;
-        $processor = $this->buildProcessor(isCloudPlatform: false, capturedCommand: $capturedCommand);
-
-        $processor->process(
-            $this->buildInput(),
-            new Post(),
-        );
-
-        self::assertInstanceOf(CreatePollerCommand::class, $capturedCommand);
-        self::assertSame('192.168.1.254', $capturedCommand->centralAddress->value);
+        self::assertSame(1, $this->synchronizer->synchronizeCalls);
     }
 
     /**
-     * The central URL is resolved before the poller is persisted, so a platform base path that
-     * cannot go into the command fails the request instead of leaving a poller behind it.
+     * Gorgone reads the poller list on its own database connection: a sync sent while the
+     * create-poller transaction is still open would find nothing to register.
      */
-    public function testItCreatesNoPollerWhenThePlatformBaseUriIsUnusable(): void
+    public function testItSynchronizesAfterTheCommandBusReturns(): void
     {
-        $capturedCommand = null;
-        $requestStack = new RequestStack();
-        $requestStack->push(
-            Request::create('https://central.example.com/centreon;id/api/latest/configuration/pollers')
+        $this->buildProcessor($this->createMock(LoggerInterface::class))
+            ->process($this->buildInput(), new Post());
+
+        self::assertSame(0, $this->synchronizeCallsDuringCommand);
+        self::assertSame(1, $this->synchronizer->synchronizeCalls);
+    }
+
+    public function testItCreatesThePollerEvenWhenGorgoneIsUnreachable(): void
+    {
+        $this->synchronizer->throwable = new GorgoneNodesSyncFailedException(
+            'Gorgone did not accept the nodes sync command',
+            previous: new \RuntimeException('Error when connecting to the Gorgone server')
         );
-        $processor = $this->buildProcessor(
-            isCloudPlatform: false,
-            capturedCommand: $capturedCommand,
-            requestStack: $requestStack,
-        );
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                // Both load-bearing fragments: the problem and the operator remedy. The
+                // connective text may be reworded without breaking the test.
+                self::logicalAnd(
+                    self::stringContains('not announced to the Central'),
+                    self::stringContains('re-save it from the legacy poller form')
+                ),
+                self::callback(static function (array $context): bool {
+                    self::assertSame(42, $context['poller_id']);
+                    self::assertSame('TestPoller', $context['poller_name']);
+                    self::assertSame('poller_api', $context['source']);
+                    self::assertIsArray($context['exception']);
+
+                    // The operator has nothing but this record: the cause must survive into it.
+                    self::assertStringContainsString(
+                        'Error when connecting to the Gorgone server',
+                        json_encode($context['exception'], JSON_THROW_ON_ERROR)
+                    );
+
+                    return true;
+                })
+            );
+
+        $resource = $this->buildProcessor($logger)->process($this->buildInput(), new Post());
+
+        self::assertSame('TestPoller', $resource->name);
+        self::assertNotEmpty($resource->installationCommand);
+    }
+
+    public function testItPropagatesAWiringErrorInsteadOfSwallowingIt(): void
+    {
+        // A missing legacy service is a deployment bug, not a Gorgone outage: swallowing it
+        // would degrade every creation silently behind a 201.
+        $this->synchronizer->throwable = new \RuntimeException('Service not found');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Service not found');
+
+        $this->buildProcessor($logger)->process($this->buildInput(), new Post());
+    }
+
+    public function testItDoesNotSynchronizeWhenThePollerAlreadyExists(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $processor = $this->buildProcessor($logger, $this->buildPoller());
+
+        $this->expectException(PollerAlreadyExistsException::class);
 
         try {
             $processor->process($this->buildInput(), new Post());
-            self::fail('An unusable platform base path must fail the request');
-        } catch (BadRequestHttpException) {
-            self::assertNull($capturedCommand, 'the poller must not have been created');
+        } finally {
+            self::assertSame(0, $this->synchronizer->synchronizeCalls);
         }
     }
 
-    private function buildProcessor(
-        bool $isCloudPlatform,
-        ?object &$capturedCommand,
-        ?RequestStack $requestStack = null,
-    ): CreatePollerProcessor {
-        $poller = new Poller(
+    private function buildPoller(): Poller
+    {
+        return new Poller(
             id: new PollerId(42),
             name: new PollerName('TestPoller'),
             address: new PollerAddress('192.168.1.1'),
@@ -154,11 +183,16 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             pollerCommands: new Collection([], PollerCommand::class),
             centralAddress: new CentralAddress('192.168.1.254'),
         );
+    }
+
+    private function buildProcessor(LoggerInterface $logger, ?Poller $existingPoller = null): CreatePollerProcessor
+    {
+        $poller = $this->buildPoller();
 
         $commandBus = $this->createMock(CommandBus::class);
         $commandBus->method('execute')
-            ->willReturnCallback(static function (object $command) use (&$capturedCommand, $poller): Poller {
-                $capturedCommand = $command;
+            ->willReturnCallback(function () use ($poller): Poller {
+                $this->synchronizeCallsDuringCommand = $this->synchronizer->synchronizeCalls;
 
                 return $poller;
             });
@@ -186,7 +220,7 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
         $engineSecretsRepository->method('getSalt')->willReturn('salt');
 
         $pollerRepository = $this->createMock(PollerRepository::class);
-        $pollerRepository->method('findOneByName')->willReturn(null);
+        $pollerRepository->method('findOneByName')->willReturn($existingPoller);
 
         return new CreatePollerProcessor(
             commandBus: $commandBus,
@@ -195,10 +229,9 @@ final class CreatePollerProcessorCommunicationTypeTest extends TestCase
             pollerRepository: $pollerRepository,
             pollerTokenRepository: $pollerTokenRepository,
             engineSecretsRepository: $engineSecretsRepository,
-            gorgoneNodesSynchronizer: new FakeGorgoneNodesSynchronizer(),
-            logger: new NullLogger(),
-            centralUrlFactory: new CentralUrlFactory($requestStack ?? new RequestStack(), $isCloudPlatform),
-            isCloudPlatform: $isCloudPlatform,
+            gorgoneNodesSynchronizer: $this->synchronizer,
+            logger: $logger,
+            centralUrlFactory: new CentralUrlFactory(new RequestStack(), false),
         );
     }
 

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
 
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\GorgoneCommunicationTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\PollerResource;
@@ -103,6 +104,11 @@ final class CreatePollerProcessorTest extends ApiTestCase
 
         $poller = $repository->findOneByName(new PollerName($name));
         self::assertNotNull($poller);
+        // Crosses the enum-to-column mapping, which no other test exercises.
+        self::assertSame(
+            GorgoneCommunicationTypeEnum::PullWss,
+            $poller->gorgoneConfiguration->communicationType
+        );
     }
 
     public function testCreatePollerWithAddress(): void

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Double/FakeGorgoneNodesSynchronizer.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Double/FakeGorgoneNodesSynchronizer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\Double;
+
+use App\MonitoringConfiguration\Domain\Service\GorgoneNodesSynchronizer;
+
+/**
+ * Counting {@see GorgoneNodesSynchronizer} test double.
+ */
+final class FakeGorgoneNodesSynchronizer implements GorgoneNodesSynchronizer
+{
+    public int $synchronizeCalls = 0;
+
+    public ?\Throwable $throwable = null;
+
+    public function synchronize(): void
+    {
+        $this->synchronizeCalls++;
+
+        if ($this->throwable instanceof \Throwable) {
+            throw $this->throwable;
+        }
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Legacy/LegacyGorgoneNodesSynchronizerTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Legacy/LegacyGorgoneNodesSynchronizerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\Legacy;
+
+use App\MonitoringConfiguration\Domain\Exception\GorgoneNodesSyncFailedException;
+use App\MonitoringConfiguration\Infrastructure\Legacy\LegacyGorgoneNodesSynchronizer;
+use App\Shared\Infrastructure\Legacy\LegacyContainer;
+use Centreon\Domain\Gorgone\Command\NodesSync;
+use Centreon\Domain\Gorgone\GorgoneException;
+use Centreon\Domain\Gorgone\Interfaces\GorgoneServiceInterface;
+use Centreon\Domain\Gorgone\Interfaces\ResponseInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The caller absorbs a failed sync, so nothing downstream would notice this adapter resolving
+ * the wrong service or sending the wrong command. These tests are the only guard.
+ */
+final class LegacyGorgoneNodesSynchronizerTest extends TestCase
+{
+    public function testItDoesNotTouchTheLegacyContainerBeforeItIsUsed(): void
+    {
+        $container = $this->createMock(LegacyContainer::class);
+        $container->expects(self::never())->method('get');
+
+        new LegacyGorgoneNodesSynchronizer($container);
+    }
+
+    public function testItSendsANodesSyncThroughTheLegacyGorgoneClient(): void
+    {
+        $gorgoneService = $this->createMock(GorgoneServiceInterface::class);
+        $gorgoneService->expects(self::once())
+            ->method('send')
+            ->with(self::isInstanceOf(NodesSync::class))
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->buildSynchronizer($gorgoneService)->synchronize();
+    }
+
+    public function testItWrapsAGorgoneFailureAndKeepsTheCause(): void
+    {
+        $cause = new GorgoneException('Error when connecting to the Gorgone server');
+
+        $gorgoneService = $this->createMock(GorgoneServiceInterface::class);
+        $gorgoneService->method('send')->willThrowException($cause);
+
+        try {
+            $this->buildSynchronizer($gorgoneService)->synchronize();
+            self::fail('Expected ' . GorgoneNodesSyncFailedException::class);
+        } catch (GorgoneNodesSyncFailedException $exception) {
+            self::assertSame($cause, $exception->getPrevious());
+        }
+    }
+
+    public function testItLetsAWiringErrorPropagateUnwrapped(): void
+    {
+        // Absorbed by the caller if it were wrapped, so a mistyped service id would degrade
+        // every poller creation in silence.
+        $container = $this->createMock(LegacyContainer::class);
+        $container->method('get')->willThrowException(new \RuntimeException('Service not found'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Service not found');
+
+        (new LegacyGorgoneNodesSynchronizer($container))->synchronize();
+    }
+
+    private function buildSynchronizer(GorgoneServiceInterface $gorgoneService): LegacyGorgoneNodesSynchronizer
+    {
+        $container = $this->createMock(LegacyContainer::class);
+        $container->expects(self::once())
+            ->method('get')
+            ->with(GorgoneServiceInterface::class)
+            ->willReturn($gorgoneService);
+
+        return new LegacyGorgoneNodesSynchronizer($container);
+    }
+}


### PR DESCRIPTION
## Description

Two related defects on `POST /configuration/pollers`. Together they left a poller created from the React UI unable to reach the Central over its websocket; fixing either one alone is not enough.

### 1. The communication type was ZMQ on premise

`POST /configuration/pollers` persisted `gorgone_communication_type` as ZMQ (`'1'`) on premise, and only Cloud got PullWSS (`'4'`). Both `install.sh` paths — vm and docker — always provision the gorgone `pullwss` module whatever the platform, so an on-premise row described a channel the poller never opens.

- The platform distinction is dropped: every poller created through this endpoint is PullWSS.
- ZMQ stays available through the legacy poller wizard.
- `isCloudPlatform` is still used for the `--cloud` flag of the generated installation command.

`gorgone_port` is deliberately left untouched: the poller-facing websocket is fronted by Apache (`mod_proxy_wstunnel`) on 80/443, so the column plays no part in PullWSS mode.

### 2. Gorgone was never told about the new poller

In PullWSS the Central only accepts a poller's websocket once Gorgone has re-read its node list. The legacy poller form sends `centreon::nodes::sync` on save; the new endpoint never did, so a poller created from the React UI stayed unknown to the Central until someone happened to re-save it from that legacy form. Correcting the communication type alone would have made the database row right and left the poller just as unreachable.

- New port `App\MonitoringConfiguration\Domain\Service\GorgoneNodesSynchronizer`, backed by `LegacyGorgoneNodesSynchronizer`, which sends `NodesSync` through the legacy Gorgone client — the single implementation of the protocol on the platform, and the one the legacy form and the remote wizard already use.
- The legacy service is resolved per call rather than in the constructor: `LegacyContainer` boots the legacy kernel on first use, and is only spared at injection time by its `#[Lazy]` proxy.
- The sync is sent from `CreatePollerProcessor` **after** the command bus has committed, not from a `PollerCreated` event handler: handlers run inside the create-poller transaction, where Gorgone — reading the database on its own connection — would not yet see the new poller.
- A Gorgone outage is logged and swallowed rather than propagated: the creation is already committed and must still return. It is logged at `error` on the dedicated `poller-install` channel, where an operator troubleshooting an unmonitored poller looks — not buried in `web.log`.
- Only `GorgoneNodesSyncFailedException` is absorbed. The adapter wraps the send failure alone and lets container-resolution errors through, so a wiring mistake — a service losing `public: true`, a mistyped id, a fatal booting the legacy kernel — still fails loudly instead of degrading every creation behind a 201.
- There is no automatic retry: the only other `centreon::nodes::sync` senders are the legacy poller form and the remote server wizard, both manual operator actions. The log record therefore names the consequence and the remedy, and carries the poller name and a source discriminator.
- The two `deptrac` entries are exceptions for this single adapter, letting it reach `Centreon\Domain\Gorgone\*`. The `App\*` → legacy barrier is otherwise unchanged.

## How to test

The platform must be **on premise** — check `GET /centreon/api/latest/platform/features`, `is_cloud_platform` must be `false`.

### Communication type

1. Create a poller from the React modal (Pollers top counter → Create new poller), environment **VM**.
2. Check the database:
   ```sql
   SELECT name, gorgone_communication_type FROM nagios_server WHERE name = 'my-poller';
   ```
   `gorgone_communication_type` must be `4`. It was `1` before this change.
3. Repeat with the **Container** environment — same expected value.
4. Cloud is unaffected: it already stored `4`.

### Gorgone nodes sync

5. Watch the Gorgone log on the Central while creating a poller:
   ```bash
   tail -f /var/log/centreon-gorgone/gorgoned.log
   ```
   A `centreon::nodes::sync` event must appear as soon as the modal reports success, with no further action of any kind.
6. Degraded path: stop Gorgone (`systemctl stop gorgoned`), then create a poller. The creation must still succeed — HTTP 201, the row present in `nagios_server`, a usable installation command in the response — and an `error` record `Poller created but not announced to the Central: re-save it from the legacy poller form to retry` must be logged, carrying `poller_id`, `poller_name` and `source`.

### Automated

Unit, no database needed:

```bash
php vendor/bin/pest \
  tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorCommunicationTypeTest.php \
  tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorGorgoneSyncTest.php \
  tests/php/App/MonitoringConfiguration/Infrastructure/Legacy/LegacyGorgoneNodesSynchronizerTest.php
```

Twelve tests. Three assert PullWSS on both platforms and the central address passed to the command. Five cover the processor: the sync is sent once per creation and only after the command bus returns, an unreachable Gorgone does not fail the creation, a wiring error does propagate, and nothing is sent when the creation is rejected. Four cover the adapter, which had no coverage at all — and could not gain any indirectly, since the caller absorbs everything it throws.

Reaching the modal on premise needs the poller submenu entry to be enabled: on develop the entry is behind a hardcoded `false` until #11388.

## Links

### Jira ticket

Resolves: [MON-208846](https://centreon.atlassian.net/browse/MON-208846)

### PR Github

Backports: #11566


[MON-208846]: https://centreon.atlassian.net/browse/MON-208846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ