### PR TITLE
chore(ci): deliver packages to Pulp alongside Artifactory

### DIFF
--- a/.github/actions/package-delivery-pulp/action.yml
+++ b/.github/actions/package-delivery-pulp/action.yml
@@ -1,0 +1,168 @@
+name: "package-delivery"
+description: "Deliver rpm and deb packages to pulp"
+inputs:
+  module_name:
+    description: "The package module name"
+    required: true
+  distrib:
+    description: "The distribution used for packaging"
+    required: true
+  version:
+    description: "Centreon packaged major version (not used by the plugins repository family)"
+    required: false
+    default: ""
+  cache_key:
+    description: "The cached package key"
+    required: true
+  stability:
+    description: "The package stability (stable, testing, unstable)"
+    required: true
+  release_type:
+    description: "Type of release (hotfix, release)"
+    required: false
+    default: ""
+  is_cloud:
+    description: "Release context (cloud or not cloud)"
+    required: true
+  delivery_type:
+    description: "Delivery to feature or standard repository"
+    required: false
+    default: "standard"
+  repository_name:
+    description: "Target repository family: standard, standard-internal, business, business-internal or plugins"
+    required: false
+    default: "standard"
+  verify:
+    description: "Verify the delivered packages afterwards (presence, metadata resolution, fetchability)"
+    required: false
+    default: "true"
+  pulp_url:
+    description: "The pulp server api url"
+    required: true
+  pulp_content_url:
+    description: "The pulp server content url"
+    required: true
+  audience:
+    description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        STABILITY: ${{ inputs.stability }}
+        DELIVERY_TYPE: ${{ inputs.delivery_type }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$DELIVERY_TYPE" != "feature" && "$STABILITY" != "testing" && "$STABILITY" != "unstable" ]]; then
+          echo "::error::stability must be one of: testing, unstable (got '$STABILITY')"
+          exit 1
+        fi
+
+    - name: Compute pulp repository properties
+      id: pulp-properties
+      uses: ./.github/actions/pulp-repository-properties
+      with:
+        module_name: ${{ inputs.module_name }}
+        distrib: ${{ inputs.distrib }}
+        version: ${{ inputs.version }}
+        stability: ${{ inputs.stability }}
+        release_type: ${{ inputs.release_type }}
+        is_cloud: ${{ inputs.is_cloud }}
+        delivery_type: ${{ inputs.delivery_type }}
+        repository_name: ${{ inputs.repository_name }}
+
+    - name: Restore packages from cache
+      if: steps.pulp-properties.outputs.skip_delivery == 'false'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ./*.${{ steps.pulp-properties.outputs.package_extension }}
+        key: ${{ inputs.cache_key }}
+        fail-on-cache-miss: true
+
+    - name: Setup pulp-cli
+      if: steps.pulp-properties.outputs.skip_delivery == 'false'
+      uses: ./.github/actions/setup-pulp-cli
+      with:
+        pulp_url: ${{ inputs.pulp_url }}
+        audience: ${{ inputs.audience }}
+        domain: ${{ steps.pulp-properties.outputs.domain }}
+
+    - name: Deliver RPM packages
+      id: deliver-rpm
+      if: steps.pulp-properties.outputs.package_extension == 'rpm' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.repository_prefix }}
+        STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
+        BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.base_path_prefix }}
+        LEGACY_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.legacy_base_path_prefix }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: ${{ github.action_path }}/deliver-rpm.sh
+
+    - name: Deliver DEB packages
+      id: deliver-deb
+      if: steps.pulp-properties.outputs.package_extension == 'deb' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
+        BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        LEGACY_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_base_path }}
+        LEGACY_STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_stable_base_path }}
+        SUITE: ${{ steps.pulp-properties.outputs.suite }}
+        STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
+        STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}
+        POOL_PATH: ${{ steps.pulp-properties.outputs.pool_path }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: ${{ github.action_path }}/deliver-deb.sh
+
+    - name: Verify RPM delivery
+      if: inputs.verify == 'true' && steps.pulp-properties.outputs.package_extension == 'rpm' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.deliver-rpm.outputs.manifest }}
+        CHECK_MODE: delivery
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-rpm.sh ||
+          echo "::warning::Pulp delivery verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"
+
+    - name: Verify DEB delivery
+      if: inputs.verify == 'true' && steps.pulp-properties.outputs.package_extension == 'deb' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.deliver-deb.outputs.manifest }}
+        CHECK_MODE: delivery
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-deb.sh ||
+          echo "::warning::Pulp delivery verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+# read through the public content-app, no auth/grant needed (see api.sh's content_curl)
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
+
+# fetch the stable suite's Release file and print its advertised architectures
+# (empty output = suite doesn't exist yet, i.e. nothing published to guard against).
+# Fails closed (non-zero) on anything but a clean 404.
+stable_suite_architectures() {
+  local release_file http_code
+  release_file=$(mktemp)
+  http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$release_file" -w '%{http_code}' \
+    "$PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}}/dists/$STABLE_SUITE/Release" 2>/dev/null || echo 000)
+  case "$http_code" in
+    404) rm -f "$release_file"; return 0 ;;
+    200) awk -F': ' '/^Architectures:/ {print $2}' "$release_file"; rm -f "$release_file" ;;
+    *)
+      rm -f "$release_file"
+      echo "::error::Cannot verify the stable suite $STABLE_SUITE (HTTP $http_code) to guard an Architecture: all package; refusing to deliver. Retry once the content endpoint is reachable." >&2
+      return 1
+      ;;
+  esac
+}
+
+# fetch one architecture's Packages index from the stable suite (empty output = not
+# published for that architecture). Fails closed on anything but a clean 404.
+fetch_stable_packages_index() {
+  local a=$1 pkg_file http_code
+  pkg_file=$(mktemp)
+  http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$pkg_file" -w '%{http_code}' \
+    "$PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}}/dists/$STABLE_SUITE/main/binary-$a/Packages" 2>/dev/null || echo 000)
+  case "$http_code" in
+    404) rm -f "$pkg_file"; return 0 ;;
+    200) cat "$pkg_file"; rm -f "$pkg_file" ;;
+    *)
+      rm -f "$pkg_file"
+      echo "::error::Cannot verify the stable suite $STABLE_SUITE binary-$a index; refusing to deliver. Retry once the content endpoint is reachable." >&2
+      return 1
+      ;;
+  esac
+}
+
+# refuse delivering a package version already published in the stable suite:
+# pulp dedupes by (package, version, arch) repository-wide, so re-delivering
+# would silently evict the stable one
+assert_not_in_stable() {
+  local file=$1 name version arch arches a packages
+  name=$(dpkg-deb -f "$file" Package)
+  version=$(dpkg-deb -f "$file" Version)
+  arch=$(dpkg-deb -f "$file" Architecture)
+
+  # the release_components api isn't listable by the OIDC ci-user (403), so
+  # check the served Packages index(es) instead. "Architecture: all" packages are
+  # listed in every binary-<arch>/Packages index the suite advertises, not a
+  # synthetic "binary-all" one that doesn't exist -- resolve the suite's actual
+  # architectures from its Release file and check each of them; other
+  # architectures still only ever need their own single index.
+  if [[ "$arch" == "all" ]]; then
+    arches=$(stable_suite_architectures) || return 1
+    # no Release yet (fresh suite) -> nothing published, nothing to guard against
+    [[ -z "$arches" ]] && return 0
+  else
+    arches="$arch"
+  fi
+
+  for a in $arches; do
+    packages=$(fetch_stable_packages_index "$a") || return 1
+    # empty index -> nothing in stable for this architecture
+    [[ -z "$packages" ]] && continue
+
+    # a package is in stable if a Packages stanza matches both name and version
+    if printf '%s\n' "$packages" | awk -v n="$name" -v v="$version" '
+         BEGIN { RS = ""; FS = "\n" }
+         {
+           has_name = 0; has_version = 0
+           for (i = 1; i <= NF; i++) {
+             if ($i == "Package: " n) has_name = 1
+             if ($i == "Version: " v) has_version = 1
+           }
+           if (has_name && has_version) found = 1
+         }
+         END { exit found ? 0 : 1 }
+       '; then
+      echo "::error::$name $version ($arch) is already published in the stable suite $STABLE_SUITE; refusing to deliver it to $SUITE. Bump the package version for a new build."
+      return 1
+    fi
+  done
+}
+
+FILES=(*.deb)
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "::error::No deb package found to deliver"
+  exit 1
+fi
+
+if ! pulp_resource_exists "repositories/deb/apt" "$REPOSITORY_NAME"; then
+  echo "::error::deb repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
+  exit 1
+fi
+
+if ! pulp_resource_exists "distributions/deb/apt" "$REPOSITORY_NAME"; then
+  echo "::error::deb distribution $REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering. Refusing to create it here to avoid an unguarded distribution."
+  exit 1
+fi
+
+REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
+
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
+# a repository-less deb upload ignores distribution/component, so the FIRST
+# package of each arch goes through the legacy repository path instead to
+# establish the suite's release component; the rest upload unassociated and
+# get associated explicitly, then all of it is added in a single modify.
+lookup_deb_content() {
+  # emit the href of a matching deb content unit, empty if absent. Retried:
+  # the api has been observed answering an empty page for content committed
+  # seconds earlier (stale read)
+  local endpoint=$1 query=$2 out attempt
+  for attempt in 1 2 3 4 5; do
+    out=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+      --data-urlencode "limit=1" \
+      $query \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/$endpoint/" | jq -r '.results[0].pulp_href // empty') || out=""
+    if [[ -n "$out" ]]; then
+      echo "$out"
+      return 0
+    fi
+    sleep $((attempt * 3))
+    refresh_pulp_token
+  done
+}
+
+resolve_task_content() {
+  # wait for a content-create task and emit its created content href; fall
+  # back to a lookup (content already existing on a job re-run)
+  local task_href=$1 endpoint=$2 fallback_query=$3
+  local body state content attempt
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    refresh_pulp_token
+    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
+    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
+    case "$state" in
+      completed)
+        content=$(echo "$body" | jq -r '.created_resources[0] // empty')
+        if [[ -n "$content" ]]; then
+          echo "$content"
+          return 0
+        fi
+        break
+        ;;
+      failed | canceled)
+        break
+        ;;
+      *)
+        sleep 3
+        ;;
+    esac
+  done
+  content=$(lookup_deb_content "$endpoint" "$fallback_query")
+  if [[ -z "$content" ]]; then
+    echo "::error::Cannot resolve the created deb content for task $task_href" >&2
+    return 1
+  fi
+  echo "$content"
+}
+
+# emit the release-component hrefs a package is associated with
+lookup_prcs() {
+  local package_href=$1
+  curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+    --data-urlencode "package=$package_href" \
+    --data-urlencode "limit=100" \
+    "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+    | jq -r '.results[].release_component'
+}
+
+# pick one file per arch for the legacy path. Prefer content that doesn't
+# exist in pulp yet: a fresh upload carries exactly one suite association
+# afterwards, identifying the release component unambiguously. For a reused
+# representative (identical bytes delivered before), capture its pre-upload
+# associations to diff against later.
+declare -A LEGACY_FOR_ARCH=()
+declare -A LEGACY_FRESH=()
+declare -A LEGACY_BEFORE=()
+refresh_pulp_token
+for i in "${!FILES[@]}"; do
+  FILE=${FILES[$i]}
+  arch=$(dpkg-deb -f "$FILE" Architecture)
+  if [[ -n "${LEGACY_FRESH[$arch]+set}" ]]; then
+    continue
+  fi
+  if ((i % 40 == 0)); then
+    refresh_pulp_token
+  fi
+  sha=$(sha256sum "$FILE" | cut -d' ' -f1)
+  existing=$(lookup_deb_content "packages" "--data-urlencode sha256=$sha")
+  if [[ -z "$existing" ]]; then
+    LEGACY_FOR_ARCH[$arch]="$FILE"
+    LEGACY_FRESH[$arch]=1
+  elif [[ -z "${LEGACY_FOR_ARCH[$arch]+set}" ]]; then
+    LEGACY_FOR_ARCH[$arch]="$FILE"
+    LEGACY_BEFORE[$arch]=$(lookup_prcs "$existing" | sort)
+  fi
+done
+
+declare -A IS_LEGACY=()
+LEGACY_FILES=()
+LEGACY_ARCHS=()
+for arch in "${!LEGACY_FOR_ARCH[@]}"; do
+  LEGACY_FILES+=("${LEGACY_FOR_ARCH[$arch]}")
+  LEGACY_ARCHS+=("$arch")
+  IS_LEGACY["${LEGACY_FOR_ARCH[$arch]}"]=1
+done
+ORPHAN_FILES=()
+for FILE in "${FILES[@]}"; do
+  [[ -n "${IS_LEGACY[$FILE]+set}" ]] || ORPHAN_FILES+=("$FILE")
+done
+
+refresh_pulp_token
+for FILE in "${LEGACY_FILES[@]}"; do
+  assert_not_in_stable "$FILE"
+done
+# sequential with retry: the legacy path creates a repository version, and
+# concurrent legs of the shared repository can lose the version race (rc 2)
+for FILE in "${LEGACY_FILES[@]}"; do
+  for legacy_attempt in 1 2 3; do
+    echo "[INFO] Uploading $FILE to $POOL_PATH/ ($SUITE/main, module $MODULE_NAME) [legacy path, attempt $legacy_attempt]"
+    LEGACY_TASK=$(
+      pulp_upload \
+        -F "file=@\"$FILE\"" \
+        -F "relative_path=$POOL_PATH/$FILE" \
+        -F "distribution=$SUITE" \
+        -F "component=main" \
+        -F "repository=$REPOSITORY_HREF" \
+        -F "pulp_labels=$PULP_LABELS" \
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/"
+    )
+    wait_task_race "$LEGACY_TASK" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      break
+    elif [[ $rc -eq 2 && $legacy_attempt -lt 3 ]]; then
+      echo "[WARN] Legacy upload of $FILE lost the repository-version race against a concurrent delivery, retrying"
+      sleep $((legacy_attempt * 15))
+    else
+      echo "::error::Legacy upload of $FILE failed"
+      exit 1
+    fi
+  done
+done
+
+# deduce the release component href from the association the legacy uploads
+# just created: a fresh representative now carries exactly one association; a
+# reused one carries its prior ones too, so diff post- against pre-upload
+refresh_pulp_token
+RELEASE_COMPONENT_HREF=""
+for i in "${!LEGACY_FILES[@]}"; do
+  FILE=${LEGACY_FILES[$i]}
+  arch=${LEGACY_ARCHS[$i]}
+  sha=$(sha256sum "$FILE" | cut -d' ' -f1)
+  href=$(lookup_deb_content "packages" "--data-urlencode sha256=$sha")
+  if [[ -z "$href" ]]; then
+    echo "::error::Cannot find the legacy-delivered package $FILE (sha256 $sha)"
+    exit 1
+  fi
+  after=$(lookup_prcs "$href" | sort)
+  if [[ -n "${LEGACY_FRESH[$arch]+set}" ]]; then
+    if [[ $(echo "$after" | grep -c .) -eq 1 ]]; then
+      RELEASE_COMPONENT_HREF="$after"
+      break
+    fi
+  else
+    new_rcs=$(comm -13 <(echo "${LEGACY_BEFORE[$arch]}") <(echo "$after") | grep . || true)
+    if [[ $(echo "$new_rcs" | grep -c .) -eq 1 ]]; then
+      RELEASE_COMPONENT_HREF="$new_rcs"
+      break
+    elif [[ $(echo "$after" | grep -c .) -eq 1 ]]; then
+      # rerun of a partially delivered leg: empty diff, but it's the only association
+      RELEASE_COMPONENT_HREF=$(echo "$after" | grep .)
+      break
+    fi
+  fi
+done
+if [[ -z "$RELEASE_COMPONENT_HREF" ]]; then
+  echo "::error::Cannot deduce the $SUITE/main release component: every legacy representative is reused content whose suite association pre-exists. Deliver a rebuilt (fresh) package or clean up the previous partial delivery."
+  exit 1
+fi
+echo "[INFO] Release component of $SUITE/main: $RELEASE_COMPONENT_HREF"
+
+# parallel repository-less uploads (pool of 8), marker-file based like rpm
+UPLOAD_DIR=$(mktemp -d)
+MAX_PARALLEL_UPLOADS=8
+for i in "${!ORPHAN_FILES[@]}"; do
+  FILE=${ORPHAN_FILES[$i]}
+  if ((i % 40 == 0)); then
+    refresh_pulp_token
+  fi
+  (
+    # subshell-local: the inherited token can go stale between parent refreshes
+    refresh_pulp_token
+    assert_not_in_stable "$FILE"
+    echo "[INFO] Uploading $FILE to $POOL_PATH/ ($SUITE/main, module $MODULE_NAME)"
+    pulp_upload \
+      -F "file=@\"$FILE\"" \
+      -F "relative_path=$POOL_PATH/$FILE" \
+      -F "pulp_labels=$PULP_LABELS" \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/" > "$UPLOAD_DIR/$i.task"
+  ) &
+  while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
+    wait -n || true
+  done
+done
+wait || true
+
+echo "[INFO] Resolving ${#ORPHAN_FILES[@]} uploaded package(s)"
+ORPHAN_SHA256S=()
+for i in "${!ORPHAN_FILES[@]}"; do
+  FILE=${ORPHAN_FILES[$i]}
+  if [[ ! -s "$UPLOAD_DIR/$i.task" ]]; then
+    echo "::error::Upload failed for $FILE (no task href, see the worker error above)"
+    exit 1
+  fi
+  ORPHAN_SHA256S+=("$(sha256sum "$FILE" | cut -d' ' -f1)")
+done
+for i in "${!ORPHAN_FILES[@]}"; do
+  if ((i % 40 == 0)); then
+    refresh_pulp_token
+  fi
+  (
+    resolve_task_content "$(cat "$UPLOAD_DIR/$i.task")" "packages" \
+      "--data-urlencode sha256=${ORPHAN_SHA256S[$i]}" > "$UPLOAD_DIR/$i.content"
+  ) &
+  while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
+    wait -n || true
+  done
+done
+wait || true
+PACKAGE_HREFS=()
+for i in "${!ORPHAN_FILES[@]}"; do
+  if [[ ! -s "$UPLOAD_DIR/$i.content" ]]; then
+    echo "::error::Cannot resolve the uploaded content for ${ORPHAN_FILES[$i]} (see the worker error above)"
+    exit 1
+  fi
+  PACKAGE_HREFS+=("$(cat "$UPLOAD_DIR/$i.content")")
+done
+
+# package_release_components create is synchronous (201 with the unit, no
+# task); a failed create (already existing on a job re-run) falls back to a lookup
+echo "[INFO] Associating ${#PACKAGE_HREFS[@]} package(s) with $SUITE/main"
+for i in "${!PACKAGE_HREFS[@]}"; do
+  if ((i % 40 == 0)); then
+    refresh_pulp_token
+  fi
+  (
+    refresh_pulp_token
+    out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+      "{\"package\": \"${PACKAGE_HREFS[$i]}\", \"release_component\": \"$RELEASE_COMPONENT_HREF\"}") || out=$'\n000'
+    code="${out##*$'\n'}"
+    body="${out%$'\n'*}"
+    href=""
+    if [[ "$code" == 2* ]]; then
+      # tolerate a non-json body (gateway error page behind a 2xx)
+      href=$(echo "$body" | jq -r '.pulp_href // .task // empty' 2>/dev/null) || href=""
+    fi
+    if [[ -z "$href" ]]; then
+      href=$(lookup_deb_content "package_release_components" \
+        "--data-urlencode package=${PACKAGE_HREFS[$i]} --data-urlencode release_component=$RELEASE_COMPONENT_HREF")
+      if [[ -n "$href" ]]; then
+        # api answers 500 on a duplicate synchronous create; expected on a rerun
+        echo "[INFO] ${ORPHAN_FILES[$i]}: suite association already exists (HTTP $code on create, expected on a rerun), reusing it"
+      else
+        echo "[WARN] Suite association create for ${ORPHAN_FILES[$i]} returned HTTP $code: $(echo "$body" | head -c 300)" >&2
+      fi
+    fi
+    printf '%s' "$href" > "$UPLOAD_DIR/$i.prc"
+  ) &
+  while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
+    wait -n || true
+  done
+done
+wait || true
+
+PRC_HREFS=()
+for i in "${!PACKAGE_HREFS[@]}"; do
+  href=""
+  [[ -s "$UPLOAD_DIR/$i.prc" ]] && href=$(cat "$UPLOAD_DIR/$i.prc")
+  if [[ "$href" == */tasks/* ]]; then
+    href=$(resolve_task_content "$href" "package_release_components" \
+      "--data-urlencode package=${PACKAGE_HREFS[$i]} --data-urlencode release_component=$RELEASE_COMPONENT_HREF")
+  fi
+  if [[ -z "$href" ]]; then
+    echo "::error::Suite association failed for ${ORPHAN_FILES[$i]} (see the worker error above)"
+    exit 1
+  fi
+  PRC_HREFS+=("$href")
+done
+rm -rf "$UPLOAD_DIR"
+
+if ((${#PACKAGE_HREFS[@]} > 0)); then
+  echo "[INFO] Adding ${#PACKAGE_HREFS[@]} package(s) and their suite associations to $REPOSITORY_NAME in a single task"
+  refresh_pulp_token
+  # body through a file: thousands of hrefs exceed the argv limit
+  ADD_BODY_FILE=$(mktemp)
+  printf '%s\n' "${PACKAGE_HREFS[@]}" "${PRC_HREFS[@]}" | jq -R . | jq -cs '{add_content_units: .}' > "$ADD_BODY_FILE"
+  # retried like the legacy uploads: same repository-version race
+  for modify_attempt in 1 2 3; do
+    MODIFY_TASK=$(start_modify_task "$PULP_URL${REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
+    wait_task_race "$MODIFY_TASK" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      break
+    elif [[ $rc -eq 2 && $modify_attempt -lt 3 ]]; then
+      echo "[WARN] Repository modify lost the repository-version race against a concurrent delivery, retrying"
+      sleep $((modify_attempt * 15))
+    else
+      echo "::error::Repository modify failed"
+      exit 1
+    fi
+  done
+fi
+
+# record every delivered package in the manifest for the verification step
+for FILE in "${FILES[@]}"; do
+  name=$(dpkg-deb -f "$FILE" Package)
+  version=$(dpkg-deb -f "$FILE" Version)
+  arch=$(dpkg-deb -f "$FILE" Architecture)
+  sha256=$(sha256sum "$FILE" | cut -d' ' -f1)
+  manifest_add "$(jq -cn \
+    --arg filename "$FILE" --arg name "$name" --arg version "$version" \
+    --arg arch "$arch" --arg sha256 "$sha256" --arg repository "$REPOSITORY_NAME" \
+    --arg base_path "${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}" --arg suite "$SUITE" --arg relative_path "$POOL_PATH/$FILE" \
+    '{filename:$filename,name:$name,version:$version,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path,suite:$suite,relative_path:$relative_path}')"
+done
+
+echo "[INFO] Publishing repository $REPOSITORY_NAME"
+create_publication deb "$REPOSITORY_NAME" --structured
+
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}/ $SUITE main"
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+# read-only grant into the stable domain, used by assert_not_in_stable below
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
+
+# refuse delivering a package version already published in the stable repository
+assert_not_in_stable() {
+  local file=$1 arch=$2 base name version release stable_repository repository_version count
+  base=$(basename "$file" .rpm)
+  base=${base%.$arch}
+  release=${base##*-}
+  base=${base%-*}
+  version=${base##*-}
+  name=${base%-*}
+
+  stable_repository="$STABLE_REPOSITORY_PREFIX-$arch"
+  # fail closed on an unreachable api, fail open only if the repo doesn't exist yet
+  local repo_page
+  repo_page=$(
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+      --data-urlencode "name=$stable_repository" \
+      --data-urlencode "limit=1" \
+      "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/repositories/rpm/rpm/"
+  ) || {
+    echo "::error::Cannot check the stable repository $stable_repository to guard $name $version-$release ($arch); refusing to deliver. Retry once the api is reachable."
+    return 1
+  }
+  repository_version=$(echo "$repo_page" | jq -r '.results[0].latest_version_href // empty')
+  # no stable repository yet => nothing can be in stable
+  [[ -z "$repository_version" ]] && return 0
+
+  count=$(
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+      --data-urlencode "repository_version=$repository_version" \
+      --data-urlencode "name=$name" \
+      --data-urlencode "version=$version" \
+      --data-urlencode "release=$release" \
+      --data-urlencode "arch=$arch" \
+      --data-urlencode "limit=1" \
+      "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/content/rpm/packages/" | jq -r '.count'
+  ) || {
+    echo "::error::Cannot check the stable repository $stable_repository content to guard $name $version-$release ($arch); refusing to deliver. Retry once the api is reachable."
+    return 1
+  }
+  if [[ "$count" -gt 0 ]]; then
+    echo "::error::$name $version-$release ($arch) is already published in the stable repository $stable_repository; refusing to deliver it to $REPOSITORY_NAME. Bump the package version for a new build."
+    return 1
+  fi
+}
+
+# wait for the upload task and emit its content href; fall back to a sha256
+# lookup if the task produced none (content already existing on a job re-run)
+resolve_uploaded_content() {
+  local task_href=$1 sha256=$2
+  local body state content attempt
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    refresh_pulp_token
+    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
+    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
+    case "$state" in
+      completed)
+        content=$(echo "$body" | jq -r '.created_resources[0] // empty')
+        if [[ -n "$content" ]]; then
+          echo "$content"
+          return 0
+        fi
+        break
+        ;;
+      failed | canceled)
+        break
+        ;;
+      *)
+        sleep 3
+        ;;
+    esac
+  done
+  content=$(
+    curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" -G \
+      --data-urlencode "sha256=$sha256" \
+      --data-urlencode "limit=1" \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/" | jq -r '.results[0].pulp_href // empty'
+  )
+  if [[ -z "$content" ]]; then
+    echo "::error::Cannot resolve the uploaded content for task $task_href (sha256 $sha256)" >&2
+    return 1
+  fi
+  echo "$content"
+}
+
+FILES=(*.rpm)
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "::error::No rpm package found to deliver"
+  exit 1
+fi
+
+mkdir -p noarch x86_64
+for FILE in "${FILES[@]}"; do
+  ARCH=$(echo "$FILE" | grep -oP '(x86_64|noarch)' | head -1 || true)
+  if [[ -z "$ARCH" ]]; then
+    echo "::error::Cannot find the architecture of package $FILE"
+    exit 1
+  fi
+  mv "$FILE" "$ARCH"
+done
+
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
+for ARCH in noarch x86_64; do
+  ARCH_FILES=("$ARCH"/*.rpm)
+  if [[ ${#ARCH_FILES[@]} -eq 0 ]]; then
+    continue
+  fi
+
+  REPOSITORY_NAME="$REPOSITORY_PREFIX-$ARCH"
+  BASE_PATH="$BASE_PATH_PREFIX/$ARCH"
+  LEGACY_BASE_PATH=""
+  [[ -n "$LEGACY_BASE_PATH_PREFIX" ]] && LEGACY_BASE_PATH="$LEGACY_BASE_PATH_PREFIX/$ARCH"
+
+  if ! pulp_resource_exists "repositories/rpm/rpm" "$REPOSITORY_NAME"; then
+    echo "::error::rpm repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
+    exit 1
+  fi
+
+  if ! pulp_resource_exists "distributions/rpm/rpm" "$REPOSITORY_NAME"; then
+    echo "::error::rpm distribution $REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering. Refusing to create it here to avoid an unguarded distribution."
+    exit 1
+  fi
+
+  REPOSITORY_HREF=$(pulp rpm repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
+
+  # upload as unassociated (repository-less) content so creates parallelize
+  # across pulp workers, then add the whole batch in one modify task
+  TASK_HREFS=()
+  SHA256S=()
+  # bounded pool of background subshells upload in parallel, each writing its
+  # task href to a marker file; a missing/empty marker means that worker failed
+  UPLOAD_DIR=$(mktemp -d)
+  MAX_PARALLEL_UPLOADS=8
+  for i in "${!ARCH_FILES[@]}"; do
+    FILE=${ARCH_FILES[$i]}
+    if ((i % 40 == 0)); then
+      refresh_pulp_token
+    fi
+    (
+      # subshell-local: the inherited token can go stale between parent refreshes
+      refresh_pulp_token
+      assert_not_in_stable "$FILE" "$ARCH"
+      echo "[INFO] Uploading $(basename "$FILE") (module $MODULE_NAME)"
+      pulp_upload \
+        -F "file=@\"$FILE\"" \
+        -F "pulp_labels=$PULP_LABELS" \
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/" > "$UPLOAD_DIR/$i.task"
+    ) &
+    while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
+      wait -n || true
+    done
+  done
+  wait || true
+
+  for i in "${!ARCH_FILES[@]}"; do
+    FILE=${ARCH_FILES[$i]}
+    if [[ ! -s "$UPLOAD_DIR/$i.task" ]]; then
+      echo "::error::Upload failed for $(basename "$FILE") (no task href, see the worker error above)"
+      exit 1
+    fi
+    TASK_HREFS+=("$(cat "$UPLOAD_DIR/$i.task")")
+    sha256=$(sha256sum "$FILE" | cut -d' ' -f1)
+    SHA256S+=("$sha256")
+
+    # name/version/release parsed the same way as assert_not_in_stable
+    FILENAME=$(basename "$FILE")
+    base=${FILENAME%.rpm}
+    base=${base%."$ARCH"}
+    release=${base##*-}
+    base=${base%-*}
+    version=${base##*-}
+    name=${base%-*}
+    manifest_add "$(jq -cn \
+      --arg filename "$FILENAME" --arg name "$name" --arg version "$version" \
+      --arg release "$release" --arg arch "$ARCH" --arg sha256 "$sha256" \
+      --arg repository "$REPOSITORY_NAME" --arg base_path "${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}" \
+      '{filename:$filename,name:$name,version:$version,release:$release,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path}')"
+  done
+  rm -rf "$UPLOAD_DIR"
+
+  echo "[INFO] Waiting for ${#TASK_HREFS[@]} upload task(s) and resolving the content"
+  # parallelized like the uploads: sequential took one task GET per package (~6 min at 675)
+  RESOLVE_DIR=$(mktemp -d)
+  for i in "${!TASK_HREFS[@]}"; do
+    if ((i % 40 == 0)); then
+      refresh_pulp_token
+    fi
+    (
+      resolve_uploaded_content "${TASK_HREFS[$i]}" "${SHA256S[$i]}" > "$RESOLVE_DIR/$i.content"
+    ) &
+    while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
+      wait -n || true
+    done
+  done
+  wait || true
+
+  CONTENT_HREFS=()
+  for i in "${!TASK_HREFS[@]}"; do
+    if [[ ! -s "$RESOLVE_DIR/$i.content" ]]; then
+      echo "::error::Cannot resolve the uploaded content of task ${TASK_HREFS[$i]} (see the worker error above)"
+      exit 1
+    fi
+    CONTENT_HREFS+=("$(cat "$RESOLVE_DIR/$i.content")")
+  done
+  rm -rf "$RESOLVE_DIR"
+
+  echo "[INFO] Adding ${#CONTENT_HREFS[@]} package(s) to $REPOSITORY_NAME in a single task"
+  # the subshell refreshes above never updated this shell's token
+  refresh_pulp_token
+  # body through a file: thousands of hrefs exceed the argv limit
+  ADD_BODY_FILE=$(mktemp)
+  printf '%s\n' "${CONTENT_HREFS[@]}" | jq -R . | jq -cs '{add_content_units: .}' > "$ADD_BODY_FILE"
+  # several modules deliver into the same repository (version race)
+  for modify_attempt in 1 2 3; do
+    MODIFY_TASK=$(start_modify_task "$PULP_URL${REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
+    wait_task_race "$MODIFY_TASK" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      break
+    elif [[ $rc -eq 2 && $modify_attempt -lt 3 ]]; then
+      echo "[WARN] Repository modify was interrupted server-side, retrying"
+      sleep $((modify_attempt * 15))
+    else
+      echo "::error::Repository modify failed"
+      exit 1
+    fi
+  done
+
+  echo "[INFO] Publishing repository $REPOSITORY_NAME"
+  create_publication rpm "$REPOSITORY_NAME"
+
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}/"
+done
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -1,0 +1,164 @@
+name: "promote testing to stable"
+description: "Promote testing packages to stable."
+inputs:
+  module_name:
+    description: "Module name"
+    required: true
+  distrib:
+    description: "The distribution used for packaging"
+    required: true
+  major_version:
+    description: "Centreon packaged major version (not used by the plugins repository family)"
+    required: false
+    default: ""
+  stability:
+    description: "The package stability (stable, testing, unstable)"
+    required: true
+  release_type:
+    description: "Type of release (hotfix, release)"
+    required: true
+  is_cloud:
+    description: "Release context (cloud or not cloud)"
+    required: true
+  repository_name:
+    description: "Target repository family: standard, standard-internal, business, business-internal or plugins"
+    required: false
+    default: "standard"
+  verify:
+    description: "Verify the promoted packages afterwards (presence, metadata resolution, fetchability)"
+    required: false
+    default: "true"
+  pulp_url:
+    description: "The pulp server api url"
+    required: true
+  pulp_content_url:
+    description: "The pulp server content url"
+    required: true
+  audience:
+    description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$RELEASE_TYPE" != "release" && "$RELEASE_TYPE" != "hotfix" ]]; then
+          echo "::error::release_type input must be defined (release or hotfix)"
+          exit 1
+        fi
+
+    - name: Compute pulp repository properties
+      id: pulp-properties
+      uses: ./.github/actions/pulp-repository-properties
+      with:
+        module_name: ${{ inputs.module_name }}
+        distrib: ${{ inputs.distrib }}
+        version: ${{ inputs.major_version }}
+        stability: ${{ inputs.stability }}
+        release_type: ${{ inputs.release_type }}
+        is_cloud: ${{ inputs.is_cloud }}
+        repository_name: ${{ inputs.repository_name }}
+
+    - name: Setup pulp-cli
+      uses: ./.github/actions/setup-pulp-cli
+      with:
+        pulp_url: ${{ inputs.pulp_url }}
+        audience: ${{ inputs.audience }}
+        domain: ${{ steps.pulp-properties.outputs.domain }}
+
+    - name: Promote RPM packages to stable
+      id: promote-rpm
+      if: steps.pulp-properties.outputs.package_extension == 'rpm'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        TESTING_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.testing_repository_prefix }}
+        TESTING_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.testing_base_path_prefix }}
+        STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
+        STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.stable_base_path_prefix }}
+        LEGACY_STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.legacy_stable_base_path_prefix }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # stable shares the domain since the domain merge; kept distinct for the scripts that address the stable tier
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
+      run: ${{ github.action_path }}/promote-rpm.sh
+
+    - name: Promote DEB packages to stable
+      id: promote-deb
+      if: steps.pulp-properties.outputs.package_extension == 'deb'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        # the promotion source is the testing repository (one deb repository per
+        # stability), not the repository matching the requested stability
+        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.testing_repository_name }}
+        BASE_PATH: ${{ steps.pulp-properties.outputs.testing_base_path }}
+        LEGACY_TESTING_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_testing_base_path }}
+        LEGACY_STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_stable_base_path }}
+        TESTING_POOL_PATH: ${{ steps.pulp-properties.outputs.testing_pool_path }}
+        TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
+        STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
+        STABLE_LEGACY_SUITE: ${{ steps.pulp-properties.outputs.stable_legacy_suite }}
+        STABLE_LEGACY_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_legacy_repository_name }}
+        STABLE_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_repository_name }}
+        STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}
+        PACKAGE_DISTRIB_NAME: ${{ steps.pulp-properties.outputs.package_distrib_name }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # stable shares the domain since the domain merge; kept distinct for the scripts that address the stable tier
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
+      run: ${{ github.action_path }}/promote-deb.sh
+
+    - name: Verify RPM promotion
+      # skipped on dry runs (stability != stable): the promote script exits
+      # before promoting anything, so there is no manifest to verify
+      if: inputs.verify == 'true' && inputs.stability == 'stable' && steps.pulp-properties.outputs.package_extension == 'rpm'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.promote-rpm.outputs.manifest }}
+        CHECK_MODE: promote
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # verifying the just-promoted content, which now lives in the stable domain
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-rpm.sh ||
+          echo "::warning::Pulp promotion verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"
+
+    - name: Verify DEB promotion
+      # skipped on dry runs (stability != stable): the promote script exits
+      # before promoting anything, so there is no manifest to verify
+      if: inputs.verify == 'true' && inputs.stability == 'stable' && steps.pulp-properties.outputs.package_extension == 'deb'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.promote-deb.outputs.manifest }}
+        CHECK_MODE: promote
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # verifying the just-promoted content, which now lives in the stable domain
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-deb.sh ||
+          echo "::warning::Pulp promotion verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+# stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
+# now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
+# switch_pulp_domain overwrites PULP_DOMAIN itself once the write phase
+# starts; download_testing_package always needs the original (testing-tier)
+# domain, including after the switch, so keep our own copy
+TESTING_DOMAIN="$PULP_DOMAIN"
+
+if ! pulp_resource_exists "repositories/deb/apt" "$REPOSITORY_NAME"; then
+  echo "::error::Nothing to promote, repository $REPOSITORY_NAME does not exist"
+  exit 1
+fi
+
+VERSION_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.latest_version_href')
+
+# fetch a published index into a file: 0=ok, 2=absent (404), 1=error
+fetch_index() {
+  local url=$1 out=$2 code
+  code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$out" -w '%{http_code}' "$url") || return 1
+  [[ "$code" == "200" ]] && return 0
+  [[ "$code" == "404" ]] && return 2
+  return 1
+}
+
+# collect the sha256 set of every package published in a suite: the served
+# dists/ indexes are the source of truth for suite membership (relative_path
+# and the release_components api can't be trusted/used here, see deliver-deb.sh).
+# A missing Release (404) is an empty suite; any other fetch failure aborts.
+suite_sha_file() {
+  local base_path=$1 suite=$2 out release_file arches arch pkg_file rc
+  out=$(mktemp)
+  release_file=$(mktemp)
+  fetch_index "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" "$release_file" && rc=0 || rc=$?
+  if [[ $rc -eq 2 ]]; then
+    echo "$out"
+    return 0
+  elif [[ $rc -ne 0 ]]; then
+    echo "::error::Cannot fetch the $suite Release index; refusing to promote from a partial view." >&2
+    return 1
+  fi
+  arches=$(awk -F': ' '/^Architectures:/ {print $2}' "$release_file")
+  for arch in $arches; do
+    pkg_file=$(mktemp)
+    if ! fetch_index "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$arch/Packages" "$pkg_file"; then
+      echo "::error::Cannot fetch the $suite binary-$arch Packages index; refusing to promote from a partial view." >&2
+      return 1
+    fi
+    awk -F': ' '/^SHA256:/ {print $2}' "$pkg_file" >> "$out"
+    rm -f "$pkg_file"
+  done
+  rm -f "$release_file"
+  sort -u "$out" -o "$out"
+  echo "$out"
+}
+
+# resolve the served filename from the testing suite's Packages file by
+# sha256 (the published pool layout doesn't match the upload relative_path)
+download_testing_package() {
+  local sha256=$1 arch=$2 dest=$3 filename
+  filename=$(
+    content_curl -fsSL --retry 3 --retry-delay 5 "$PULP_CONTENT_URL/${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}/dists/$TESTING_SUITE/main/binary-$arch/Packages" |
+      awk -v sha="$sha256" 'BEGIN { RS = ""; FS = "\n" } index($0, "SHA256: " sha) { for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i; exit } }'
+  )
+  if [[ -z "$filename" ]]; then
+    echo "::error::Cannot locate the published file for sha256 $sha256 in $TESTING_SUITE ($arch)" >&2
+    return 1
+  fi
+  content_curl -fsSL --retry 3 --retry-delay 5 -o "$dest" "$PULP_CONTENT_URL/${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}/$filename"
+}
+
+TESTING_SHAS_FILE=$(suite_sha_file "${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}" "$TESTING_SUITE")
+
+# paginated: the repository keeps every delivered version across all suites,
+# so the module listing can exceed a single page
+RESULTS_FILE=$(mktemp)
+url="$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/?$(
+  printf 'repository_version=%s&pulp_label_select=%s&limit=1000' \
+    "$(jq -rn --arg v "$VERSION_HREF" '$v | @uri')" \
+    "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
+)"
+while [[ -n "$url" ]]; do
+  refresh_pulp_token
+  page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url")
+  echo "$page" | jq -c '.results[]' >> "$RESULTS_FILE"
+  url=$(echo "$page" | jq -r '.next // empty')
+done
+
+# only the LATEST version of each package is promoted (deb has no retention
+# mechanism, testing accumulates every build); compare segment by segment
+# (numeric as numbers) since a plain string max ranks "0.9" above "0.10"
+TESTING_SET_FILE=$(mktemp)
+jq -R . "$TESTING_SHAS_FILE" | jq -s 'map({key: ., value: true}) | from_entries' > "$TESTING_SET_FILE"
+PACKAGES=$(
+  jq -s --slurpfile testing_set "$TESTING_SET_FILE" \
+    'def vkey: [scan("[0-9]+|[^0-9]+") | (tonumber? // .)];
+     [.[] | select($testing_set[0][.sha256])]
+     | group_by(.package, .architecture) | map(max_by(.version | vkey))' \
+    "$RESULTS_FILE"
+)
+rm -f "$RESULTS_FILE" "$TESTING_SHAS_FILE" "$TESTING_SET_FILE"
+PACKAGES_COUNT=$(echo "$PACKAGES" | jq 'length')
+
+if [[ "$PACKAGES_COUNT" -eq 0 ]]; then
+  echo "::error::Nothing to promote, no package of module $MODULE_NAME found in the $TESTING_SUITE suite of $REPOSITORY_NAME"
+  exit 1
+fi
+
+echo "[INFO] $PACKAGES_COUNT packages of module $MODULE_NAME found in the $TESTING_SUITE suite of $REPOSITORY_NAME"
+
+if [[ "$STABILITY" != "stable" ]]; then
+  echo "[INFO] Dry run, $PACKAGES_COUNT packages would be promoted to $STABLE_SUITE/main"
+  exit 0
+fi
+
+# everything from here on targets the stable-tier domain
+refresh_pulp_token
+switch_pulp_domain "$PULP_STABLE_DOMAIN"
+
+if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_REPOSITORY_NAME"; then
+  echo "::error::Stable repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories are provisioned centrally by delivery-tooling create-repos; run create-repos before promoting."
+  exit 1
+fi
+STABLE_REPOSITORY_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
+
+# 24.x standard clients use the dedicated legacy repository form
+# (apt-standard-24.10-stable/ with a plain-codename suite, provisioned by
+# create-repos): mirror every candidate package association into that suite so
+# both suites always list the same stable content. Idempotent (rerun safe).
+ensure_legacy_suite_associations() {
+  [[ -z "${STABLE_LEGACY_REPOSITORY_NAME:-}" ]] && return 0
+  refresh_pulp_token
+  if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_LEGACY_REPOSITORY_NAME"; then
+    echo "::error::Dedicated legacy repository $STABLE_LEGACY_REPOSITORY_NAME does not exist. Pulp repositories are provisioned centrally by delivery-tooling create-repos; run create-repos before promoting."
+    return 1
+  fi
+  local legacy_repo_href latest legacy_rc
+  legacy_repo_href=$(pulp deb repository show --name "$STABLE_LEGACY_REPOSITORY_NAME" | jq -r '.pulp_href')
+  latest=$(pulp deb repository show --name "$STABLE_LEGACY_REPOSITORY_NAME" | jq -r '.latest_version_href')
+  legacy_rc=$(
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/release_components/?$(
+        printf 'repository_version=%s&distribution=%s&component=main&limit=1' \
+          "$(jq -rn --arg v "$latest" '$v | @uri')" "$(jq -rn --arg v "$STABLE_LEGACY_SUITE" '$v | @uri')"
+      )" | jq -r '.results[0].pulp_href // empty'
+  )
+  if [[ -z "$legacy_rc" ]]; then
+    echo "::error::Cannot resolve the $STABLE_LEGACY_SUITE/main release component of $STABLE_LEGACY_REPOSITORY_NAME (provisioned by create-repos)"
+    return 1
+  fi
+  echo "[INFO] Mirroring $PACKAGES_COUNT package association(s) into $STABLE_LEGACY_REPOSITORY_NAME $STABLE_LEGACY_SUITE/main"
+  local units_file body_file sha href out code body prc n=0
+  units_file=$(mktemp)
+  while read -r sha; do
+    if ((n % 40 == 0)); then refresh_pulp_token; fi
+    n=$((n + 1))
+    href=$(lookup_deb_content "packages" "--data-urlencode sha256=$sha")
+    if [[ -z "$href" ]]; then
+      echo "::error::Cannot resolve the promoted package (sha256 $sha) for the $STABLE_LEGACY_SUITE mirror"
+      return 1
+    fi
+    out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+      "{\"package\": \"$href\", \"release_component\": \"$legacy_rc\"}") || out=$'\n000'
+    code="${out##*$'\n'}"
+    body="${out%$'\n'*}"
+    prc=""
+    if [[ "$code" == 2* ]]; then
+      prc=$(echo "$body" | jq -r '.pulp_href // empty' 2>/dev/null) || prc=""
+    fi
+    if [[ -z "$prc" ]]; then
+      # the api answers 500 on a duplicate synchronous create; expected on a rerun
+      prc=$(lookup_deb_content "package_release_components" \
+        "--data-urlencode package=$href --data-urlencode release_component=$legacy_rc")
+    fi
+    if [[ -z "$prc" ]]; then
+      echo "::error::Legacy suite association failed for sha256 $sha (HTTP $code)"
+      return 1
+    fi
+    printf '%s\n%s\n' "$href" "$prc" >> "$units_file"
+  done < <(echo "$PACKAGES" | jq -r '.[].sha256')
+  body_file=$(mktemp)
+  jq -R . "$units_file" | jq -cs '{add_content_units: ([.[] | select(. != "")] | unique)}' > "$body_file"
+  rm -f "$units_file"
+  local task rc
+  for _ in 1 2 3; do
+    task=$(start_modify_task "$PULP_URL${legacy_repo_href}modify/" "$body_file")
+    wait_task_race "$task" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      rm -f "$body_file"
+      create_publication deb "$STABLE_LEGACY_REPOSITORY_NAME" --structured
+      return 0
+    fi
+  done
+  echo "::error::Cannot add the $STABLE_LEGACY_SUITE mirror associations to $STABLE_LEGACY_REPOSITORY_NAME"
+  return 1
+}
+
+# "already promoted" is decided against the stable repository's OWN version
+# (it's always dedicated, never shared, so it only ever receives stable content)
+STABLE_SHAS_FILE=$(mktemp)
+STABLE_VERSION_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
+url="$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/?$(
+  printf 'repository_version=%s&fields=sha256&limit=1000' \
+    "$(jq -rn --arg v "$STABLE_VERSION_HREF" '$v | @uri')"
+)"
+while [[ -n "$url" ]]; do
+  refresh_pulp_token
+  page=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" "$url")
+  echo "$page" | jq -r '.results[].sha256' >> "$STABLE_SHAS_FILE"
+  url=$(echo "$page" | jq -r '.next // empty')
+done
+sort -u "$STABLE_SHAS_FILE" -o "$STABLE_SHAS_FILE"
+
+mkdir -p promoted-packages
+
+# mirrors deliver-deb.sh's own PULP_LABELS, but this run's own git context
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
+# emit the href of a matching stable-domain deb content unit, empty if absent.
+# Retried: the api has been observed answering an empty page for content
+# committed seconds earlier (stale read)
+lookup_deb_content() {
+  local endpoint=$1 query=$2 out attempt
+  for attempt in 1 2 3 4 5; do
+    out=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+      --data-urlencode "limit=1" \
+      $query \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/$endpoint/" | jq -r '.results[0].pulp_href // empty') || out=""
+    if [[ -n "$out" ]]; then
+      echo "$out"
+      return 0
+    fi
+    sleep $((attempt * 3))
+    refresh_pulp_token
+  done
+}
+
+# emit the release-component hrefs a package is associated with
+lookup_prcs() {
+  local package_href=$1
+  curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+    --data-urlencode "package=$package_href" \
+    --data-urlencode "limit=100" \
+    "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+    | jq -r '.results[].release_component'
+}
+
+# candidates already published in the stable suite need no new association;
+# when EVERYTHING already reached stable (a rerun after the modify), only the
+# publication may be missing: republish and stop.
+UNPROMOTED_HREFS=()
+while read -r PACKAGE; do
+  sha=$(echo "$PACKAGE" | jq -r '.sha256')
+  if ! grep -qxF "$sha" "$STABLE_SHAS_FILE"; then
+    UNPROMOTED_HREFS+=("$(echo "$PACKAGE" | jq -r '.pulp_href')")
+  fi
+done < <(echo "$PACKAGES" | jq -c '.[]')
+rm -f "$STABLE_SHAS_FILE"
+if ((${#UNPROMOTED_HREFS[@]} == 0)); then
+  echo "[INFO] All $PACKAGES_COUNT package(s) are already promoted to $STABLE_SUITE; republishing only"
+  while read -r PACKAGE; do
+    manifest_add "$(echo "$PACKAGE" | jq -c \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
+      --arg suite "$STABLE_SUITE" \
+      '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
+  done < <(echo "$PACKAGES" | jq -c '.[]')
+  ensure_legacy_suite_associations
+  create_publication deb "$STABLE_REPOSITORY_NAME" --structured
+  echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
+  manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
+  exit 0
+fi
+
+# batched promote, mirroring the batched delivery. Testing and stable share
+# their domain (and content) since the domain merge: the batch below associates
+# the testing package hrefs directly, no re-download/re-upload. Only the FIRST
+# package of each arch goes through the legacy upload path, to establish the
+# release component and deduce its href (see deliver-deb.sh; listing release
+# components requires admin rights).
+declare -A ARCH_SEEN=()
+LEGACY_PACKAGES=()
+BATCH_PACKAGES=()
+while read -r PACKAGE; do
+  ARCH=$(echo "$PACKAGE" | jq -r '.architecture')
+  if [[ -z "${ARCH_SEEN[$ARCH]+set}" ]]; then
+    ARCH_SEEN[$ARCH]=1
+    LEGACY_PACKAGES+=("$PACKAGE")
+  else
+    BATCH_PACKAGES+=("$PACKAGE")
+  fi
+done < <(echo "$PACKAGES" | jq -c '.[]')
+
+# capture the reference package's pre-upload stable associations (if it
+# already exists there, e.g. a rerun) so the new one stands out as the diff
+refresh_pulp_token
+LEGACY_REF_SHA256=$(echo "${LEGACY_PACKAGES[0]}" | jq -r '.sha256')
+LEGACY_REF_BEFORE_HREF=$(lookup_deb_content "packages" "--data-urlencode sha256=$LEGACY_REF_SHA256")
+LEGACY_REF_BEFORE=""
+[[ -n "$LEGACY_REF_BEFORE_HREF" ]] && LEGACY_REF_BEFORE=$(lookup_prcs "$LEGACY_REF_BEFORE_HREF" | sort)
+
+for PACKAGE in "${LEGACY_PACKAGES[@]}"; do
+  RELATIVE_PATH=$(echo "$PACKAGE" | jq -r '.relative_path')
+  SHA256=$(echo "$PACKAGE" | jq -r '.sha256')
+  ARCH=$(echo "$PACKAGE" | jq -r '.architecture')
+  FILE_NAME=$(basename "$RELATIVE_PATH")
+  FILE="promoted-packages/$FILE_NAME"
+
+  echo "[INFO] Downloading $FILE_NAME from $TESTING_SUITE"
+  download_testing_package "$SHA256" "$ARCH" "$FILE"
+
+  # same relative_path into stable: pulp reuses existing content and adds the
+  # stable suite association, creating the ReleaseComponent/ReleaseArchitecture
+  # retried: the legacy path creates a repository version and can lose the race
+  for legacy_attempt in 1 2 3; do
+    echo "[INFO] Promoting $FILE_NAME to $STABLE_SUITE/main [legacy path, attempt $legacy_attempt]"
+    TASK_HREF=$(
+      pulp_upload \
+        -F "file=@\"$FILE\"" \
+        -F "relative_path=$RELATIVE_PATH" \
+        -F "distribution=$STABLE_SUITE" \
+        -F "component=main" \
+        -F "repository=$STABLE_REPOSITORY_HREF" \
+        -F "pulp_labels=$PULP_LABELS" \
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/"
+    )
+    wait_task_race "$TASK_HREF" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      break
+    elif [[ $rc -eq 2 && $legacy_attempt -lt 3 ]]; then
+      echo "[WARN] Legacy promotion of $FILE_NAME lost the repository-version race, retrying"
+      sleep $((legacy_attempt * 15))
+    else
+      echo "::error::Legacy promotion of $FILE_NAME failed"
+      exit 1
+    fi
+  done
+done
+
+if ((${#BATCH_PACKAGES[@]} > 0)); then
+  # the release component is the association the legacy re-upload just added
+  # to the reference package (diffed against its pre-upload set captured above)
+  refresh_pulp_token
+  LEGACY_REF_STABLE_HREF=$(lookup_deb_content "packages" "--data-urlencode sha256=$LEGACY_REF_SHA256")
+  if [[ -z "$LEGACY_REF_STABLE_HREF" ]]; then
+    echo "::error::Cannot resolve the promoted reference package (sha256 $LEGACY_REF_SHA256) in the stable domain"
+    exit 1
+  fi
+  LEGACY_REF_AFTER=$(lookup_prcs "$LEGACY_REF_STABLE_HREF" | sort)
+  STABLE_RC_SET=$(comm -13 <(echo "$LEGACY_REF_BEFORE") <(echo "$LEGACY_REF_AFTER") | grep . || true)
+  if [[ $(echo "$STABLE_RC_SET" | grep -c .) -ne 1 ]]; then
+    refresh_pulp_token
+    STABLE_LATEST=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
+    STABLE_RC_SET=$(
+      curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" \
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/release_components/?$(
+          printf 'repository_version=%s&distribution=%s&component=main&limit=1' \
+            "$(jq -rn --arg v "$STABLE_LATEST" '$v | @uri')" "$(jq -rn --arg v "$STABLE_SUITE" '$v | @uri')"
+        )" | jq -r '.results[0].pulp_href // empty'
+    )
+  fi
+  STABLE_RC=$(echo "$STABLE_RC_SET" | grep . | head -1)
+  if [[ -z "$STABLE_RC" ]]; then
+    # a promotion interrupted after its repository modify only misses the
+    # publication: republish and re-check every candidate before giving up
+    echo "[WARN] Cannot deduce the $STABLE_SUITE/main release component (got: ${STABLE_RC_SET:-none}); republishing to check for an interrupted promotion"
+    ensure_legacy_suite_associations
+    create_publication deb "$STABLE_REPOSITORY_NAME" --structured
+    RECHECK_SHAS_FILE=$(suite_sha_file "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" "$STABLE_SUITE")
+    MISSING_COUNT=0
+    while read -r sha; do
+      grep -qxF "$sha" "$RECHECK_SHAS_FILE" || MISSING_COUNT=$((MISSING_COUNT + 1))
+    done < <(echo "$PACKAGES" | jq -r '.[].sha256')
+    rm -f "$RECHECK_SHAS_FILE"
+    if ((MISSING_COUNT == 0)); then
+      echo "[INFO] Every candidate package is published in $STABLE_SUITE; the interrupted promotion only missed the publication"
+      while read -r PACKAGE; do
+        manifest_add "$(echo "$PACKAGE" | jq -c \
+          --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
+          --arg suite "$STABLE_SUITE" \
+          '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
+      done < <(echo "$PACKAGES" | jq -c '.[]')
+      echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
+      manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
+      exit 0
+    fi
+    echo "::error::Cannot deduce the $STABLE_SUITE/main release component (got: ${STABLE_RC_SET:-none}) and $MISSING_COUNT candidate package(s) are missing from the published $STABLE_SUITE suite. A previous promotion likely left the suite associations without the repository content; deliver a rebuilt (fresh) build or add the packages to the stable repository manually."
+    exit 1
+  fi
+  echo "[INFO] Release component of $STABLE_SUITE/main: $STABLE_RC"
+
+  # remaining packages: the testing content hrefs are associated with the
+  # stable release component directly (same domain, shared content); the
+  # packages keep their delivery-time labels
+  PACKAGE_HREFS=()
+  for PACKAGE in "${BATCH_PACKAGES[@]}"; do
+    PACKAGE_HREFS+=("$(echo "$PACKAGE" | jq -r '.pulp_href')")
+  done
+
+  # package_release_components create is synchronous (201 with the unit, no
+  # task); a failed create (already existing on a job re-run) falls back to a lookup
+  echo "[INFO] Associating ${#PACKAGE_HREFS[@]} package(s) with $STABLE_SUITE/main"
+  MAX_PARALLEL=8
+  PRC_DIR=$(mktemp -d)
+  for i in "${!PACKAGE_HREFS[@]}"; do
+    if ((i % 40 == 0)); then
+      refresh_pulp_token
+    fi
+    (
+      refresh_pulp_token
+      package_href="${PACKAGE_HREFS[$i]}"
+      out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+        "{\"package\": \"$package_href\", \"release_component\": \"$STABLE_RC\"}") || out=$'\n000'
+      code="${out##*$'\n'}"
+      body="${out%$'\n'*}"
+      href=""
+      if [[ "$code" == 2* ]]; then
+        # tolerate a non-json body (gateway error page behind a 2xx)
+        href=$(echo "$body" | jq -r '.pulp_href // empty' 2>/dev/null) || href=""
+      fi
+      if [[ -z "$href" ]]; then
+        # api answers 500 on a duplicate synchronous create; expected on a rerun
+        echo "[INFO] $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package'): stable association create answered HTTP $code, falling back to the lookup (expected on a rerun)"
+        href=$(lookup_deb_content "package_release_components" \
+          "--data-urlencode package=$package_href --data-urlencode release_component=$STABLE_RC")
+      fi
+      printf '%s\n%s' "$package_href" "$href" > "$PRC_DIR/$i.pair"
+    ) &
+    while (($(jobs -rp | wc -l) >= MAX_PARALLEL)); do
+      wait -n || true
+    done
+  done
+  wait || true
+
+  ADD_UNITS_FILE=$(mktemp)
+  for i in "${!BATCH_PACKAGES[@]}"; do
+    if [[ ! -s "$PRC_DIR/$i.pair" ]] || [[ -z "$(sed -n '2p' "$PRC_DIR/$i.pair")" ]]; then
+      echo "::error::Stable suite association failed for package $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package') (see the worker error above)"
+      exit 1
+    fi
+    cat "$PRC_DIR/$i.pair" >> "$ADD_UNITS_FILE"
+    echo >> "$ADD_UNITS_FILE"
+  done
+  rm -rf "$PRC_DIR"
+
+  echo "[INFO] Adding ${#BATCH_PACKAGES[@]} package(s) and their suite associations to $STABLE_REPOSITORY_NAME in a single task"
+  refresh_pulp_token
+  # body through a file: thousands of hrefs exceed the argv limit
+  ADD_BODY_FILE=$(mktemp)
+  jq -R . "$ADD_UNITS_FILE" | jq -cs '{add_content_units: [.[] | select(. != "")]}' > "$ADD_BODY_FILE"
+  rm -f "$ADD_UNITS_FILE"
+  # retried like the legacy uploads: same repository-version race
+  for modify_attempt in 1 2 3; do
+    MODIFY_TASK=$(start_modify_task "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
+    wait_task_race "$MODIFY_TASK" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      break
+    elif [[ $rc -eq 2 && $modify_attempt -lt 3 ]]; then
+      echo "[WARN] Stable repository modify lost the repository-version race, retrying"
+      sleep $((modify_attempt * 15))
+    else
+      echo "::error::Stable repository modify failed"
+      exit 1
+    fi
+  done
+fi
+
+# record the promoted packages (with their stable suite coordinates) so the
+# verification step verifies exactly this set against the stable suite
+while read -r PACKAGE; do
+  manifest_add "$(echo "$PACKAGE" | jq -c \
+    --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
+    --arg suite "$STABLE_SUITE" \
+    '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
+done < <(echo "$PACKAGES" | jq -c '.[]')
+
+ensure_legacy_suite_associations
+echo "[INFO] Publishing repository $STABLE_REPOSITORY_NAME"
+create_publication deb "$STABLE_REPOSITORY_NAME" --structured
+
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+# stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
+# now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
+declare -A ARCH_CONTENT
+declare -A ARCH_RESULTS
+TOTAL_PACKAGES_COUNT=0
+
+for ARCH in noarch x86_64; do
+  TESTING_REPOSITORY_NAME="$TESTING_REPOSITORY_PREFIX-$ARCH"
+
+  if ! pulp_resource_exists "repositories/rpm/rpm" "$TESTING_REPOSITORY_NAME"; then
+    echo "[INFO] Testing repository $TESTING_REPOSITORY_NAME does not exist"
+    continue
+  fi
+
+  VERSION_HREF=$(pulp rpm repository show --name "$TESTING_REPOSITORY_NAME" | jq -r '.latest_version_href')
+
+  # paginate: the testing repository keeps every delivered version, so the
+  # module listing can exceed a single page
+  RESULTS_FILE=$(mktemp)
+  url="$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/?$(
+    printf 'repository_version=%s&pulp_label_select=%s&limit=1000' \
+      "$(jq -rn --arg v "$VERSION_HREF" '$v | @uri')" \
+      "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
+  )"
+  while [[ -n "$url" ]]; do
+    refresh_pulp_token
+    page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url")
+    echo "$page" | jq -c '.results[]' >> "$RESULTS_FILE"
+    url=$(echo "$page" | jq -r '.next // empty')
+  done
+
+  # only the LATEST build of each package is promoted; compare version/release
+  # segment by segment (numeric as numbers) since a plain string max ranks "0.9" above "0.10"
+  RESULTS=$(jq -s 'def vkey: [scan("[0-9]+|[^0-9]+") | (tonumber? // .)];
+    [.[] | {pulp_href, name, version, release, arch, location_href, sha256}]
+    | group_by(.name, .arch) | map(max_by([(.version | vkey), (.release | vkey)]))' "$RESULTS_FILE")
+  rm -f "$RESULTS_FILE"
+  CONTENT=$(echo "$RESULTS" | jq '[.[].pulp_href]')
+  ARCH_PACKAGES_COUNT=$(echo "$CONTENT" | jq 'length')
+
+  echo "[INFO] $ARCH_PACKAGES_COUNT $ARCH packages of module $MODULE_NAME found in $TESTING_REPOSITORY_NAME"
+  ARCH_CONTENT[$ARCH]="$CONTENT"
+  ARCH_RESULTS[$ARCH]="$RESULTS"
+  TOTAL_PACKAGES_COUNT=$((TOTAL_PACKAGES_COUNT + ARCH_PACKAGES_COUNT))
+done
+
+if [[ "$TOTAL_PACKAGES_COUNT" -eq 0 ]]; then
+  echo "::error::Nothing to promote, no package of module $MODULE_NAME found in $TESTING_REPOSITORY_PREFIX repositories"
+  exit 1
+fi
+
+if [[ "$STABILITY" != "stable" ]]; then
+  echo "[INFO] Dry run, $TOTAL_PACKAGES_COUNT packages would be promoted to $STABLE_REPOSITORY_PREFIX repositories"
+  exit 0
+fi
+
+# everything from here on targets the stable-tier domain
+refresh_pulp_token
+switch_pulp_domain "$PULP_STABLE_DOMAIN"
+
+for ARCH in noarch x86_64; do
+  CONTENT="${ARCH_CONTENT[$ARCH]:-[]}"
+  RESULTS="${ARCH_RESULTS[$ARCH]:-[]}"
+  ARCH_PACKAGES_COUNT=$(echo "$CONTENT" | jq 'length')
+
+  if [[ "$ARCH_PACKAGES_COUNT" -eq 0 ]]; then
+    echo "[INFO] No $ARCH package to promote"
+    continue
+  fi
+
+  STABLE_REPOSITORY_NAME="$STABLE_REPOSITORY_PREFIX-$ARCH"
+  STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
+  LEGACY_STABLE_BASE_PATH=""
+  [[ -n "$LEGACY_STABLE_BASE_PATH_PREFIX" ]] && LEGACY_STABLE_BASE_PATH="$LEGACY_STABLE_BASE_PATH_PREFIX/$ARCH"
+
+  if ! pulp_resource_exists "repositories/rpm/rpm" "$STABLE_REPOSITORY_NAME"; then
+    echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
+    exit 1
+  fi
+
+  if ! pulp_resource_exists "distributions/rpm/rpm" "$STABLE_REPOSITORY_NAME"; then
+    echo "::error::stable rpm distribution $STABLE_REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting. Refusing to create it here to avoid an unguarded distribution."
+    exit 1
+  fi
+
+  STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
+
+  # Same-domain promotion: testing and stable share their domain, so the
+  # testing content hrefs (already collected above) are associated with the
+  # stable repository directly — no re-download/re-upload, the packages keep
+  # their delivery-time labels (check-rpm.sh only needs "module").
+  echo "[INFO] Promoting $ARCH_PACKAGES_COUNT packages to $STABLE_REPOSITORY_NAME"
+  # pulp-cli repository content modify does not resolve content by pulp_href, use the api directly
+  ADD_BODY_FILE=$(mktemp)
+  echo "$CONTENT" | jq -c '{add_content_units: .}' > "$ADD_BODY_FILE"
+  # retried like the deb path: concurrent promotions can race on the repository version
+  for modify_attempt in 1 2 3; do
+    TASK_HREF=$(start_modify_task "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
+    wait_task_race "$TASK_HREF" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      break
+    elif [[ $rc -eq 2 && $modify_attempt -lt 3 ]]; then
+      echo "[WARN] Stable repository modify was interrupted server-side, retrying"
+      sleep $((modify_attempt * 15))
+    else
+      echo "::error::Stable repository modify failed"
+      exit 1
+    fi
+  done
+
+  echo "[INFO] Publishing repository $STABLE_REPOSITORY_NAME"
+  create_publication rpm "$STABLE_REPOSITORY_NAME"
+
+  # record the promoted packages (with their stable target coordinates) so the
+  # verification step verifies exactly this set against the stable repo
+  while read -r PKG; do
+    manifest_add "$(echo "$PKG" | jq -c \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
+      '{filename: (.location_href | sub(".*/"; "")), name, version, release, arch, sha256, repository: $repository, base_path: $base_path}')"
+  done < <(echo "${ARCH_RESULTS[$ARCH]}" | jq -c '.[]')
+
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/"
+done
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -1,0 +1,153 @@
+name: "pulp-repository-properties"
+description: "Compute pulp repository names, base paths and suites of a package delivery"
+inputs:
+  module_name:
+    description: "The package module name"
+    required: true
+  distrib:
+    description: "The distribution used for packaging"
+    required: true
+  version:
+    description: "Centreon packaged major version (not used by the plugins repository family)"
+    required: false
+    default: ""
+  stability:
+    description: "The package stability (stable, testing, unstable)"
+    required: true
+  release_type:
+    description: "Type of release (hotfix, release)"
+    required: false
+    default: ""
+  is_cloud:
+    description: "Release context (cloud or not cloud)"
+    required: true
+  delivery_type:
+    description: "Delivery to feature or standard repository"
+    required: false
+    default: "standard"
+  repository_name:
+    description: "Target repository family: standard, standard-internal, business, business-internal or plugins"
+    required: false
+    default: "standard"
+outputs:
+  package_extension:
+    description: "Package extension according to the distribution"
+    value: ${{ steps.parse-distrib.outputs.package_extension }}
+  distrib_family:
+    description: "Distrib family (el, debian, ubuntu)"
+    value: ${{ steps.parse-distrib.outputs.distrib_family }}
+  package_distrib_name:
+    description: "Distribution suffix in package name"
+    value: ${{ steps.parse-distrib.outputs.package_distrib_name }}
+  skip_delivery:
+    description: "Whether the delivery must be skipped"
+    value: ${{ steps.properties.outputs.skip_delivery }}
+  repository_prefix:
+    description: "Repository name prefix of rpm repositories (one repository per architecture)"
+    value: ${{ steps.properties.outputs.repository_prefix }}
+  base_path_prefix:
+    description: "Base path prefix of rpm distributions (one distribution per architecture)"
+    value: ${{ steps.properties.outputs.base_path_prefix }}
+  legacy_base_path_prefix:
+    description: "Legacy (front) rpm base path prefix, used by the content verifications"
+    value: ${{ steps.properties.outputs.legacy_base_path_prefix }}
+  legacy_testing_base_path_prefix:
+    description: "Legacy (front) testing rpm base path prefix"
+    value: ${{ steps.properties.outputs.legacy_testing_base_path_prefix }}
+  legacy_stable_base_path_prefix:
+    description: "Legacy (front) stable rpm base path prefix"
+    value: ${{ steps.properties.outputs.legacy_stable_base_path_prefix }}
+  repository_name:
+    description: "Repository name of the deb repository"
+    value: ${{ steps.properties.outputs.repository_name }}
+  base_path:
+    description: "Base path of the deb distribution"
+    value: ${{ steps.properties.outputs.base_path }}
+  legacy_base_path:
+    description: "Legacy (front) deb base path, used by the content verifications"
+    value: ${{ steps.properties.outputs.legacy_base_path }}
+  legacy_testing_base_path:
+    description: "Legacy (front) testing deb base path"
+    value: ${{ steps.properties.outputs.legacy_testing_base_path }}
+  legacy_stable_base_path:
+    description: "Legacy (front) stable deb base path"
+    value: ${{ steps.properties.outputs.legacy_stable_base_path }}
+  suite:
+    description: "Apt suite of the deb delivery"
+    value: ${{ steps.properties.outputs.suite }}
+  testing_repository_prefix:
+    description: "Repository name prefix of testing rpm repositories, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_repository_prefix }}
+  testing_base_path_prefix:
+    description: "Base path prefix of testing rpm distributions, used to download promotion source content"
+    value: ${{ steps.properties.outputs.testing_base_path_prefix }}
+  stable_repository_prefix:
+    description: "Repository name prefix of stable rpm repositories"
+    value: ${{ steps.properties.outputs.stable_repository_prefix }}
+  stable_base_path_prefix:
+    description: "Base path prefix of stable rpm distributions"
+    value: ${{ steps.properties.outputs.stable_base_path_prefix }}
+  testing_repository_name:
+    description: "Repository name of the testing deb repository, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_repository_name }}
+  testing_base_path:
+    description: "Base path of the testing deb distribution, used to download promotion source content"
+    value: ${{ steps.properties.outputs.testing_base_path }}
+  testing_suite:
+    description: "Apt suite of testing deb packages"
+    value: ${{ steps.properties.outputs.testing_suite }}
+  stable_suite:
+    description: "Apt suite of stable deb packages"
+    value: ${{ steps.properties.outputs.stable_suite }}
+  stable_legacy_suite:
+    description: "Plain-codename suite of the dedicated 24.x stable legacy repositories (empty otherwise)"
+    value: ${{ steps.properties.outputs.stable_legacy_suite }}
+  stable_legacy_repository_name:
+    description: "Dedicated 24.x stable legacy repository fed by the promote mirror (empty otherwise)"
+    value: ${{ steps.properties.outputs.stable_legacy_repository_name }}
+  stable_repository_name:
+    description: "Repository holding the stable deb packages (one deb repository per stability)"
+    value: ${{ steps.properties.outputs.stable_repository_name }}
+  stable_base_path:
+    description: "Base path serving the stable packages"
+    value: ${{ steps.properties.outputs.stable_base_path }}
+  pool_path:
+    description: "Module scoped pool path of the deb delivery"
+    value: ${{ steps.properties.outputs.pool_path }}
+  testing_pool_path:
+    description: "Module scoped pool path of testing deb packages, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_pool_path }}
+  stable_pool_path:
+    description: "Module scoped pool path of stable deb packages"
+    value: ${{ steps.properties.outputs.stable_pool_path }}
+  domain:
+    description: "Pulp Domain of the delivery (testing/unstable tier) repository"
+    value: ${{ steps.properties.outputs.domain }}
+  stable_domain:
+    description: "Pulp Domain of the stable-tier repository"
+    value: ${{ steps.properties.outputs.stable_domain }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse distrib name
+      id: parse-distrib
+      uses: ./.github/actions/parse-distrib
+      with:
+        distrib: ${{ inputs.distrib }}
+
+    - name: Compute pulp repository properties
+      id: properties
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        DISTRIB_FAMILY: ${{ steps.parse-distrib.outputs.distrib_family }}
+        VERSION: ${{ inputs.version }}
+        STABILITY: ${{ inputs.stability }}
+        RELEASE_TYPE: ${{ inputs.release_type }}
+        IS_CLOUD: ${{ inputs.is_cloud }}
+        DELIVERY_TYPE: ${{ inputs.delivery_type }}
+        REPOSITORY_TYPE: ${{ inputs.repository_name }}
+        GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      run: ${{ github.action_path }}/properties.sh

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "$MODULE_NAME" || -z "$DISTRIB" || -z "$STABILITY" || -z "$IS_CLOUD" ]]; then
+  echo "::error::some mandatory inputs are empty, please check the logs."
+  exit 1
+fi
+
+# repository_name selects the standard (open-source), business (paid) or plugins
+# repository family. standard/business have "-internal" variants: either a cloud
+# context (is_cloud) or an explicit "-internal" suffix means the internal repo.
+# plugins repositories are not versioned (packages carry their own date-based
+# versioning), so the version input is only required for the other families.
+REPOSITORY_TYPE="${REPOSITORY_TYPE:-standard}"
+case "$REPOSITORY_TYPE" in
+  standard | standard-internal) REPO_BASE="standard" ;;
+  business | business-internal) REPO_BASE="business" ;;
+  plugins) REPO_BASE="plugins" ;;
+  *)
+    echo "::error::Unsupported repository_name: $REPOSITORY_TYPE"
+    exit 1
+    ;;
+esac
+
+if [[ "$REPO_BASE" != "plugins" && -z "$VERSION" ]]; then
+  echo "::error::version input is mandatory for the $REPOSITORY_TYPE repository family."
+  exit 1
+fi
+
+# parse-distrib emits the el family either generically ("el") or per version
+# ("el7"/"el8"/"el9"/"el10" on centreon-collect); normalize it to "el" so the
+# family checks below are portable across both conventions.
+DEB_PREFIX=""
+case "$DISTRIB_FAMILY" in
+  el | el[0-9]*)
+    DISTRIB_FAMILY="el"
+    ;;
+  debian) DEB_PREFIX="apt-" ;;
+  ubuntu) DEB_PREFIX="ubuntu-" ;;
+  *)
+    echo "::error::Unsupported distribution family: $DISTRIB_FAMILY"
+    exit 1
+    ;;
+esac
+
+# uniform stability segments across every edition (plugins included):
+# unstable, testing-release, testing-hotfix, stable
+TESTING_SEGMENT="testing"
+TESTING_POOL_SEGMENT="testing"
+if [[ "$RELEASE_TYPE" == "release" || "$RELEASE_TYPE" == "hotfix" ]]; then
+  TESTING_SEGMENT="testing-$RELEASE_TYPE"
+  TESTING_POOL_SEGMENT="testing/$RELEASE_TYPE"
+fi
+
+STABILITY_SEGMENT="$STABILITY"
+POOL_SEGMENT="$STABILITY"
+if [[ "$STABILITY" == "testing" ]]; then
+  STABILITY_SEGMENT="$TESTING_SEGMENT"
+  POOL_SEGMENT="$TESTING_POOL_SEGMENT"
+fi
+
+REPOSITORY_PREFIX=""
+BASE_PATH_PREFIX=""
+LEGACY_BASE_PATH_PREFIX=""
+LEGACY_TESTING_BASE_PATH_PREFIX=""
+LEGACY_STABLE_BASE_PATH_PREFIX=""
+LEGACY_BASE_PATH=""
+LEGACY_TESTING_BASE_PATH=""
+LEGACY_STABLE_BASE_PATH=""
+TESTING_REPOSITORY_PREFIX=""
+TESTING_BASE_PATH_PREFIX=""
+STABLE_REPOSITORY_PREFIX=""
+STABLE_BASE_PATH_PREFIX=""
+REPOSITORY_NAME=""
+BASE_PATH=""
+SUITE=""
+TESTING_REPOSITORY_NAME=""
+TESTING_BASE_PATH=""
+TESTING_SUITE=""
+STABLE_SUITE=""
+STABLE_LEGACY_SUITE=""
+STABLE_LEGACY_REPOSITORY_NAME=""
+POOL_PATH=""
+TESTING_POOL_PATH=""
+STABLE_POOL_PATH=""
+
+if [[ "$REPO_BASE" == "plugins" ]]; then
+  # plugins repositories are not versioned: rpm paths carry no version segment
+  # and deb suites are the plain distribution codename.
+  if [[ "$DELIVERY_TYPE" == "feature" ]]; then
+    echo "::notice::Feature delivery is not supported for plugins packages, skipping delivery."
+    echo "skip_delivery=true" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+
+  if [[ "$DISTRIB_FAMILY" == "el" ]]; then
+    REPOSITORY_PREFIX="rpm-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="rpm/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="rpm-$DISTRIB-$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="rpm/$DISTRIB/$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="rpm-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="rpm/$DISTRIB/stable"
+    LEGACY_SEGMENT_RPM="$STABILITY_SEGMENT"
+    [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT_RPM="testing"
+    LEGACY_TESTING_SEGMENT_RPM="$TESTING_SEGMENT"
+    [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT_RPM="testing"
+    LEGACY_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/$LEGACY_SEGMENT_RPM"
+    LEGACY_TESTING_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/$LEGACY_TESTING_SEGMENT_RPM"
+    LEGACY_STABLE_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/stable"
+  else
+    # one deb repository per stability (base path = repository name), suites
+    # carry the plain codename only
+    REPOSITORY_NAME="${DEB_PREFIX}${STABILITY_SEGMENT}"
+    BASE_PATH="$REPOSITORY_NAME"
+    # historical layout: one repository per stability with plain-codename
+    # suites; the legacy stability (bare "testing") lives in the front prefix
+    LEGACY_SEGMENT="$STABILITY_SEGMENT"
+    [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT="testing"
+    LEGACY_TESTING_SEGMENT="$TESTING_SEGMENT"
+    [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT="testing"
+    SUITE="$DISTRIB"
+    TESTING_REPOSITORY_NAME="${DEB_PREFIX}${TESTING_SEGMENT}"
+    TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
+    TESTING_SUITE="$DISTRIB"
+    STABLE_REPOSITORY_NAME="${DEB_PREFIX}stable"
+    STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
+    STABLE_SUITE="$DISTRIB"
+    # legacy (front) paths used by the content verifications: the CI exercises
+    # the compatibility rewrites on every delivery
+    LEGACY_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-${LEGACY_SEGMENT}"
+    LEGACY_TESTING_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-${LEGACY_TESTING_SEGMENT}"
+    LEGACY_STABLE_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-stable"
+    POOL_PATH="pool/$POOL_SEGMENT/$MODULE_NAME"
+    TESTING_POOL_PATH="pool/$TESTING_POOL_SEGMENT/$MODULE_NAME"
+    STABLE_POOL_PATH="pool/stable/$MODULE_NAME"
+  fi
+elif [[ "$DELIVERY_TYPE" == "feature" ]]; then
+  if [[ "$DISTRIB_FAMILY" != "el" ]]; then
+    echo "::notice::Feature delivery is not supported for $DISTRIB_FAMILY packages, skipping delivery."
+    echo "skip_delivery=true" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+
+  FEATURE_TICKET=$(echo "$GH_HEAD_REF" | grep -oE 'MON-[0-9]+' | head -1 || true)
+  if [[ -z "$FEATURE_TICKET" ]]; then
+    echo "::error::Cannot extract the feature ticket from branch name $GH_HEAD_REF"
+    exit 1
+  fi
+
+  REPOSITORY_PREFIX="rpm-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
+  BASE_PATH_PREFIX="rpm-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  LEGACY_BASE_PATH_PREFIX="rpm-$REPO_BASE-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+else
+  RPM_ROOT="rpm"
+  DEB_INFIX=""
+  if [[ "$IS_CLOUD" == "true" || "$REPOSITORY_TYPE" == *-internal ]]; then
+    RPM_ROOT="rpm-internal"
+    DEB_INFIX="internal-"
+  fi
+
+  if [[ "$DISTRIB_FAMILY" == "el" ]]; then
+    REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/stable"
+    # legacy (front) paths used by the content verifications (the front also
+    # accepts the historical token'd business form)
+    LEGACY_RPM_ROOT="rpm-$REPO_BASE"
+    [[ "$RPM_ROOT" == "rpm-internal" ]] && LEGACY_RPM_ROOT="rpm-$REPO_BASE-internal"
+    LEGACY_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    LEGACY_TESTING_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    LEGACY_STABLE_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/stable"
+  else
+    # one deb repository per stability (base path = repository name), shared by
+    # every major version: the version lives in the suite name only
+    # (e.g. "trixie-26.09")
+    REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${STABILITY_SEGMENT}"
+    BASE_PATH="$REPOSITORY_NAME"
+    # suites keep their historical stability-suffixed names so the legacy
+    # client lines (deb .../apt-standard/ trixie-26.10-stable main) work
+    # through the content-front rewrites; each suite lives in its own
+    # per-stability repository regardless
+    SUITE="$DISTRIB-$VERSION-$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${TESTING_SEGMENT}"
+    TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
+    TESTING_SUITE="$DISTRIB-$VERSION-$TESTING_SEGMENT"
+    STABLE_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}stable"
+    STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
+    STABLE_SUITE="$DISTRIB-$VERSION-stable"
+    # 24.x clients use dedicated legacy stable repositories with plain-codename
+    # suites (apt|ubuntu-standard-<major>-stable, apt-<major>-business-stable):
+    # the promote mirrors its package associations into them
+    if [[ -z "$DEB_INFIX" && ( "$VERSION" == "24.04" || "$VERSION" == "24.10" ) ]]; then
+      if [[ "$REPO_BASE" == "standard" ]]; then
+        STABLE_LEGACY_REPOSITORY_NAME="${DEB_PREFIX}standard-$VERSION-stable"
+        STABLE_LEGACY_SUITE="$DISTRIB"
+      elif [[ "$REPO_BASE" == "business" && "$DEB_PREFIX" == "apt-" ]]; then
+        STABLE_LEGACY_REPOSITORY_NAME="apt-$VERSION-business-stable"
+        STABLE_LEGACY_SUITE="$DISTRIB"
+      fi
+    fi
+    LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}"
+    [[ -n "$DEB_INFIX" ]] && LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}-internal"
+    LEGACY_BASE_PATH="$LEGACY_DEB_ROOT"
+    LEGACY_TESTING_BASE_PATH="$LEGACY_DEB_ROOT"
+    LEGACY_STABLE_BASE_PATH="$LEGACY_DEB_ROOT"
+    POOL_PATH="pool/$VERSION/$POOL_SEGMENT/$MODULE_NAME"
+    TESTING_POOL_PATH="pool/$VERSION/$TESTING_POOL_SEGMENT/$MODULE_NAME"
+    STABLE_POOL_PATH="pool/$VERSION/stable/$MODULE_NAME"
+  fi
+fi
+
+# unless a dedicated stable repository was selected above, stable shares the
+# delivery repository (rpm resolves stable through the *_PREFIX variables)
+STABLE_REPOSITORY_NAME="${STABLE_REPOSITORY_NAME:-$REPOSITORY_NAME}"
+STABLE_BASE_PATH="${STABLE_BASE_PATH:-$BASE_PATH}"
+
+# one Pulp Domain per edition; stable and non-stable repositories share it
+# ("-internal"/cloud repos too). The stable/non-stable write boundary is the
+# repository name, enforced server-side by name-scoped grants. stable_domain
+# is kept as a distinct output for the scripts that address the stable tier,
+# even though it now always equals domain.
+DOMAIN="$REPO_BASE"
+STABLE_DOMAIN="$DOMAIN"
+
+echo "[DEBUG] - repository_type: $REPOSITORY_TYPE"
+echo "[DEBUG] - repository_prefix: $REPOSITORY_PREFIX"
+echo "[DEBUG] - base_path_prefix: $BASE_PATH_PREFIX"
+echo "[DEBUG] - testing_repository_prefix: $TESTING_REPOSITORY_PREFIX"
+echo "[DEBUG] - testing_base_path_prefix: $TESTING_BASE_PATH_PREFIX"
+echo "[DEBUG] - stable_repository_prefix: $STABLE_REPOSITORY_PREFIX"
+echo "[DEBUG] - stable_base_path_prefix: $STABLE_BASE_PATH_PREFIX"
+echo "[DEBUG] - repository_name: $REPOSITORY_NAME"
+echo "[DEBUG] - base_path: $BASE_PATH"
+echo "[DEBUG] - suite: $SUITE"
+echo "[DEBUG] - testing_repository_name: $TESTING_REPOSITORY_NAME"
+echo "[DEBUG] - testing_base_path: $TESTING_BASE_PATH"
+echo "[DEBUG] - testing_suite: $TESTING_SUITE"
+echo "[DEBUG] - stable_suite: $STABLE_SUITE"
+echo "[DEBUG] - pool_path: $POOL_PATH"
+echo "[DEBUG] - testing_pool_path: $TESTING_POOL_PATH"
+echo "[DEBUG] - stable_pool_path: $STABLE_POOL_PATH"
+echo "[DEBUG] - domain: $DOMAIN"
+echo "[DEBUG] - stable_domain: $STABLE_DOMAIN"
+
+{
+  echo "skip_delivery=false"
+  echo "repository_prefix=$REPOSITORY_PREFIX"
+  echo "base_path_prefix=$BASE_PATH_PREFIX"
+  echo "legacy_base_path_prefix=$LEGACY_BASE_PATH_PREFIX"
+  echo "legacy_testing_base_path_prefix=$LEGACY_TESTING_BASE_PATH_PREFIX"
+  echo "legacy_stable_base_path_prefix=$LEGACY_STABLE_BASE_PATH_PREFIX"
+  echo "testing_repository_prefix=$TESTING_REPOSITORY_PREFIX"
+  echo "testing_base_path_prefix=$TESTING_BASE_PATH_PREFIX"
+  echo "stable_repository_prefix=$STABLE_REPOSITORY_PREFIX"
+  echo "stable_base_path_prefix=$STABLE_BASE_PATH_PREFIX"
+  echo "repository_name=$REPOSITORY_NAME"
+  echo "base_path=$BASE_PATH"
+  echo "legacy_base_path=$LEGACY_BASE_PATH"
+  echo "legacy_testing_base_path=$LEGACY_TESTING_BASE_PATH"
+  echo "legacy_stable_base_path=$LEGACY_STABLE_BASE_PATH"
+  echo "suite=$SUITE"
+  echo "testing_repository_name=$TESTING_REPOSITORY_NAME"
+  echo "testing_base_path=$TESTING_BASE_PATH"
+  echo "testing_suite=$TESTING_SUITE"
+  echo "stable_suite=$STABLE_SUITE"
+  echo "stable_legacy_suite=$STABLE_LEGACY_SUITE"
+  echo "stable_legacy_repository_name=$STABLE_LEGACY_REPOSITORY_NAME"
+  echo "stable_repository_name=$STABLE_REPOSITORY_NAME"
+  echo "stable_base_path=$STABLE_BASE_PATH"
+  echo "pool_path=$POOL_PATH"
+  echo "testing_pool_path=$TESTING_POOL_PATH"
+  echo "stable_pool_path=$STABLE_POOL_PATH"
+  echo "domain=$DOMAIN"
+  echo "stable_domain=$STABLE_DOMAIN"
+} >> "$GITHUB_OUTPUT"

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -70,29 +70,25 @@ runs:
               --arg major_version "$major_version" \
               --arg repo_type "feature" \
               --arg feature_ticket "$feature_ticket" \
+              --arg target "jfrog" \
               '{
                 event_type: "create-feature-repositories",
                 client_payload: {
                   major_version: $major_version,
                   repo_type: $repo_type,
-                  feature_ticket: $feature_ticket
+                  feature_ticket: $feature_ticket,
+                  target: $target
                 }
               }'
             )"
 
-        response=""
         attempt=0
-        until [[ $(echo "$response" | tr -d '\n' | tail -c 3) -eq 200 || $attempt -ge 40 ]]; do
+        count=$(jf rt search rpm-standard-feature/$feature_ticket/$major_version/*.repo 2>/dev/null | jq '. | length' 2>/dev/null || echo "0")
+        until [[ $count -eq 3 || $attempt -ge 40 ]]; do
           attempt=$((attempt+1))
-          echo "[INFO] Checking is the feature repository has been created... [ATTEMPT $attempt]"
-          response=$(curl \
-            --write-out "%{http_code}" \
-            --request GET \
-            --url "${{ env.JF_URL }}/artifactory/api/v2/repositories/rpm-standard-feature-$feature_ticket" \
-            --header "Authorization: Bearer ${{ env.JF_ACCESS_TOKEN }}" \
-            --header "Content-Type: application/json"
-          )
+          echo "[INFO] Checking if the feature repository has been created... [ATTEMPT $attempt]"
           sleep 15
+          count=$(jf rt search rpm-standard-feature/$feature_ticket/$major_version/*.repo 2>/dev/null | jq '. | length' 2>/dev/null || echo "0")
         done
 
         if [[ $attempt -ge 40 ]]; then
@@ -163,7 +159,7 @@ runs:
         done
 
         if [[ "$DELIVERY_TYPE" == "feature" ]]; then
-          ROOT_REPO_PATH="rpm-standard-feature-$(echo "$GH_HEAD_REF" | grep -oP '^.*MON-[0-9]+')"
+          ROOT_REPO_PATH="rpm-standard-feature/$(echo "$GH_HEAD_REF" | grep -oP '^.*MON-[0-9]+')"
         elif [[ "$IS_CLOUD" == "true" ]]; then
           ROOT_REPO_PATH="rpm-standard-internal"
         else

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -1,0 +1,115 @@
+name: "setup-pulp-cli"
+description: "Install pulp-cli and authenticate to pulp with a GitHub OIDC token"
+inputs:
+  pulp_url:
+    description: "The pulp server api url"
+    required: true
+  audience:
+    description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: true
+  domain:
+    description: "Pulp Domain to operate in (DOMAIN_ENABLED). Pre-Domains repositories live in \"default\"."
+    required: false
+    default: "default"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.12"
+
+    - name: Install pulp-cli
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if ! command -v pulp >/dev/null 2>&1; then
+          echo "[INFO] Installing pulp-cli"
+          pip install --quiet "pulp-cli==0.37.1" "pulp-cli-deb==0.4.3"
+        fi
+
+    - name: Request a GitHub OIDC token for pulp
+      shell: bash
+      env:
+        AUDIENCE: ${{ inputs.audience }}
+      run: |
+        set -euo pipefail
+
+        # an unset org variable is forwarded as "": fail loudly rather than
+        # falling back to a default audience, a token minted for the wrong
+        # audience must never be silently requested against another server
+        if [[ -z "$AUDIENCE" ]]; then
+          echo "::error::audience input is empty (is the PULP_OIDC_AUDIENCE org variable defined?)"
+          exit 1
+        fi
+
+        # the job must grant id-token write permission for these to be set
+        if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+          echo "::error::Missing OIDC token request context, the job needs 'permissions: id-token: write'"
+          exit 1
+        fi
+
+        # retry on transient GitHub OIDC token service errors (5xx/timeouts):
+        # the endpoint occasionally returns 503, and a single blip must not break
+        # the whole delivery.
+        PULP_TOKEN=$(
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            -G --data-urlencode "audience=$AUDIENCE" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value'
+        )
+        if [[ -z "$PULP_TOKEN" || "$PULP_TOKEN" == "null" ]]; then
+          echo "::error::Could not obtain a GitHub OIDC token"
+          exit 1
+        fi
+
+        # keep the token out of any log and expose it to the next steps.
+        # the issuance time and audience let the api helpers refresh the token
+        # mid-delivery: github oidc tokens expire ~5 minutes after issuance,
+        # which is shorter than a large delivery.
+        echo "::add-mask::$PULP_TOKEN"
+        {
+          echo "PULP_TOKEN=$PULP_TOKEN"
+          echo "PULP_TOKEN_ISSUED_AT=$(date +%s)"
+          echo "PULP_OIDC_AUDIENCE=$AUDIENCE"
+        } >> "$GITHUB_ENV"
+
+    - name: Configure pulp-cli
+      shell: bash
+      env:
+        PULP_URL: ${{ inputs.pulp_url }}
+        DOMAIN: ${{ inputs.domain }}
+      run: |
+        set -euo pipefail
+
+        # fall back to the default when the caller passes an empty value (unset
+        # org variable forwarded as "" would otherwise override the default).
+        PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+        DOMAIN="${DOMAIN:-default}"
+
+        # keep the pulp-cli config (which stores the OIDC token) under the per-job
+        # RUNNER_TEMP rather than the runner's persistent ~/.config, and share the
+        # location with the later steps, so a self-hosted runner does not retain
+        # the token in a home reused across jobs.
+        export XDG_CONFIG_HOME="${RUNNER_TEMP:-/tmp}/pulp-cli-config"
+        mkdir -p "$XDG_CONFIG_HOME"
+        echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" >> "$GITHUB_ENV"
+
+        # WorkloadIdentityAuthentication reads a Bearer token, no username/password
+        # pulp-cli splits --header on the first colon and keeps the value
+        # verbatim, so no space after the colon (rejected as leading whitespace)
+        pulp config create --overwrite \
+          --base-url "$PULP_URL" \
+          --api-root "/" \
+          --domain "$DOMAIN" \
+          --header "Authorization:Bearer $PULP_TOKEN" \
+          --timeout 0
+
+        # fail fast on connectivity issues, scripts cannot distinguish
+        # a missing resource from an unreachable server otherwise
+        if ! pulp status >/dev/null; then
+          echo "::error::Pulp server $PULP_URL is not reachable"
+          exit 1
+        fi

--- a/.github/scripts/pulp/api.sh
+++ b/.github/scripts/pulp/api.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Shared pulp api helpers for the delivery/promotion scripts. Source this file
+# like manifest.sh; PULP_URL and PULP_TOKEN must be set by the caller.
+#
+# DOMAIN_ENABLED requires every viewset URL to carry a domain segment, no
+# unprefixed fallback; every domain-scoped REST call in this file is prefixed with "/$PULP_DOMAIN"
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+
+# forces pulp-cli's config to update immediately, unlike a plain PULP_DOMAIN
+# reassignment: refresh_pulp_token only re-runs "pulp config create" once the
+# token itself goes stale (>240s), which could leave pulp-cli on the old domain that long
+switch_pulp_domain() {
+  PULP_DOMAIN="$1"
+  if command -v pulp >/dev/null 2>&1; then
+    if ! pulp config create --overwrite --base-url "$PULP_URL" --api-root "/" \
+      --domain "$PULP_DOMAIN" \
+      --header "Authorization:Bearer $PULP_TOKEN" --timeout 0 >/dev/null 2>&1; then
+      echo "::error::Cannot switch the pulp-cli profile to domain $PULP_DOMAIN" >&2
+      return 1
+    fi
+  fi
+}
+
+# the github actions oidc token expires ~5 minutes after issuance, which is
+# shorter than a large delivery: refresh it before it goes stale whenever the
+# job can mint tokens (id-token: write context + audience exported by
+# setup-pulp-cli). The fresh token is propagated to the following steps
+# (GITHUB_ENV) and to the pulp-cli config so the pulp commands keep working.
+refresh_pulp_token() {
+  local now token
+  now=$(date +%s)
+  if ((now - ${PULP_TOKEN_ISSUED_AT:-0} < 240)); then
+    return 0
+  fi
+  if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" || -z "${PULP_OIDC_AUDIENCE:-}" ]]; then
+    return 0
+  fi
+  token=$(
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+      -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+      -G --data-urlencode "audience=$PULP_OIDC_AUDIENCE" \
+      "$ACTIONS_ID_TOKEN_REQUEST_URL" 2>/dev/null | jq -r '.value' 2>/dev/null
+  ) || token=""
+  if [[ -z "$token" || "$token" == "null" ]]; then
+    return 0
+  fi
+  PULP_TOKEN="$token"
+  PULP_TOKEN_ISSUED_AT="$now"
+  # written to stderr: this function also runs inside command substitutions
+  # (pulp_upload), where a stdout echo would corrupt the captured output
+  echo "::add-mask::$token" >&2
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    {
+      echo "PULP_TOKEN=$token"
+      echo "PULP_TOKEN_ISSUED_AT=$now"
+    } >> "$GITHUB_ENV"
+  fi
+  if command -v pulp >/dev/null 2>&1; then
+    pulp config create --overwrite --base-url "$PULP_URL" --api-root "/" \
+      --domain "$PULP_DOMAIN" \
+      --header "Authorization:Bearer $token" --timeout 0 >/dev/null 2>&1 || true
+  fi
+}
+
+# wait for a pulp api task to complete. a failed poll request (network blip,
+# api 5xx) is retried like an unexpected state instead of aborting the caller
+# under set -e; the 600-attempt cap bounds the total wait (~30 min): under a
+# full-matrix delivery the publication of a large repository can sit several
+# minutes in the worker queue before its ~5 min of actual execution.
+wait_task() {
+  local task_href=$1
+  local state attempt
+  for ((attempt = 0; attempt < 600; attempt++)); do
+    refresh_pulp_token
+    state=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null | jq -r '.state' 2>/dev/null) || state=""
+    case "$state" in
+      completed)
+        return 0
+        ;;
+      failed|canceled)
+        echo "::error::Task $task_href $state: $(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" | jq -c '.error')"
+        return 1
+        ;;
+      *)
+        sleep 3
+        ;;
+    esac
+  done
+  echo "::error::Task $task_href did not complete in time (~30 min)"
+  return 1
+}
+
+# upload a package through the pulp api, with retry on transient failures
+# (concurrent deliveries can race on artifact creation), echoes the task href
+pulp_upload() {
+  local attempt response http_code body
+  for attempt in 1 2 3 4 5; do
+    refresh_pulp_token
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' "$@" 2>/dev/null) || response=""
+    http_code=${response##*$'\n'}
+    body=${response%$'\n'*}
+    if [[ "$http_code" == "202" ]]; then
+      echo "$body" | jq -r '.task'
+      return 0
+    fi
+    echo "[WARN] upload attempt $attempt/5 failed (HTTP ${http_code:-network-error}), retrying..." >&2
+    sleep $((attempt * 5))
+  done
+  echo "::error::Upload failed after 5 attempts (HTTP ${http_code:-network-error})" >&2
+  return 1
+}
+
+# wait for a task, distinguishing a RETRYABLE failure from a genuine one:
+# - lost repository-version race: concurrent legs of a SHARED deb repository
+#   collide on the version bookkeeping (duplicate (repository_id, number)
+#   insert, or the retention cleanup deleting a version another transaction
+#   still references)
+# - "Worker has gone missing": the task worker pod was terminated mid-task
+#   (scale-down, node consolidation)
+# Re-running the operation converges, so callers retry on rc 2.
+# 0=completed, 2=retryable failure, 1=failed or timed out.
+wait_task_race() {
+  local task_href=$1 body state error attempt
+  for ((attempt = 0; attempt < 600; attempt++)); do
+    refresh_pulp_token
+    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
+    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
+    case "$state" in
+      completed)
+        return 0
+        ;;
+      failed | canceled)
+        error=$(echo "$body" | jq -c '.error // empty' 2>/dev/null) || error=""
+        if echo "$error" | grep -qE 'core_repositoryversion|Worker has gone missing'; then
+          return 2
+        fi
+        # the "gone missing" reason lands in a separate field on some tasks
+        if echo "$body" | jq -r '.reason // empty' 2>/dev/null | grep -q 'Worker has gone missing'; then
+          return 2
+        fi
+        echo "::error::Task $task_href $state: $error"
+        return 1
+        ;;
+      *)
+        sleep 3
+        ;;
+    esac
+  done
+  echo "::error::Task $task_href did not complete in time (~30 min)"
+  return 1
+}
+
+# check that a named pulp resource exists through the REST list api,
+# distinguishing a genuine absence from an api failure: a failed "pulp show"
+# reads as "does not exist" and turned an api saturation window into
+# "nothing to promote". 0=exists, 1=absent; an unanswerable api aborts the
+# caller (set -e) after retries: better fail loud than act on a guess.
+# usage: pulp_resource_exists <type_path> <name>   e.g. repositories/deb/apt
+pulp_resource_exists() {
+  local type_path=$1 name=$2 attempt response http_code count
+  for attempt in 1 2 3 4; do
+    refresh_pulp_token
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' -G \
+      --data-urlencode "name=$name" --data-urlencode "limit=1" \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/$type_path/" 2>/dev/null) || response=$'\n000'
+    http_code="${response##*$'\n'}"
+    if [[ "$http_code" == "200" ]]; then
+      count=$(printf '%s' "${response%$'\n'*}" | jq -r '.count' 2>/dev/null) || count=""
+      [[ "$count" == "0" ]] && return 1
+      [[ -n "$count" ]] && return 0
+    fi
+    sleep $((attempt * 5))
+  done
+  echo "::error::Cannot check the existence of $name (HTTP ${http_code:-network-error}); refusing to guess." >&2
+  exit 70
+}
+
+# POST a json body with MANUAL retry on transient gateway failures: curl
+# --retry concatenates the bodies of failed attempts, which corrupts a
+# captured json response (a 502 html page glued before the 201 body). A 500
+# is NOT retried: on this api it means a duplicate synchronous content
+# create, and the caller's lookup fallback is the correct answer.
+# Echoes the final body followed by a newline and the final status code (the
+# function runs inside command substitutions, so it cannot hand the code back
+# through a variable); the manual retry guarantees a single body, making the
+# last-line split safe.
+post_json() {
+  local url=$1 json=$2 attempt response code
+  response=$'\n000'
+  for attempt in 1 2 3 4; do
+    refresh_pulp_token
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' \
+      -X POST -H "Content-Type: application/json" -d "$json" "$url" 2>/dev/null) || response=$'\n000'
+    code="${response##*$'\n'}"
+    case "$code" in
+      2* | 4* | 500) break ;;
+      *) sleep $((attempt * 3)) ;;
+    esac
+  done
+  printf '%s\n%s' "${response%$'\n'*}" "$code"
+}
+
+# start a repository modify task, with retry on transient gateway failures:
+# it is the single most critical call of the flow (all uploaded content lands
+# in the repository through it) and add_content_units is idempotent, so
+# retrying is always safe. Echoes the task href.
+start_modify_task() {
+  local url=$1 body_file=$2 attempt response http_code body
+  for attempt in 1 2 3 4 5; do
+    refresh_pulp_token
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' \
+      -X POST -H "Content-Type: application/json" \
+      -d @"$body_file" "$url" 2>/dev/null) || response=""
+    http_code=${response##*$'\n'}
+    body=${response%$'\n'*}
+    if [[ "$http_code" == "202" ]]; then
+      echo "$body" | jq -r '.task'
+      return 0
+    fi
+    echo "[WARN] modify attempt $attempt/5 on $url failed (HTTP ${http_code:-network-error}), retrying..." >&2
+    sleep $((attempt * 5))
+  done
+  echo "::error::Repository modify failed after 5 attempts on $url (HTTP ${http_code:-network-error}): $(echo "$body" | head -c 300)" >&2
+  return 1
+}
+
+# create a publication in the background and wait for it with re-authenticating
+# polling: pulp-cli reads its token once at startup, so its built-in wait fails
+# with "Authentication failed for tasks_read" as soon as the publication of a
+# large repository outlives the OIDC token validity (~5 minutes)
+# curl against the content endpoint with the CI credentials: the guarded
+# *business-internal distributions authorize the download through the same
+# GitHub OIDC authentication as the api (the CI user holds the guard
+# downloader role); unguarded distributions ignore the header.
+content_curl() {
+  refresh_pulp_token
+  curl -H "Authorization: Bearer $PULP_TOKEN" "$@"
+}
+
+create_publication() {
+  local plugin=$1 repository=$2
+  shift 2
+  # pulp-cli's own task re-poll is domain-unaware and 404s under Domains ("No
+  # Task matches the given query"), so this goes straight through
+  # post_json/wait_task_race instead, both already domain-aware
+  local publication_path
+  case "$plugin" in
+    rpm) publication_path="rpm/rpm" ;;
+    deb) publication_path="deb/apt" ;;
+    *) echo "::error::create_publication: unsupported plugin $plugin" >&2; return 1 ;;
+  esac
+  local repo_href body_json response code body task attempt outer rc
+  # outer retry: the publication task itself can die server-side for
+  # retryable reasons (task worker terminated mid-task, version race)
+  for outer in 1 2 3; do
+    task=""
+    for attempt in 1 2 3; do
+      refresh_pulp_token
+      repo_href=$(pulp "$plugin" repository show --name "$repository" 2>/dev/null | jq -r '.pulp_href // empty') || repo_href=""
+      if [[ -n "$repo_href" ]]; then
+        if [[ "$*" == *"--structured"* ]]; then
+          body_json=$(jq -nc --arg repo "$repo_href" '{repository: $repo, structured: true, simple: false}')
+        else
+          body_json=$(jq -nc --arg repo "$repo_href" '{repository: $repo}')
+        fi
+        response=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/publications/$publication_path/" "$body_json")
+        code="${response##*$'\n'}"
+        body="${response%$'\n'*}"
+        if [[ "$code" == "202" ]]; then
+          task=$(echo "$body" | jq -r '.task // empty')
+          [[ -n "$task" ]] && break
+        fi
+      fi
+      echo "[WARN] publication start attempt $attempt/3 failed for $repository, retrying..." >&2
+      sleep $((attempt * 10))
+    done
+    if [[ -z "$task" ]]; then
+      echo "::error::Cannot start the publication of repository $repository"
+      return 1
+    fi
+    wait_task_race "$task" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      return 0
+    elif [[ $rc -eq 2 && $outer -lt 3 ]]; then
+      echo "[WARN] Publication of $repository was interrupted server-side, retrying"
+      sleep $((outer * 15))
+    else
+      echo "::error::Publication of repository $repository failed"
+      return 1
+    fi
+  done
+}

--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Shared helpers for the pulp delivery/promotion verification scripts
+# (check-rpm.sh, check-deb.sh).
+#
+# The check never aborts mid-verification: every expected package is checked, its
+# per-package result is recorded, the full table is rendered to the step summary,
+# and only then is a non-zero status returned if anything failed. Source this
+# file, call load_expected, verify the packages, then call render_summary.
+
+# authenticated content fetches (content_curl) and token refresh
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "${BASH_SOURCE[0]}")/api.sh"
+
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+
+switch_pulp_domain "$PULP_DOMAIN" || exit 1
+# 900s: the published indexes can lag a finished publication by up to the
+# content-app cache TTL (600s), the window must survive that worst case
+METADATA_TIMEOUT="${METADATA_TIMEOUT:-900}"
+METADATA_INTERVAL="${METADATA_INTERVAL:-15}"
+
+# accumulated per-package result rows and the aggregate failure flag
+ROWS=()
+PRESENT_OK=0
+META_OK=0
+TOTAL=0
+FAILED=0
+
+# load_expected <package_type> — load the manifest emitted by the delivery or
+# promotion step into PACKAGES_JSON/COUNT; the manifest is required.
+load_expected() {
+  local package_type=$1
+  if [[ -z "${MANIFEST:-}" || ! -s "${MANIFEST:-}" ]]; then
+    echo "::error::pulp verification requires the manifest emitted by the delivery/promote step"
+    exit 1
+  fi
+  echo "[INFO] Reading expected ${package_type} packages from manifest ${MANIFEST}"
+  PACKAGES_JSON=$(jq -c '.packages' "$MANIFEST")
+  COUNT=$(echo "$PACKAGES_JSON" | jq 'length')
+  if [[ "$COUNT" -eq 0 ]]; then
+    echo "::error::No expected ${package_type} package to verify"
+    exit 1
+  fi
+  echo "[INFO] ${COUNT} expected ${package_type} package(s) to verify"
+}
+
+# wait_for_metadata — repeatedly call the sourcing script's resolve_pending (one
+# resolution round over the still-unresolved packages, returning 0 once none
+# remain) until everything resolves, METADATA_TIMEOUT is reached, or the
+# resolution stalls. The retry window only covers publication propagation: once
+# a round reads the published metadata and resolves nothing new while some
+# packages already resolved, the remaining ones are not in the publication at
+# all (e.g. evicted by the retention policy) and no amount of waiting will
+# surface them - report them right away instead of burning the whole window.
+wait_for_metadata() {
+  local deadline=$(( SECONDS + METADATA_TIMEOUT ))
+  local resolved previous_resolved=-1 stall_rounds=0
+  until resolve_pending; do
+    resolved=0
+    for i in "${!E_FILENAME[@]}"; do
+      [[ "${META_IDX[$i]}" == "true" ]] && resolved=$((resolved + 1))
+    done
+    if ((resolved > 0 && resolved == previous_resolved)); then
+      stall_rounds=$((stall_rounds + 1))
+    else
+      stall_rounds=0
+    fi
+    # several consecutive stalled rounds before giving up: a single one is
+    # not enough, the published index can lag the publication by minutes
+    # (content-app cache TTL), which read as false negatives on freshly
+    # delivered builds
+    if ((stall_rounds >= 6)); then
+      echo "[WARN] ${resolved}/${#E_FILENAME[@]} package(s) resolvable in the published metadata and no progress in the last 6 rounds; the remaining ones are not part of the publication, giving up early"
+      break
+    fi
+    previous_resolved=$resolved
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      echo "[WARN] Metadata resolution timed out after ${METADATA_TIMEOUT}s (${resolved}/${#E_FILENAME[@]} resolvable)"
+      break
+    fi
+    echo "[INFO] ${resolved}/${#E_FILENAME[@]} package(s) resolvable, waiting ${METADATA_INTERVAL}s for the metadata to propagate..."
+    sleep "$METADATA_INTERVAL"
+  done
+}
+
+# record_row <filename> <arch> <present:bool> <in_metadata:bool> <fetchable:bool>
+record_row() {
+  local filename=$1 arch=$2 present=$3 in_meta=$4 fetchable=$5
+  local p m f
+  TOTAL=$((TOTAL + 1))
+  if [[ "$present" == "true" ]]; then p="✅"; PRESENT_OK=$((PRESENT_OK + 1)); else p="❌"; FAILED=1; fi
+  if [[ "$in_meta" == "true" ]]; then m="✅"; META_OK=$((META_OK + 1)); else m="❌"; FAILED=1; fi
+  if [[ "$fetchable" == "true" ]]; then f="✅"; else f="❌"; FAILED=1; fi
+  ROWS+=("| \`$filename\` | $arch | $p | $m | $f |")
+  echo "[CHECK] $filename ($arch): present=$p metadata=$m fetchable=$f"
+}
+
+# check_fetchable_and_record — HEAD each resolved package on the content url and
+# record every package's result row. Uses the E_FILENAME/E_ARCH/E_BASEPATH,
+# PRESENT_IDX, META_IDX and RESOLVED_IDX arrays filled by the sourcing script.
+check_fetchable_and_record() {
+  local i url code fetchable attempt
+  for i in "${!E_FILENAME[@]}"; do
+    fetchable=false
+    if [[ "${META_IDX[$i]}" == "true" ]]; then
+      url="${PULP_CONTENT_URL}/${E_BASEPATH[$i]}/${RESOLVED_IDX[$i]}"
+      # retry: one flaky HEAD out of hundreds (content-app/S3 hiccup) must not
+      # fail the whole verification
+      for attempt in 1 2 3; do
+        code=$(content_curl -fsSL -o /dev/null -w '%{http_code}' -I "$url" 2>/dev/null || echo 000)
+        [[ "$code" == "200" ]] && { fetchable=true; break; }
+        sleep 2
+      done
+    fi
+    record_row "${E_FILENAME[$i]}" "${E_ARCH[$i]}" "${PRESENT_IDX[$i]}" "${META_IDX[$i]}" "$fetchable"
+  done
+}
+
+# render_summary — write the per-OS table to the step summary (and stdout), then
+# return non-zero if any package failed any check. Called once, after all checks.
+render_summary() {
+  local title
+  title="### ${DISTRIB:-?} — ${STABILITY:-?} (${CHECK_MODE:-delivery}, pulp)"
+
+  {
+    echo "$title"
+    echo ""
+    echo "| Package | Arch | On repository | In metadata | Fetchable |"
+    echo "|---|---|---|---|---|"
+    if ((${#ROWS[@]})); then
+      printf '%s\n' "${ROWS[@]}"
+    fi
+    echo ""
+    echo "Result: ${PRESENT_OK}/${TOTAL} present · ${META_OK}/${TOTAL} resolvable"
+    if [[ "$FAILED" -ne 0 ]]; then
+      echo ""
+      echo "> ❌ Some packages are missing on the repository or unresolvable through metadata."
+    fi
+    echo ""
+  } | tee -a "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+  if [[ "$FAILED" -ne 0 ]]; then
+    echo "::error::pulp verification: ${DISTRIB:-?} verification failed (see the table above)"
+    return 1
+  fi
+  echo "[INFO] All ${TOTAL} package(s) verified on ${DISTRIB:-?}"
+  return 0
+}

--- a/.github/scripts/pulp/check-deb.sh
+++ b/.github/scripts/pulp/check-deb.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Verify that the delivered/promoted DEB packages are (1) physically present as
+# content units in their target pulp repository and (2) resolvable through the
+# published apt metadata (and actually fetchable from the content url).
+#
+# Metadata resolution mirrors promote-deb.sh: the structured publication serves
+# packages under the canonical pool layout, so the published Filename is resolved
+# from the suite's Packages index by sha256. Architecture "all" packages are
+# listed under every binary-<arch>, so they are looked up across the suite's
+# architectures.
+#
+# The expected list is the manifest emitted by the delivery/promote step. The
+# script never exits early — see check-common.sh.
+set -uo pipefail
+
+# shellcheck source=.github/scripts/pulp/check-common.sh
+source "$(dirname "$0")/check-common.sh"
+
+load_expected "DEB"
+
+# --- load expected packages into parallel arrays ---------------------------
+mapfile -t E_FILENAME   < <(echo "$PACKAGES_JSON" | jq -r '.[].filename')
+mapfile -t E_ARCH       < <(echo "$PACKAGES_JSON" | jq -r '.[].arch')
+mapfile -t E_SHA256     < <(echo "$PACKAGES_JSON" | jq -r '.[].sha256')
+mapfile -t E_REPOSITORY < <(echo "$PACKAGES_JSON" | jq -r '.[].repository')
+mapfile -t E_BASEPATH   < <(echo "$PACKAGES_JSON" | jq -r '.[].base_path')
+mapfile -t E_SUITE      < <(echo "$PACKAGES_JSON" | jq -r '.[].suite')
+mapfile -t E_RELPATH    < <(echo "$PACKAGES_JSON" | jq -r '.[].relative_path')
+
+# --- physical presence: content units in the repository's latest version ----
+# newest first, stopping as soon as every expected package of the repository
+# has been seen: the shared plugins repository holds 10k+ module packages and
+# deep offset pagination both costs the server dearly and eventually fails,
+# while the freshly delivered packages are the newest content by construction.
+# The listing goes to a file and grep reads the file: piping it into grep -q
+# would SIGPIPE the writer on the (early-exiting) first match, and pipefail
+# then turns every successful match into a false negative.
+declare -A PRESENT_BY_REPO   # repo -> file holding one relative_path per line
+for repo in $(printf '%s\n' "${E_REPOSITORY[@]}" | sort -u); do
+  PRESENT_BY_REPO[$repo]=$(mktemp)
+  version_href=$(pulp deb repository show --name "$repo" 2>/dev/null | jq -r '.latest_version_href // empty')
+  if [[ -z "$version_href" ]]; then
+    echo "[WARN] Repository $repo does not exist or has no version"
+    continue
+  fi
+  url="$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/?$(
+    printf 'repository_version=%s&pulp_label_select=%s&ordering=-pulp_created&limit=1000' \
+      "$(jq -rn --arg v "$version_href" '$v | @uri')" \
+      "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
+  )"
+  pages=0
+  while [[ -n "$url" ]] && ((pages < 20)); do
+    page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url") || {
+      echo "[WARN] presence page fetch failed for $repo ($url)" >&2
+      break
+    }
+    if ((pages == 0)); then
+      echo "[INFO] Repository $repo holds $(echo "$page" | jq -r '.count') module package(s) in its latest version"
+    fi
+    echo "$page" | jq -r '.results[].relative_path' >> "${PRESENT_BY_REPO[$repo]}"
+    pages=$((pages + 1))
+    all_found=true
+    for i in "${!E_FILENAME[@]}"; do
+      [[ "${E_REPOSITORY[$i]}" == "$repo" ]] || continue
+      if ! grep -Fxq "${E_RELPATH[$i]}" "${PRESENT_BY_REPO[$repo]}"; then
+        all_found=false
+        break
+      fi
+    done
+    [[ "$all_found" == "true" ]] && break
+    url=$(echo "$page" | jq -r '.next // empty')
+  done
+done
+
+declare -A PRESENT_IDX
+for i in "${!E_FILENAME[@]}"; do
+  if grep -Fxq "${E_RELPATH[$i]}" "${PRESENT_BY_REPO[${E_REPOSITORY[$i]}]}"; then
+    PRESENT_IDX[$i]=true
+  else
+    PRESENT_IDX[$i]=false
+  fi
+done
+
+# --- metadata resolvability + fetchability, with a bounded retry window -----
+# resolve a package's published Filename from a suite Packages index by sha256
+resolve_filename() {
+  # read the Packages index from a file: awk exits on the first match, and a
+  # pipe writer would take a SIGPIPE ("printf: write error: Broken pipe" noise)
+  local packages_file=$1 sha=$2
+  [[ -s "$packages_file" ]] || return 0
+  awk -v sha="$sha" '
+    BEGIN { RS = ""; FS = "\n" }
+    index($0, "SHA256: " sha) {
+      for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i; exit }
+    }' "$packages_file"
+}
+
+declare -A META_IDX      # idx -> true|false
+declare -A RESOLVED_IDX  # idx -> published Filename
+for i in "${!E_FILENAME[@]}"; do META_IDX[$i]=false; done
+
+# one resolution round: fetch each suite's Packages indexes once, then resolve
+# each pending package's published Filename by sha256
+resolve_pending() {
+  local -A pkg_cache=()    # key: base_path|suite|arch -> Packages index file
+  local -A arches_cache=() # key: base_path|suite -> space separated arches
+  local all_resolved=true i base_path suite arch search_arches sk ck a filename cache_file
+  for i in "${!E_FILENAME[@]}"; do
+    [[ "${META_IDX[$i]}" == "true" ]] && continue
+    base_path=${E_BASEPATH[$i]}; suite=${E_SUITE[$i]}; arch=${E_ARCH[$i]}
+
+    # architectures to search: the package arch, plus every arch of the suite
+    # for "all" packages (which are duplicated across each binary-<arch>)
+    search_arches="$arch"
+    if [[ "$arch" == "all" ]]; then
+      sk="$base_path|$suite"
+      if [[ -z "${arches_cache[$sk]+set}" ]]; then
+        arches_cache[$sk]=$(content_curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" 2>/dev/null \
+          | awk -F': ' '/^Architectures:/ { print $2; exit }')
+      fi
+      search_arches="${arches_cache[$sk]:-amd64 arm64 all}"
+    fi
+
+    filename=""
+    for a in $search_arches; do
+      ck="$base_path|$suite|$a"
+      if [[ -z "${pkg_cache[$ck]+set}" ]]; then
+        cache_file=$(mktemp)
+        content_curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$a/Packages" 2>/dev/null > "$cache_file" || true
+        pkg_cache[$ck]=$cache_file
+      fi
+      filename=$(resolve_filename "${pkg_cache[$ck]}" "${E_SHA256[$i]}")
+      [[ -n "$filename" ]] && break
+    done
+
+    if [[ -n "$filename" ]]; then
+      META_IDX[$i]=true
+      RESOLVED_IDX[$i]=$filename
+    else
+      all_resolved=false
+    fi
+  done
+  rm -f "${pkg_cache[@]}"
+  [[ "$all_resolved" == "true" ]]
+}
+
+wait_for_metadata
+check_fetchable_and_record
+render_summary

--- a/.github/scripts/pulp/check-rpm.sh
+++ b/.github/scripts/pulp/check-rpm.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Verify that the delivered/promoted RPM packages are (1) physically present as
+# content units in their target pulp repository and (2) resolvable through the
+# published repodata (and actually fetchable from the content url).
+#
+# The expected list is the manifest emitted by the delivery/promote step. The
+# script never exits early — see check-common.sh.
+set -uo pipefail
+
+# shellcheck source=.github/scripts/pulp/check-common.sh
+source "$(dirname "$0")/check-common.sh"
+
+load_expected "RPM"
+
+# --- load expected packages into parallel arrays ---------------------------
+mapfile -t E_FILENAME   < <(echo "$PACKAGES_JSON" | jq -r '.[].filename')
+mapfile -t E_ARCH       < <(echo "$PACKAGES_JSON" | jq -r '.[].arch')
+mapfile -t E_SHA256     < <(echo "$PACKAGES_JSON" | jq -r '.[].sha256')
+mapfile -t E_REPOSITORY < <(echo "$PACKAGES_JSON" | jq -r '.[].repository')
+mapfile -t E_BASEPATH   < <(echo "$PACKAGES_JSON" | jq -r '.[].base_path')
+
+# --- physical presence: content units in each repository's latest version --
+# newest first, stopping as soon as every expected package of the repository
+# has been seen: a large repository makes deep offset pagination costly and
+# flaky, while the freshly delivered packages are the newest content by
+# construction.
+# The listing goes to a file and grep reads the file: piping it into grep -q
+# would SIGPIPE the writer on the (early-exiting) first match, and pipefail
+# then turns every successful match into a false negative.
+declare -A PRESENT_BY_REPO   # repo -> file holding one filename per line
+declare -A EXPECTED_COUNT_BY_REPO
+declare -A TOTAL_COUNT_BY_REPO
+
+for repo in $(printf '%s\n' "${E_REPOSITORY[@]}" | sort -u); do
+  PRESENT_BY_REPO[$repo]=$(mktemp)
+  version_href=$(pulp rpm repository show --name "$repo" 2>/dev/null | jq -r '.latest_version_href // empty')
+  if [[ -z "$version_href" ]]; then
+    echo "[WARN] Repository $repo does not exist or has no version"
+    continue
+  fi
+  url="$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/?$(
+    printf 'repository_version=%s&pulp_label_select=%s&ordering=-pulp_created&limit=1000' \
+      "$(jq -rn --arg v "$version_href" '$v | @uri')" \
+      "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
+  )"
+  pages=0
+  while [[ -n "$url" ]] && ((pages < 20)); do
+    page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url") || {
+      echo "[WARN] presence page fetch failed for $repo ($url)" >&2
+      break
+    }
+    if ((pages == 0)); then
+      TOTAL_COUNT_BY_REPO[$repo]=$(echo "$page" | jq -r '.count')
+      echo "[INFO] Repository $repo holds ${TOTAL_COUNT_BY_REPO[$repo]} module package(s) in its latest version"
+    fi
+    echo "$page" | jq -r '.results[].location_href' | awk -F/ '{print $NF}' >> "${PRESENT_BY_REPO[$repo]}"
+    pages=$((pages + 1))
+    all_found=true
+    for i in "${!E_FILENAME[@]}"; do
+      [[ "${E_REPOSITORY[$i]}" == "$repo" ]] || continue
+      if ! grep -Fxq "${E_FILENAME[$i]}" "${PRESENT_BY_REPO[$repo]}"; then
+        all_found=false
+        break
+      fi
+    done
+    [[ "$all_found" == "true" ]] && break
+    url=$(echo "$page" | jq -r '.next // empty')
+  done
+done
+
+declare -A PRESENT_IDX   # idx -> true|false
+for i in "${!E_FILENAME[@]}"; do
+  repo=${E_REPOSITORY[$i]}
+  EXPECTED_COUNT_BY_REPO[$repo]=$(( ${EXPECTED_COUNT_BY_REPO[$repo]:-0} + 1 ))
+  if grep -Fxq "${E_FILENAME[$i]}" "${PRESENT_BY_REPO[$repo]}"; then
+    PRESENT_IDX[$i]=true
+  else
+    PRESENT_IDX[$i]=false
+  fi
+done
+
+# right number (delivery only): warn when the repository holds more module
+# packages than expected. Count-based only: with shared repositories and the
+# daily develop deliveries, listing every extra name is noise (and the full
+# listing is what the bounded pagination above avoids).
+[[ "${CHECK_MODE:-delivery}" == "delivery" ]] && for repo in "${!EXPECTED_COUNT_BY_REPO[@]}"; do
+  total=${TOTAL_COUNT_BY_REPO[$repo]:-0}
+  if [[ "$total" -gt "${EXPECTED_COUNT_BY_REPO[$repo]}" ]]; then
+    echo "::warning::Repository $repo holds $total module packages, ${EXPECTED_COUNT_BY_REPO[$repo]} delivered by this run (older builds and other modules accumulate until cleanup)"
+  fi
+done
+
+# --- metadata resolvability + fetchability, with a bounded retry window -----
+declare -A META_IDX      # idx -> true|false
+declare -A RESOLVED_IDX  # idx -> published location href
+for i in "${!E_FILENAME[@]}"; do META_IDX[$i]=false; done
+
+# resolve the published location href of the package whose sha256 checksum
+# matches, from a primary.xml body: matching by checksum (not filename) binds
+# the verification to the exact delivered content, like the DEB by-sha256 match
+resolve_href() {
+  # read the primary.xml from a file: awk exits on the first match, and a pipe
+  # writer would take a SIGPIPE ("printf: write error: Broken pipe" noise)
+  local primary_file=$1 sha=$2
+  [[ -s "$primary_file" ]] || return 0
+  awk -v sha="$sha" '
+    BEGIN { RS = "</package>" }
+    index($0, ">" sha "</checksum>") {
+      if (match($0, /<location[^>]*href="[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/.*href="/, "", s); sub(/"$/, "", s)
+        print s; exit
+      }
+    }' "$primary_file"
+}
+
+# one resolution round: fetch each base_path's primary.xml once, then resolve
+# each pending package's published href by sha256
+resolve_pending() {
+  local -A primary_cache=()
+  local all_resolved=true i base_path repomd primary_href href cache_file
+  for i in "${!E_FILENAME[@]}"; do
+    [[ "${META_IDX[$i]}" == "true" ]] && continue
+    base_path=${E_BASEPATH[$i]}
+
+    if [[ -z "${primary_cache[$base_path]+set}" ]]; then
+      cache_file=$(mktemp)
+      repomd=$(content_curl -fsSL "$PULP_CONTENT_URL/$base_path/repodata/repomd.xml" 2>/dev/null || true)
+      primary_href=$(printf '%s' "$repomd" | grep -oP '<location href="\K[^"]+primary\.xml[^"]*' | head -1 || true)
+      if [[ -n "$primary_href" ]]; then
+        content_curl -fsSL "$PULP_CONTENT_URL/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null > "$cache_file" || true
+      fi
+      primary_cache[$base_path]=$cache_file
+    fi
+
+    href=$(resolve_href "${primary_cache[$base_path]}" "${E_SHA256[$i]}")
+    if [[ -n "$href" ]]; then
+      META_IDX[$i]=true
+      RESOLVED_IDX[$i]=$href
+    else
+      all_resolved=false
+    fi
+  done
+  rm -f "${primary_cache[@]}"
+  [[ "$all_resolved" == "true" ]]
+}
+
+wait_for_metadata
+check_fetchable_and_record
+render_summary

--- a/.github/scripts/pulp/manifest.sh
+++ b/.github/scripts/pulp/manifest.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Shared helpers to emit the delivery/promotion manifest consumed by the
+# verification scripts (check-rpm.sh, check-deb.sh). Source this file, append
+# one compact JSON object per package with manifest_add, then finalize the
+# manifest with manifest_write.
+#
+# The manifest is the authoritative "expected packages" list: it is captured at
+# the moment of upload (the packages that were on the runner before/at upload),
+# so the check step verifies exactly this set rather than re-reading the build
+# cache. Each entry carries the package identity (for the content-api presence
+# query), its sha256 (for the by-checksum metadata match) and the pulp target
+# coordinates (so the check re-derives no path).
+
+MANIFEST_ENTRIES=()
+
+# manifest_add <compact-json-object>
+manifest_add() {
+  MANIFEST_ENTRIES+=("$1")
+}
+
+# manifest_write <module> <distrib> <package_type> <stability> <mode> <content_url>
+# writes the manifest json to the workspace and exposes its path as the
+# "manifest" step output when running inside a github action.
+manifest_write() {
+  local module=$1 distrib=$2 package_type=$3 stability=$4 mode=$5 content_url=$6
+  local file="${GITHUB_WORKSPACE:-$PWD}/pulp-delivery-manifest.json"
+
+  # the packages array is slurped from stdin: with hundreds of packages an
+  # --argjson argument would exceed the kernel argv size limit (E2BIG).
+  # NB: the jq variable is named module_name, not module — `module` is a reserved
+  # jq keyword and `$module` fails to parse on stricter jq builds (the CI runner)
+  {
+    if ((${#MANIFEST_ENTRIES[@]})); then
+      printf '%s\n' "${MANIFEST_ENTRIES[@]}"
+    fi
+  } | jq -s \
+    --arg module_name "$module" \
+    --arg distrib "$distrib" \
+    --arg package_type "$package_type" \
+    --arg stability "$stability" \
+    --arg mode "$mode" \
+    --arg content_url "$content_url" \
+    '{
+      "module": $module_name,
+      distrib: $distrib,
+      package_type: $package_type,
+      stability: $stability,
+      mode: $mode,
+      pulp_content_url: $content_url,
+      packages: .
+    }' > "$file"
+
+  echo "[INFO] Wrote delivery manifest ($(jq '.packages | length' "$file") package(s)) to $file"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "manifest=$file" >> "$GITHUB_OUTPUT"
+  fi
+}

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -571,6 +571,54 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-pulp:
+    continue-on-error: true
+    needs: [changes, get-environment, package, e2e-test]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Deliver packages on Pulp
+        id: deliver_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: awie
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver]
     if: |
@@ -602,6 +650,50 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: promote ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: awie
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver, promote]

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -333,6 +333,54 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-pulp:
+    continue-on-error: true
+    needs: [get-environment, changes, package]
+    if: |
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+      github.event.pull_request.head.repo.fork != true &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Deliver packages on Pulp
+        id: deliver_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: dsm
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver]
     if: |
@@ -364,6 +412,50 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: promote ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: dsm
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver, promote]

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -190,6 +190,52 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-pulp:
+    continue-on-error: true
+    needs: [get-environment, changes, package]
+    if: |
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+      needs.get-environment.outputs.is_cloud == 'false' &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Deliver packages on Pulp
+        id: deliver_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: ha
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment]
     if: |
@@ -220,3 +266,46 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) &&
+      github.event_name != 'workflow_dispatch' &&
+      needs.get-environment.outputs.is_cloud == 'false' &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: promote ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: ha
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -634,6 +634,53 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-pulp:
+    continue-on-error: true
+    needs: [get-environment, changes, package, e2e-test]
+    if: |
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Deliver packages on Pulp
+        id: deliver_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: open-tickets
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver]
     if: |
@@ -665,6 +712,50 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+
+    name: promote ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: open-tickets
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver, promote]

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1315,6 +1315,53 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-pulp:
+    continue-on-error: true
+    runs-on: centreon-common
+    needs: [changes, get-environment, bruno-api-test, e2e-test]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      github.event.pull_request.head.repo.fork != true
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Deliver packages on Pulp
+        id: deliver_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: web
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver]
     if: |
@@ -1345,6 +1392,49 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.get-environment.outputs.package_matrix) }}
+    name: promote ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: web
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver, promote]


### PR DESCRIPTION
Brings the dual package delivery (Artifactory and Pulp) of `develop` to `dev-25.10.x`. This branch had no Pulp reference at all, so the change has two parts.

**1. Actions and scripts, byte-identical to `develop`:** `package-delivery-pulp`, `promote-to-stable-pulp`, `pulp-repository-properties`, `setup-pulp-cli` and `.github/scripts/pulp/*` (new on this branch), plus the Artifactory `rpm-delivery` (native `centreon.jfrog.io` hostname, `target: jfrog` in the delivery-tooling dispatch payload, feature repository readiness checked with `jf rt search` on the `rpm-standard-feature/<ticket>` layout).

**2. Caller workflows** (`awie.yml`, `dsm.yml`, `ha.yml`, `open-tickets.yml`, `web.yml`): a `<job>-pulp` twin is added right after each Artifactory delivery/promotion job (`deliver` → `deliver-pulp`, `deliver-rpm` / `deliver-deb` → `deliver-*-pulp`, `promote` → `promote-pulp`). Each twin is the `develop` job with the branch's own `needs` (Artifactory jobs mapped to their Pulp twin), `runs-on`, matrix and `actions/checkout` pin, and keeps `develop`'s gate and steps: `continue-on-error`, `permissions: id-token: write`, the delivery/promotion step and the warning step. The Artifactory jobs are untouched, Pulp failures never block the workflow.

Notes:
- Pulp repositories for 25.10 are provisioned on dev and prod (el8, el9, el10, bookworm, trixie).
- Promotion on Pulp runs on `stable` events only, as on `develop`; the Artifactory `promote` keeps its own gate.
- Same source commits as the 26.10 backports ([#11568](https://github.com/centreon/centreon/pull/11568), [#11569](https://github.com/centreon/centreon/pull/11569)): [#11275](https://github.com/centreon/centreon/pull/11275), [#11278](https://github.com/centreon/centreon/pull/11278), [#11170](https://github.com/centreon/centreon/pull/11170), [#11390](https://github.com/centreon/centreon/pull/11390), [#11401](https://github.com/centreon/centreon/pull/11401), [#11406](https://github.com/centreon/centreon/pull/11406), [#11415](https://github.com/centreon/centreon/pull/11415), [#11417](https://github.com/centreon/centreon/pull/11417), [#11427](https://github.com/centreon/centreon/pull/11427), [#11434](https://github.com/centreon/centreon/pull/11434), [#11446](https://github.com/centreon/centreon/pull/11446), [#11504](https://github.com/centreon/centreon/pull/11504).

Checks: every workflow parses, every `needs` resolves, every required action input is provided, referenced action paths exist, `bash -n` on the scripts, yamllint without new finding.

Fixes: [MON-208847](https://centreon.atlassian.net/browse/MON-208847)

## How to test

Run a component workflow on this branch (push, or a pull request with the `delivery-feature` label): the `deliver-*-pulp` jobs must upload the packages to Pulp next to the Artifactory delivery, with the post-delivery checks green. On a stable event, the `promote-pulp` job promotes the content by href. A Pulp failure only produces a warning.


[MON-208847]: https://centreon.atlassian.net/browse/MON-208847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ