### PR TITLE
fix(configuration): salvage standalone fixes and tests from the services listing migration

### DIFF
--- a/centreon/tests/e2e/.gitignore
+++ b/centreon/tests/e2e/.gitignore
@@ -4,3 +4,8 @@ fixtures/packages
 cucumber-messages.ndjson
 cypress
 *.yml
+
+# Local-only Cypress overrides pointing at a developer's environment; never
+# used by CI. Ignored so a `git add` on this directory cannot sweep them in.
+cypress.local.config.ts
+support/e2e.local.ts

--- a/centreon/www/include/common/javascript/showLogo.js
+++ b/centreon/www/include/common/javascript/showLogo.js
@@ -33,8 +33,14 @@
  */
 
 function showLogo(_img_dst, _value) {
-	var _img = document.getElementById(_img_dst);        
-	if (_value && _value.indexOf('REP') < 0) {            
+	var _img = document.getElementById(_img_dst);
+	// Some forms (the OnPrem service/template ones) render the icon inside the
+	// select2 selection and carry no preview node: nothing to refresh, so return
+	// rather than dereference a missing element.
+	if (!_img) {
+	    return;
+	}
+	if (_value && _value.indexOf('REP') < 0) {
             _img.src = 'include/common/getHiddenImage.php?id=' + _value + '&logo=1';            
         } else {
             _img.src = './img/blank.gif';

--- a/centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
+++ b/centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
@@ -19,6 +19,11 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+
 require_once realpath(__DIR__ . '/../../../../../../config/centreon.config.php');
 
 require_once __DIR__ . '/argumentsXmlFunction.php';
@@ -29,6 +34,7 @@ require_once _CENTREON_PATH_ . '/www/class/centreonXML.class.php';
 // Get session
 require_once _CENTREON_PATH_ . 'www/class/centreonSession.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreon.class.php';
+require_once _CENTREON_PATH_ . 'www/class/centreonACL.class.php';
 
 if (! isset($_SESSION['centreon'])) {
     CentreonSession::start(1);
@@ -38,6 +44,28 @@ if (isset($_SESSION['centreon'])) {
     $oreon = $_SESSION['centreon'];
 } else {
     exit;
+}
+
+// The endpoint hands back persisted command arguments for the ids it is given,
+// so reaching one of the three pages that embed the form is the minimum. The
+// form is included by formService.php (60201 services by host, 60202 by host
+// group) and by formServiceTemplateModel.php (60206).
+if (! $oreon->user->admin) {
+    $access = $oreon->user->access;
+    $reachesForm = $access !== null
+        && ($access->page(60201) !== 0 || $access->page(60202) !== 0 || $access->page(60206) !== 0);
+
+    if (! $reachesForm) {
+        // The XSLT consumer ignores the HTTP status, so this trace is the only
+        // signal a denial leaves anywhere.
+        Logger::create(LogChannelEnum::WEB)->warning(
+            'Command arguments: page access denied',
+            ['contact_id' => (int) $oreon->user->get_id()]
+        );
+        http_response_code(403);
+
+        exit;
+    }
 }
 
 // Get language
@@ -65,6 +93,73 @@ if (isset($_GET['cmdId'], $_GET['svcId'], $_GET['svcTplId'], $_GET['o'])) {
     $svcId = CentreonDB::escape($_GET['svcId']);
     $svcTplId = CentreonDB::escape($_GET['svcTplId']);
     $o = CentreonDB::escape($_GET['o']);
+
+    // Page access alone would let any id be probed, so the service is also
+    // checked against the caller ACL. Only monitored services
+    // (service_register = '1') carry a centreon_acl entry of their own; the
+    // other registers (templates, meta services) are deliberately left to the
+    // page check above, which is the only lever available for them.
+    if ((int) $svcId !== 0 && ! $oreon->user->admin) {
+        try {
+            $isMonitoredService = (bool) $db->fetchOne(
+                <<<'SQL'
+                    SELECT 1 FROM `service`
+                    WHERE service_id = :svcId AND service_register = '1'
+                    LIMIT 1
+                    SQL,
+                QueryParameters::create([QueryParameter::int('svcId', (int) $svcId)])
+            );
+
+            if ($isMonitoredService) {
+                $groupIds = array_values(array_filter(array_map(
+                    'intval',
+                    array_keys($oreon->user->access->getAccessGroups())
+                )));
+
+                $isGranted = false;
+                if ($groupIds !== []) {
+                    $aclDbName       = $db->getConnectionConfig()->getDatabaseNameRealTime();
+                    $aclPlaceholders = [];
+                    $aclParameters   = [QueryParameter::int('svcId', (int) $svcId)];
+                    foreach ($groupIds as $index => $groupId) {
+                        $placeholder       = 'acl_gid' . $index;
+                        $aclPlaceholders[] = ':' . $placeholder;
+                        $aclParameters[]   = QueryParameter::int($placeholder, $groupId);
+                    }
+                    $aclIn = implode(', ', $aclPlaceholders);
+
+                    $isGranted = (bool) $db->fetchOne(
+                        <<<SQL
+                            SELECT 1 FROM `{$aclDbName}`.centreon_acl
+                            WHERE service_id = :svcId AND group_id IN ({$aclIn})
+                            LIMIT 1
+                            SQL,
+                        QueryParameters::create($aclParameters)
+                    );
+                }
+
+                if (! $isGranted) {
+                    // The XSLT consumer ignores the HTTP status, so this trace is
+                    // the only signal a denial leaves anywhere.
+                    Logger::create(LogChannelEnum::WEB)->warning(
+                        'Command arguments: service access denied',
+                        ['contact_id' => (int) $oreon->user->get_id(), 'svc_id' => (int) $svcId]
+                    );
+                    http_response_code(403);
+
+                    exit;
+                }
+            }
+        } catch (Throwable $exception) {
+            Logger::create(LogChannelEnum::WEB)->error(
+                'Command arguments: failed to resolve the service ACL scope',
+                ['exception' => $exception, 'svc_id' => (int) $svcId]
+            );
+            http_response_code(500);
+
+            exit;
+        }
+    }
 
     $tab = [];
     if (! $cmdId && $svcTplId) {


### PR DESCRIPTION
## Description

Salvages the standalone, still-applicable fixes from the abandoned services submenu listing/form migration [#10073](https://github.com/centreon/centreon/pull/10073) (dropped in favour of the React + API Platform approach). Each fix corrects code that already lives on this branch today, independent of the abandoned migration.

The host categories migration this salvage originally also targeted was rolled back on `develop` (#11467). The listing/form-framework, host-categories-endpoint and ACL-e2e parts of the salvage targeted code that no longer exists and were dropped — this PR is now scoped to the fixes below.

> **Backport note (dev-24.10.x).** The `Additional-connectors/04-ACC-update` e2e repair from the parent PR does **not** apply on this branch: the spec is written in a different (older) style — it reopens the form via the *Edit connector configuration* button with inline field assertions and never waits on `@getConnectorDetail`, so the bug the parent fixed is not present, and the `verifyAccFieldValues` custom command it relies on does not exist here. That change was intentionally dropped; the two real fixes and the `.gitignore` entry are backported unchanged.

### Fixes

- **`argumentsXml.php` — authorization hardening.** The command-arguments XML endpoint (returning persisted `command_command_id_arg` values) verified only that a session existed, so any authenticated user could read another tenant's service command arguments by probing ids. It now:
  - requires the caller to reach one of the three pages that embed the form (60201 services by host, 60202 by host group, 60206 service template) — else `403`;
  - for a monitored service (`service_register = '1'`), checks the `svcId` against the caller's `centreon_acl` group scope — else `403`. Templates and meta services are deliberately left to the page check (they carry no `centreon_acl` row);
  - fails **closed**: an ACL-resolution error logs and returns `500` before any XML is emitted.
  Queries are parameterized (`QueryParameters` / `QueryParameter::int`, including the generated `IN (...)` placeholder list); refusals are logged on the WEB channel (the XSLT consumer ignores the HTTP status, so the log is the only signal). Admins bypass, as before.
- **`showLogo.js` — null-guard the icon-preview refresh.** `showLogo()` dereferenced `getElementById(...)` with no check, so a form that renders the icon inside the select2 selection and carries no preview node (the OnPrem service/template forms) threw a `TypeError`. It now returns early when the node is absent; forms that do have a preview node are unchanged.

### Tests

- **`tests/e2e/.gitignore`** — ignore the local-only Cypress override files (`cypress.local.config.ts`, `support/e2e.local.ts`) so a `git add` on the directory cannot sweep them in.

### Known limitation — test coverage of the authorization hardening

The new `argumentsXml.php` authorization branches ship **without an automated regression net**: the endpoint is a legacy procedural script (session/`$oreon`/live-DB dependencies) with no unit-test seam, and its only existing e2e runs as admin, which short-circuits the new block. Because the XSLT consumer ignores the HTTP status, a future regression here would be silent. The proper vehicle is an e2e ACL scenario (a restricted user denied command arguments for a monitored service outside its scope, allowed for one inside), which needs realtime `centreon_acl` fixtures — left as a follow-up. The logic itself was verified by the internal review pass (code, security, silent-failure).

## How to test

Manually, on a platform with a non-admin user:
1. As a non-admin **without** access to the service pages (60201/60202/60206), request `include/configuration/configObject/service/xml/argumentsXml.php?cmdId=<id>&svcId=<id>&svcTplId=0&o=c` → `403`, nothing returned.
2. As a non-admin **with** access to a service form but whose ACL group does **not** cover a given monitored service, request the arguments for that `svcId` → `403`. Repeat for a service **inside** the ACL scope → arguments returned.
3. Open the OnPrem service or service-template form and change the check-command icon: the preview updates (or is a no-op) without a JS error, instead of breaking the form.

## Links

### Jira ticket

Resolves: [MON-208943](https://centreon.atlassian.net/browse/MON-208943)

### PR Github

- Backports: #11451
- Relates to: #10073 — the abandoned services listing migration this salvage is extracted from (untouched).


[MON-208943]: https://centreon.atlassian.net/browse/MON-208943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ