### PR TITLE
fix(traps): salvage standalone trap form & Generate page fixes from #10066

### DIFF
--- a/centreon/phpstan.legacy.www.baseline.neon
+++ b/centreon/phpstan.legacy.www.baseline.neon
@@ -223,12 +223,6 @@ parameters:
 			path: www/include/common/vault-functions.php
 
 		-
-			message: '#^Array has 2 duplicate keys with value ''generate'' \(''generate'', ''generate''\)\.$#'
-			identifier: array.duplicateKey
-			count: 1
-			path: www/include/configuration/configGenerateTraps/formGenerateTraps.php
-
-		-
 			message: '#^Function duplicateArgDesc\(\) should return unknown_type but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1

--- a/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -37,7 +37,9 @@ $acl = $centreon->user->access;
 $tab_nagios_server = $acl->getPollerAclConf(['get_row'    => 'name', 'order'      => ['name'], 'keys'       => ['id'], 'conditions' => ['ns_activate' => 1]]);
 
 // Sort the list of poller server
-$pollersId = isset($_GET['poller']) ? explode(',', $_GET['poller']) : [];
+// A query string can carry any type (e.g. ?poller[]=1) while explode() only
+// accepts a string: discard anything else instead of raising a TypeError.
+$pollersId = is_string($_GET['poller'] ?? null) ? explode(',', $_GET['poller']) : [];
 
 foreach ($tab_nagios_server as $key => $name) {
     if (in_array($key, $pollersId)) {
@@ -74,7 +76,7 @@ $options = [null => null, 'RELOADCENTREONTRAPD' => _('Reload'), 'RESTARTCENTREON
 $form->addElement('select', 'signal', _('Send signal'), $options);
 
 // Set checkbox checked.
-$form->setDefaults(['generate' => '1', 'generate' => '1', 'opt' => '1']);
+$form->setDefaults(['generate' => '1', 'opt' => '1']);
 
 $redirect = $form->addElement('hidden', 'o');
 $redirect->setValue($o);

--- a/centreon/www/include/configuration/configObject/traps/formTraps.php
+++ b/centreon/www/include/configuration/configObject/traps/formTraps.php
@@ -19,6 +19,12 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Adaptation\Log\Enum\LogChannelEnum;
+use Adaptation\Log\Logger;
+
 if (! isset($centreon)) {
     exit();
 }
@@ -43,11 +49,40 @@ $cdata = CentreonData::getInstance();
 $preexecArray = [];
 $mrulesArray = [];
 if (($o == TRAP_MODIFY || $o == TRAP_WATCH) && is_int($trapsId)) {
-    $DBRESULT = $pearDB->query("SELECT * FROM traps WHERE traps_id = '{$trapsId}' LIMIT 1");
-    // Set base value
-    $trap = array_map('myDecodeTrap', $DBRESULT->fetchRow());
+    $trapQuery = <<<'SQL'
+        SELECT * FROM traps WHERE traps_id = :trapsId LIMIT 1
+        SQL;
+
+    try {
+        $row = $pearDB->fetchAssociative(
+            $trapQuery,
+            QueryParameters::create([QueryParameter::int('trapsId', $trapsId)])
+        );
+    } catch (ConnectionException $exception) {
+        Logger::create(LogChannelEnum::WEB)->error(
+            'Error retrieving the SNMP trap',
+            ['trapsId' => $trapsId, 'exception' => $exception]
+        );
+
+        $msg = new CentreonMsg();
+        $msg->error(_('Could not load the SNMP trap. Please try again.'));
+
+        return;
+    }
+
+    // Editing a trap that no longer exists returns no row: surface it instead of
+    // rendering a blank edit form that would report a phantom success on save.
+    if (! is_array($row)) {
+        Logger::create(LogChannelEnum::WEB)->notice('SNMP trap not found', ['trapsId' => $trapsId]);
+
+        $msg = new CentreonMsg();
+        $msg->error(_('This SNMP trap no longer exists.'));
+
+        return;
+    }
+
+    $trap = array_map('myDecodeTrap', $row);
     $trap['severity'] = $trap['severity_id'];
-    $DBRESULT->closeCursor();
 
     $preexecArray = $trapObj->getPreexecFromTrapId($trapsId);
     $mrulesArray = $trapObj->getMatchingRulesFromTrapId($trapsId);
@@ -248,7 +283,7 @@ $form->addElement(
 
 $form->addElement('textarea', 'traps_customcode', _('Custom code'), $attrsTextarea);
 
-$form->addElement('select', 'traps_advanced_treatment_default', _('Advanced matching behavior'), [0 => _('If no match, submit default status'), 1 => _('If no match, disable submit'), 2 => _('If match, disable submit')], ['id' => 'traps_advanced_treatment']);
+$form->addElement('select', 'traps_advanced_treatment_default', _('Advanced matching behavior'), [0 => _('If no match, submit default status'), 1 => _('If no match, disable submit'), 2 => _('If match, disable submit')], ['id' => 'traps_advanced_treatment_default']);
 
 $excecution_type[] = $form->createElement('radio', 'traps_exec_interval_type', null, _('None'), '0');
 $excecution_type[] = $form->createElement('radio', 'traps_exec_interval_type', null, _('By OID'), '1');


### PR DESCRIPTION
## Description

This PR **salvages standalone bug fixes** from the abandoned SNMP traps listing migration [#10066](https://github.com/centreon/centreon/pull/10066) (branch `feature/configuration-legacy-listing-traps`, whose 5 companion form PRs are now closed). Each fix below corrects a defect **already present on this branch today**, independent of the abandoned migration — the migration code itself is not brought over.

### Fixes

**Fix 1 — SNMP trap edit form controller** · `formTraps.php` · **risk: low**
- The edited trap was read via an interpolated `$pearDB->query()` then `array_map('myDecodeTrap', $DBRESULT->fetchRow())`. `fetchRow()` returns `false` when `traps_id` matches no row, so `array_map()` ran over `false` — a fatal `TypeError` on PHP 8, reachable via a hand-edited `traps_id` in the URL. The read is now bound through `QueryParameters` (`QueryParameter::int`) and the outcomes are separated:
  - a genuine load failure (`ConnectionException`) is logged and reported to the user, then the form is not rendered;
  - a `traps_id` that matches no trap under edit/view is surfaced (logged, and a *"This SNMP trap no longer exists."* message shown) instead of rendering a blank edit form that would report a phantom success on save.
  The catch is narrowed to `ConnectionException` — the only exception `fetchAssociative` throws — so a mapping bug is not relabelled as a load failure.
- The *"Advanced matching behavior"* select reused the DOM id `traps_advanced_treatment`, already carried by the advanced-treatment checkbox. It now uses `traps_advanced_treatment_default` (unique).

**Fix 2 — SNMP trap Generate page** · `formGenerateTraps.php`, `phpstan.legacy.www.baseline.neon` · **risk: low**
- `explode(',', $_GET['poller'])` crashed with a `TypeError` on PHP 8 when the query string carried an array (`?poller[]=1`): the `isset()` guard only covered a missing key, never a wrong type. Non-string values are now discarded (empty selection, same as reaching the page without the parameter).
- Removed a duplicate `'generate'` key in `setDefaults()` and dropped the now-unmatched legacy PHPStan baseline entry.

## How to test

1. **Trap edit — missing trap** — open a trap edit URL (`?p=6151&o=c&traps_id=<n>`) with a `traps_id` that matches no row. The page must show *"This SNMP trap no longer exists."* instead of a blank edit form or a 500, and saving must not report a phantom success.
2. **Trap edit — nominal** — edit an existing trap: the form loads with its values and saving works as before.
3. **Generate page guard** — Configuration > SNMP Traps > Generate with `?poller[]=1` in the URL. The page must render instead of raising a `TypeError`.

## Links

### Jira ticket

Resolves: [MON-208948](https://centreon.atlassian.net/browse/MON-208948)

### PR Github

Backports: #11465


[MON-208948]: https://centreon.atlassian.net/browse/MON-208948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ