### PR TITLE
fix(configuration): read the notification-view selector from POST as well as GET

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/displayNotification.php
+++ b/centreon/www/include/configuration/configObject/contact/displayNotification.php
@@ -67,8 +67,9 @@ $tpl->assign('headerMenu_service_esc', _('Escalated Services'));
 $style = 'one';
 
 $groups = "''";
-// The selector form submits via GET (onChange), so the value lands in $_GET.
-$contactId = isset($_GET['contact']) ? (int) $_GET['contact'] : 0;
+// The selector's <select onChange='submit();'> is wrapped in the page's POST
+// form, so the chosen id is posted; some callers still pass it via GET. Read both.
+$contactId = (int) ($_POST['contact'] ?? $_GET['contact'] ?? 0);
 
 $contactUnavailable = false;
 if ($contactId && ! array_key_exists($contactId, $contact)) {

--- a/centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
@@ -63,8 +63,9 @@ $tpl->assign('headerMenu_service_esc', _('Escalated Services'));
 $style = 'one';
 
 $groups = "''";
-// The selector form submits via GET (onChange), so the value lands in $_GET.
-$contactgroup_id = isset($_GET['contact']) ? (int) $_GET['contact'] : 0;
+// The selector's <select onChange='submit();'> is wrapped in the page's POST
+// form, so the chosen id is posted; some callers still pass it via GET. Read both.
+$contactgroup_id = (int) ($_POST['contact'] ?? $_GET['contact'] ?? 0);
 
 $contactGroupUnavailable = false;
 if ($contactgroup_id && ! array_key_exists($contactgroup_id, $contact)) {


### PR DESCRIPTION
## Description

- The Users notification views (**Configuration > Users > Contacts / Contact Groups > Notifications**) submit the contact selector through the page's enclosing `<form method="POST">`, so the chosen id arrives in `$_POST`.
- A previous change (#11450) read `$_GET['contact']` only — the id therefore resolved to `0` and the view never rendered the selected contact's / group's notifications.
- Fix: read `$_POST['contact'] ?? $_GET['contact']` in `contact/displayNotification.php` and `contactgroup/displayNotification.php`, matching the `meta_service` selector.
- Empirically confirmed on the CDE: before the fix, selecting a valid in-scope contact left the view on the *"Please select a user..."* prompt; the selector's only enclosing form is `method="post"` (no GET form is rendered).

## How to test

1. **Configuration > Users > Contacts > Notifications**: pick, in the selector, a contact that has notification relations → its host/service notifications and escalations render. *Before:* the view stayed on *"Please select a user in order to view his notifications"*.
2. **Configuration > Users > Contact Groups > Notifications**: same.
3. As a non-admin, an out-of-scope id via the URL still shows the generic *"This contact / contact group is not available"* (ACL scoping unchanged).

## Links

### Jira ticket

Resolves: [MON-208980](https://centreon.atlassian.net/browse/MON-208980)

### PR Github

- Relates to: #11450 — the salvage PR whose `$_POST` → `$_GET` change this corrects.


[MON-208980]: https://centreon.atlassian.net/browse/MON-208980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ