### PR TITLE
fix(e2e): grant SYS_NICE capability to the platform-update/upgrade web container

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -206,7 +206,9 @@ export default (on: Cypress.PluginEvents): void => {
       name,
       portBindings = [],
     }: StartContainerProps) => {
-      let container = await new GenericContainer(image).withName(name);
+      let container = await new GenericContainer(image)
+        .withName(name)
+        .withAddedCapabilities('SYS_NICE');
 
       portBindings.forEach(({ source, destination }) => {
         container = container.withExposedPorts({

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -123,7 +123,7 @@ const getDatabaseService = (engine: DatabaseEngine): string => {
   return isAlma() ? 'mysqld' : 'mysql';
 };
 
-const mysqlRootGrant = `mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'centreon'; GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION"`;
+const mysqlRootGrant = `mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'centreon'; GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION"`;
 const mariadbRootGrant = `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`;
 
 const rootGrantCommand = (engine: DatabaseEngine): string =>


### PR DESCRIPTION
## What
Fixes two independent, pre-existing bugs in `Platform-upgrade-update/01-platform-update.feature` that only surface on the MySQL combos (`alma8-mysql:8.0`, `bookworm-mysql:8.4`) of the e2e matrix.

### 1. `systemctl start mysqld` fails with `ExecStartPre control process exited with error code`
Adds `SYS_NICE` to the container capabilities used by `cy.startContainer()` ([tasks.ts](centreon/packages/js-config/cypress/e2e/tasks.ts)), the singular helper used only by `Platform-upgrade-update/01-platform-update` and `02-platform-upgrade`.

**Root cause**, reproduced locally with the real `centreon-web-dependencies-alma8` image:
- `mysql-server` (`8.0.46-1.module_el8.10.0`) sets the `cap_sys_nice` file capability on `/usr/libexec/mysqld`.
- The `web` container is started via testcontainers `GenericContainer` with Docker's default capability set, which doesn't include `CAP_SYS_NICE`.
- The kernel refuses to `execve()` a binary requesting a file capability the container doesn't hold in its bounding set -> `ExecStartPre=/usr/libexec/mysql-prepare-db-dir` fails with `Operation not permitted` -> `systemctl start mysqld` fails.

Confirmed fix, reproduced end-to-end: a fresh container started with `--cap-add=SYS_NICE`, same `dnf install -y mysql-server mysql`, then `systemctl start mysqld` -> `active (running)` on the first try. MariaDB is unaffected (doesn't request that capability, and Linux capabilities are strictly additive/opt-in). `startContainer` (singular) isn't used by any other test suite.

### 2. Install wizard stuck on step 6 on `bookworm-mysql:8.4`
Forces `caching_sha2_password` for the mysql root grant in [common.ts](centreon/tests/e2e/features/Platform-upgrade-update/common.ts) (`mysqlRootGrant`).

**Root cause**, reproduced locally with the real `centreon-web-dependencies-bookworm` image:
- Debian's `mysql-community-server` package defaults `root@localhost` to the `auth_socket` plugin (OS peer-credential auth, password ignored).
- `ALTER USER 'root'@'localhost' IDENTIFIED BY '...'` alone does not switch the plugin away from `auth_socket`.
- The `mysql` CLI has a special case where `-h localhost` always uses the Unix socket, masking the problem. PDO (used by the install wizard's `process_step6.php`) makes a real TCP connection, which `auth_socket` unconditionally rejects (`Access denied`, SQL error 1698).
- The wizard's step 6 JS (`validation()` in `step6.tpl`) only advances to step 7 when `process_step6.php` returns an empty `connection` error, so the UI silently stays stuck on step 6 until the 20s Cypress timeout.

Confirmed fix, reproduced end-to-end: after `ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'centreon'`, `process_step6.php` returns `"connection":""` and the wizard advances normally. `alma8-mysql` is unaffected (Oracle's RPM build doesn't default root to `auth_socket`), so this change is a safe no-op there.

## Verification
- Both root causes reproduced locally against the real dependency images (`alma8`, `bookworm`) before any fix was written.
- Both fixes confirmed to resolve the issue locally before pushing.
- CI run with the full OS/DB matrix + upgrade tests forced on: https://github.com/centreon/centreon/actions/runs/34373307408
