### PR TITLE
feat(host-category): expose GET /configuration/host_categories selector

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -139,6 +139,9 @@ tags:
   -
     name: HostTemplate
     description: "Resource 'HostTemplate' operations."
+  -
+    name: HostCategory
+    description: "Resource 'HostCategory' operations."
 security:
   -
     Token: []
@@ -5471,6 +5474,77 @@ paths:
             maximum: 30
           style: form
           explode: true
+  /api/configuration/host_categories:
+    get:
+      operationId: api_configurationhost_categories_get_collection
+      tags:
+        - HostCategory
+      responses:
+        '200':
+          description: 'HostCategory collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'HostCategory.HostCategoryCollectionOutput.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/HostCategory.HostCategoryCollectionOutput.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HostCategory.HostCategoryCollectionOutput'
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Retrieves the collection of HostCategory resources.'
+      description: 'Retrieves the collection of HostCategory resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by host category name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
 components:
   securitySchemes:
     Token:
@@ -10737,3 +10811,21 @@ components:
           type: integer
         name:
           type: string
+    HostCategory.HostCategoryCollectionOutput:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    HostCategory.HostCategoryCollectionOutput.jsonld:
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostCategory/HostCategory.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostCategory/HostCategory.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostCategory;
+
+use App\Shared\Domain\Aggregate\AggregateRoot;
+
+/**
+ * @extends AggregateRoot<HostCategoryId>
+ */
+final class HostCategory extends AggregateRoot
+{
+    public function __construct(
+        ?HostCategoryId $id,
+        public readonly HostCategoryName $name,
+    ) {
+        parent::__construct($id);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostCategory/HostCategoryId.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostCategory/HostCategoryId.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostCategory;
+
+use App\Shared\Domain\Aggregate\AggregateRootId;
+
+final readonly class HostCategoryId extends AggregateRootId
+{
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostCategory/HostCategoryName.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostCategory/HostCategoryName.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostCategory;
+
+use Webmozart\Assert\Assert;
+
+final readonly class HostCategoryName
+{
+    public const MIN_LENGTH = 1;
+    public const MAX_LENGTH = 200;
+
+    public function __construct(
+        public string $value,
+    ) {
+        Assert::lengthBetween($value, self::MIN_LENGTH, self::MAX_LENGTH);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/HostCategoryCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/HostCategoryCriteria.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Repository\Criteria;
+
+use App\Security\Domain\Aggregate\UserId;
+use Webmozart\Assert\Assert;
+
+final class HostCategoryCriteria
+{
+    private ?int $page = null;
+
+    private ?int $itemsPerPage = null;
+
+    private ?string $name = null;
+
+    private ?UserId $viewerId = null;
+
+    public function withPagination(int $page, int $itemsPerPage): self
+    {
+        Assert::positiveInteger($page);
+        Assert::positiveInteger($itemsPerPage);
+
+        $new = clone $this;
+        $new->page = $page;
+        $new->itemsPerPage = $itemsPerPage;
+
+        return $new;
+    }
+
+    public function withName(string $name): self
+    {
+        // notEmpty() relies on empty(), which would wrongly reject a legitimate name of "0"
+        Assert::stringNotEmpty($name);
+
+        $new = clone $this;
+        $new->name = $name;
+
+        return $new;
+    }
+
+    /**
+     * @param UserId|null $viewerId the user to scope results for, or null when no ACL restriction applies (e.g. an admin)
+     */
+    public function withViewerId(?UserId $viewerId): self
+    {
+        $new = clone $this;
+        $new->viewerId = $viewerId;
+
+        return $new;
+    }
+
+    public function getPage(): ?int
+    {
+        return $this->page;
+    }
+
+    public function getItemsPerPage(): ?int
+    {
+        return $this->itemsPerPage;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getViewerId(): ?UserId
+    {
+        return $this->viewerId;
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/HostCategoryRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/HostCategoryRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Repository;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategory;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostCategoryCriteria;
+
+interface HostCategoryRepository
+{
+    /**
+     * @return \IteratorAggregate<int, HostCategory>&\Countable
+     */
+    public function findAll(?HostCategoryCriteria $criteria = null): \IteratorAggregate&\Countable;
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Security/HostCategoryPermissionEnum.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Security/HostCategoryPermissionEnum.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Security;
+
+enum HostCategoryPermissionEnum: string
+{
+    case CanRead = 'can_read_host_category';
+    case CanReadAndWrite = 'can_read_and_write_host_category';
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostCategory/HostCategoryCollectionOutput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostCategory/HostCategoryCollectionOutput.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+final class HostCategoryCollectionOutput
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostCategory/HostCategoryResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostCategory/HostCategoryResource.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\OpenApi\Model;
+use App\MonitoringConfiguration\Domain\Security\HostCategoryPermissionEnum;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostCategory\ListHostCategoriesProvider;
+
+#[ApiResource(
+    shortName: 'HostCategory',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/configuration/host_categories',
+            provider: ListHostCategoriesProvider::class,
+            output: HostCategoryCollectionOutput::class,
+            openapi: new Model\Operation(
+                parameters: [
+                    new Model\Parameter(
+                        name: 'name[lk]',
+                        in: 'query',
+                        description: 'Filter by host category name using "like" operator',
+                        required: false,
+                        schema: ['type' => 'string'],
+                    ),
+                ],
+            ),
+            security: '
+                is_granted("' . HostCategoryPermissionEnum::CanRead->value . '") or
+                is_granted("' . HostCategoryPermissionEnum::CanReadAndWrite->value . '")',
+            securityMessage: 'You are not allowed to list host categories',
+        ),
+    ],
+)]
+final class HostCategoryResource
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostCategory/HostCategoryCollectionTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostCategory/HostCategoryCollectionTransformer.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostCategory;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategory;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostCategory\HostCategoryCollectionOutput;
+use App\Shared\Infrastructure\TransformerInterface;
+
+/**
+ * @implements TransformerInterface<HostCategory, HostCategoryCollectionOutput>
+ */
+final readonly class HostCategoryCollectionTransformer implements TransformerInterface
+{
+    public function transform(mixed $from): HostCategoryCollectionOutput
+    {
+        return new HostCategoryCollectionOutput(
+            id: $from->id()->value,
+            name: $from->name->value,
+        );
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostCategory/ListHostCategoriesProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostCategory/ListHostCategoriesProvider.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostCategory;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategory;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostCategoryCriteria;
+use App\MonitoringConfiguration\Domain\Repository\HostCategoryRepository;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostCategory\HostCategoryCollectionOutput;
+use App\Security\Infrastructure\Security\CredentialUser;
+use App\Shared\Domain\Repository\Paginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Webmozart\Assert\Assert;
+
+/**
+ * @implements ProviderInterface<HostCategoryCollectionOutput>
+ */
+final readonly class ListHostCategoriesProvider implements ProviderInterface
+{
+    /**
+     * @param TransformerInterface<HostCategory, HostCategoryCollectionOutput> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: HostCategoryCollectionTransformer::class)]
+        private TransformerInterface $transformer,
+        private HostCategoryRepository $repository,
+        private Pagination $pagination,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @return iterable<HostCategoryCollectionOutput>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
+    {
+        $credentialUser = $this->security->getUser();
+        Assert::isInstanceOf($credentialUser, CredentialUser::class);
+        // Super admins and Cloud tenant admins escape ACL scoping, matching legacy
+        // FindHostCategories::isUserAdmin (Contact::isAdmin OR customer_admin_acl on Cloud).
+        $hasUnrestrictedResourceAccess = $credentialUser->credential->hasUnrestrictedResourceAccess();
+
+        $criteria = new HostCategoryCriteria();
+        if ($this->pagination->isEnabled($operation, $context)) {
+            $itemsPerPage = $this->pagination->getLimit($operation, $context);
+            if ($itemsPerPage <= 0) {
+                throw new BadRequestHttpException('itemsPerPage must be a positive integer.');
+            }
+            $criteria = $criteria->withPagination($this->pagination->getPage($context), $itemsPerPage);
+        }
+
+        /** @var array{name?: mixed} $filters */
+        $filters = $context['filters'] ?? [];
+        $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
+
+        // Unrestricted users see every host category; others are scoped to their accessible categories.
+        $criteria = $hasUnrestrictedResourceAccess
+            ? $criteria
+            : $criteria->withViewerId($credentialUser->credential->userId);
+
+        $hostCategories = $this->repository->findAll($criteria);
+        $resources = [];
+        foreach ($hostCategories as $hostCategory) {
+            $resources[] = $this->transformer->transform($hostCategory);
+        }
+
+        if (! $hostCategories instanceof Paginator) {
+            return $resources;
+        }
+
+        return new TraversablePaginator(
+            new \ArrayIterator($resources),
+            $hostCategories->getCurrentPage(),
+            $hostCategories->getItemsPerPage(),
+            $hostCategories->getTotalItems()
+        );
+    }
+
+    private function handleNameFilter(mixed $nameFilter, HostCategoryCriteria $criteria): HostCategoryCriteria
+    {
+        if ($nameFilter === null) {
+            return $criteria;
+        }
+
+        // a client sending "?name=foo" instead of "?name[lk]=foo" lands here as a plain string
+        if (! is_array($nameFilter)) {
+            throw new BadRequestHttpException('The "name" filter must use the "name[lk]=value" format.');
+        }
+
+        $likeValue = $nameFilter['lk'] ?? null;
+        if (is_array($likeValue)) {
+            $likeValue = reset($likeValue);
+        }
+
+        if (! is_string($likeValue) || $likeValue === '') {
+            return $criteria;
+        }
+
+        return $criteria->withName($likeValue);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostCategoryRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostCategoryRepository.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategory;
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategoryId;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostCategoryCriteria;
+use App\MonitoringConfiguration\Domain\Repository\HostCategoryRepository;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Domain\Repository\ResourceAccessRepository;
+use App\Shared\Domain\Collection;
+use App\Shared\Infrastructure\Dbal\DbalCriteriaApplierTrait;
+use App\Shared\Infrastructure\Dbal\DbalRepository;
+use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * @phpstan-type RowTypeAlias = array{
+ *   hc_id: int,
+ *   hc_name: string,
+ * }
+ */
+final readonly class DbalHostCategoryRepository extends DbalRepository implements HostCategoryRepository
+{
+    use DbalCriteriaApplierTrait;
+    public const TABLE_NAME = 'hostcategories';
+
+    /**
+     * @param TransformerInterface<RowTypeAlias, HostCategory> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: 'doctrine.dbal.default_connection')]
+        private Connection $connection,
+
+        #[Autowire(service: HostCategoryTransformer::class)]
+        private TransformerInterface $transformer,
+
+        private ResourceAccessRepository $resourceAccessRepository,
+    ) {
+    }
+
+    public function findAll(?HostCategoryCriteria $criteria = null): \IteratorAggregate&\Countable
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('hc.hc_id', 'hc.hc_name')
+            ->from(self::TABLE_NAME, 'hc')
+            // a HostCategory is a hostcategories row without a severity level; rows carrying a
+            // level are host severities, a distinct concept that must never surface here.
+            ->where('hc.level IS NULL')
+            ->orderBy('hc.hc_id'); // required for deterministic pagination
+
+        if ($criteria instanceof HostCategoryCriteria) {
+            $this->filterByCriteria($qb, $criteria);
+        }
+
+        if ($criteria?->getPage() === null || $criteria->getItemsPerPage() === null) {
+            /** @var array<RowTypeAlias> $rows */
+            $rows = $qb->executeQuery()->fetchAllAssociative();
+
+            return $this->createHostCategories($rows);
+        }
+
+        $this->paginate($qb, $criteria);
+
+        // total across all pages: countMatching clones $qb and strips its sort/pagination,
+        // so it is unaffected by the pagination applied above.
+        $count = $this->countMatching($qb, 'COUNT(DISTINCT hc.hc_id)');
+
+        /** @var array<RowTypeAlias> $rows */
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        return new InMemoryPaginator(
+            items: $this->createHostCategories($rows),
+            totalItems: $count,
+            currentPage: $criteria->getPage() ?? throw new \LogicException('Unexpected null page'),
+            itemsPerPage: $criteria->getItemsPerPage() ?? throw new \LogicException('Unexpected null items per page'),
+        );
+    }
+
+    private function filterByCriteria(QueryBuilder $qb, HostCategoryCriteria $criteria): void
+    {
+        if (($name = $criteria->getName()) !== null) {
+            $qb->andWhere($qb->expr()->like('hc.hc_name', $qb->createNamedParameter('%' . $name . '%')));
+        }
+
+        $this->filterByViewer($qb, $criteria);
+    }
+
+    private function filterByViewer(QueryBuilder $qb, HostCategoryCriteria $criteria): void
+    {
+        $viewerId = $criteria->getViewerId();
+        if (! $viewerId instanceof UserId) {
+            return;
+        }
+
+        $accessibleHostCategories = $this->resourceAccessRepository->findAccessibleHostCategoryIds($viewerId);
+        // null means no host-category restriction applies — the viewer sees every category.
+        if (! $accessibleHostCategories instanceof Collection) {
+            return;
+        }
+
+        $accessibleHostCategoryIds = array_map(
+            static fn (HostCategoryId $hostCategoryId): int => $hostCategoryId->value,
+            $accessibleHostCategories->toArray()
+        );
+
+        // A non-null but empty set means the viewer is restricted on host categories yet granted
+        // none (e.g. their ACL points only at severities): they see nothing. Mirrors legacy, where
+        // hasRestrictedAccessToHostCategories is true but findAllByAccessGroupIds returns no row.
+        if ($accessibleHostCategoryIds === []) {
+            $qb->andWhere('1 = 0');
+
+            return;
+        }
+
+        // Restrict to categories the viewer can access. findAccessibleHostCategoryIds already scopes
+        // the set to levelless categories, so it never carries a severity id.
+        $qb->andWhere(
+            'hc.hc_id IN (' . $qb->createNamedParameter(
+                $accessibleHostCategoryIds,
+                ArrayParameterType::INTEGER
+            ) . ')'
+        );
+    }
+
+    /**
+     * @param array<RowTypeAlias> $rows
+     *
+     * @return Collection<HostCategory>
+     */
+    private function createHostCategories(array $rows): Collection
+    {
+        return new Collection(
+            array_map(
+                fn (array $row): HostCategory => $this->transformer->transform($row),
+                $rows
+            ),
+            HostCategory::class
+        );
+    }
+
+    private function paginate(QueryBuilder $qb, HostCategoryCriteria $criteria): void
+    {
+        if ($criteria->getPage() === null || $criteria->getItemsPerPage() === null) {
+            return;
+        }
+
+        $qb->setFirstResult(($criteria->getPage() - 1) * $criteria->getItemsPerPage())
+            ->setMaxResults($criteria->getItemsPerPage());
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/HostCategoryTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/HostCategoryTransformer.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategory;
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategoryId;
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategoryName;
+use App\Shared\Infrastructure\TransformerInterface;
+
+/**
+ * @phpstan-import-type RowTypeAlias from DbalHostCategoryRepository
+ *
+ * @implements TransformerInterface<RowTypeAlias,HostCategory>
+ */
+final readonly class HostCategoryTransformer implements TransformerInterface
+{
+    /**
+     * @param RowTypeAlias $from
+     */
+    public function transform(mixed $from): HostCategory
+    {
+        return new HostCategory(
+            id: new HostCategoryId($from['hc_id']),
+            name: new HostCategoryName($from['hc_name']),
+        );
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Security/HostCategoryPermissionVoter.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Security/HostCategoryPermissionVoter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Security;
+
+use App\MonitoringConfiguration\Domain\Security\HostCategoryPermissionEnum;
+use App\Security\Domain\Aggregate\Permission;
+use App\Security\Infrastructure\Security\CredentialUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<value-of<HostCategoryPermissionEnum>, mixed>
+ */
+final class HostCategoryPermissionVoter extends Voter
+{
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return HostCategoryPermissionEnum::tryFrom($attribute) !== null;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        $user = $token->getUser();
+
+        if (! $user instanceof CredentialUser) {
+            $vote?->addReason('The user is not logged in.');
+
+            return false;
+        }
+
+        if (! $user->credential->isPermissionGranted(new Permission($attribute))) {
+            $vote?->addReason('The user has not the required permission.');
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/centreon/src/App/Security/Domain/Repository/ResourceAccessRepository.php
+++ b/centreon/src/App/Security/Domain/Repository/ResourceAccessRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\Security\Domain\Repository;
 
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategoryId;
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
 use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
@@ -34,6 +35,20 @@ interface ResourceAccessRepository
     public function hasAccessToAllPollers(UserId $userId): bool;
 
     public function hasAccessToPoller(PollerId $pollerId, UserId $userId): bool;
+
+    /**
+     * Returns the levelless host categories the user is restricted to.
+     *
+     * Three states, mirroring the legacy host-category ACL (DbReadHostCategoryRepository::
+     * findAllByAccessGroupIds guarded by hasRestrictedAccessToHostCategories):
+     *  - null                   → no restriction applies; the user sees every category
+     *  - an empty Collection    → the user is restricted but grants no accessible regular category
+     *                             (e.g. only severities, or no accessible ACL resource): sees nothing
+     *  - a non-empty Collection → the user is restricted to exactly these categories
+     *
+     * @return Collection<HostCategoryId>|null
+     */
+    public function findAccessibleHostCategoryIds(UserId $userId): ?Collection;
 
     /**
      * Returns the host severities (host categories carrying a level) the user is restricted to.

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
@@ -27,6 +27,7 @@ use App\MonitoringConfiguration\Domain\Security\AgentConfigurationPermissionEnum
 use App\MonitoringConfiguration\Domain\Security\CommandPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\ConnectorPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\GlobalMacroPermissionEnum;
+use App\MonitoringConfiguration\Domain\Security\HostCategoryPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\HostGroupPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\HostPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\HostTemplatePermissionEnum;
@@ -64,6 +65,8 @@ final readonly class DbalCredentialTransformer implements TransformerInterface
         'ROLE_CONFIGURATION_HOSTS_HOSTS_RW' => HostPermissionEnum::CanReadAndWrite->value,
         'ROLE_CONFIGURATION_HOSTS_TEMPLATES_R' => HostTemplatePermissionEnum::CanRead->value,
         'ROLE_CONFIGURATION_HOSTS_TEMPLATES_RW' => HostTemplatePermissionEnum::CanReadAndWrite->value,
+        'ROLE_CONFIGURATION_HOSTS_CATEGORIES_R' => HostCategoryPermissionEnum::CanRead->value,
+        'ROLE_CONFIGURATION_HOSTS_CATEGORIES_RW' => HostCategoryPermissionEnum::CanReadAndWrite->value,
     ];
 
     /**

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\Security\Infrastructure\Dbal;
 
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategoryId;
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
 use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
@@ -88,6 +89,62 @@ final readonly class DbalResourceAccessRepository implements ResourceAccessRepos
             'contactId' => $userId->value,
             'pollerId' => $pollerId->value,
         ]);
+    }
+
+    public function findAccessibleHostCategoryIds(UserId $userId): ?Collection
+    {
+        $accessibleAclResQb = $this->getAccessibleAclResourcesQueryBuilder();
+
+        // Tier 1 — legacy `if ($accessGroups === []) return []`: a user with no accessible ACL resource
+        // is fully restricted (fails closed), not unrestricted. Returning an empty Collection keeps the
+        // "sees nothing" contract distinct from the "sees everything" null below.
+        $hasAccessibleResourceQb = $this->connection->createQueryBuilder();
+        $hasAccessibleResourceQb
+            ->select('1')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->setParameter('contactId', $userId->value)
+            ->setMaxResults(1);
+
+        if ($this->connection->fetchOne($hasAccessibleResourceQb->getSQL(), ['contactId' => $userId->value]) === false) {
+            return new Collection([], HostCategoryId::class);
+        }
+
+        // Tier 2 — legacy `hasRestrictedAccessToHostCategories() === false`: accessible resources exist
+        // but none carry a host-category ACL relation (of any level), so no category restriction is in
+        // force and the user sees every category.
+        $hasHostCategoryRelationQb = $this->connection->createQueryBuilder();
+        $hasHostCategoryRelationQb
+            ->select('1')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources_hc_relations', 'arhcr', 'arhcr.acl_res_id = accessible_res.acl_res_id')
+            ->setParameter('contactId', $userId->value)
+            ->setMaxResults(1);
+
+        if ($this->connection->fetchOne($hasHostCategoryRelationQb->getSQL(), ['contactId' => $userId->value]) === false) {
+            return null;
+        }
+
+        // Tier 3 — legacy `AND hc.hc_id IN (<granted categories>)` on a `hc.level IS NULL` join: the user
+        // is restricted to the regular (levelless) categories their accessible resources grant. A levelless
+        // host category is a regular category; one carrying a level is a host "severity", a distinct
+        // concept. A user granted only severities yields an empty set and therefore sees no category,
+        // matching legacy findAllByAccessGroupIds, which filters level IS NULL over the grant.
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('DISTINCT arhcr.hc_id')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources_hc_relations', 'arhcr', 'arhcr.acl_res_id = accessible_res.acl_res_id')
+            ->innerJoin('arhcr', 'hostcategories', 'hc', 'hc.hc_id = arhcr.hc_id')
+            ->where('hc.level IS NULL')
+            ->setParameter('contactId', $userId->value);
+
+        /** @var list<array{hc_id: numeric-string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($qb->getSQL(), ['contactId' => $userId->value]);
+
+        return new Collection(
+            array_map(static fn (array $row): HostCategoryId => new HostCategoryId((int) $row['hc_id']), $rows),
+            HostCategoryId::class,
+        );
     }
 
     public function findAccessibleHostSeverityIds(UserId $userId): ?Collection

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostCategory/ListHostCategoriesProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostCategory/ListHostCategoriesProviderTest.php
@@ -1,0 +1,300 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostCategory;
+
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostCategory\HostCategoryResource;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Uid\Uuid;
+use Tests\App\Shared\ApiTestCase;
+use Webmozart\Assert\Assert;
+
+final class ListHostCategoriesProviderTest extends ApiTestCase
+{
+    private const BASE_ENDPOINT = '/api/configuration/host_categories';
+
+    // topology pages whose hierarchy builds ROLE_CONFIGURATION_HOSTS_CATEGORIES_R
+    // (Configuration > Hosts > Categories), bridged to HostCategoryPermissionEnum::CanRead
+    // via DbalCredentialTransformer::LEGACY_PERMISSION_MAP.
+    private const HOST_CATEGORY_READ_TOPOLOGY_PAGES = [6, 601, 60104];
+
+    private Connection $connection;
+
+    private string $tag;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->tag = Uuid::v4()->toRfc4122();
+    }
+
+    public function testItRequiresAuthentication(): void
+    {
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testItIsForbiddenForUserWithoutSufficientAcl(): void
+    {
+        $username = bin2hex(random_bytes(8));
+        $this->createApiUser($this->connection, $username, admin: false);
+        $this->login($username);
+
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testItListsHostCategoriesAsAdminWithOnlyIdAndName(): void
+    {
+        $this->insertHostCategory("cat-A-{$this->tag}");
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => "cat-A-{$this->tag}"]]]);
+        self::assertResponseIsSuccessful();
+        self::assertMatchesResourceCollectionJsonSchema(HostCategoryResource::class);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => "cat-A-{$this->tag}"],
+            ],
+        ]);
+
+        /** @var list<array<string, mixed>> $member */
+        $member = $response->toArray()['member'];
+        self::assertEqualsCanonicalizing(['@id', '@type', 'id', 'name'], array_keys($member[0]));
+    }
+
+    public function testItExcludesSeveritiesFromListing(): void
+    {
+        $this->insertHostCategory("cat-{$this->tag}");
+        $this->insertHostCategory("sev-{$this->tag}", level: 1);
+
+        $this->login();
+
+        // both share the hostcategories table; only the levelless category is a host category
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => "{$this->tag}"]]]);
+        self::assertResponseIsSuccessful();
+        self::assertSame(
+            ["cat-{$this->tag}"],
+            array_column((array) $response->toArray()['member'], 'name')
+        );
+    }
+
+    public function testItFiltersHostCategoriesByNameUsingLikeOperator(): void
+    {
+        $this->insertHostCategory("match-{$this->tag}");
+        $this->insertHostCategory("other-{$this->tag}");
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => "match-{$this->tag}"]]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => "match-{$this->tag}"],
+            ],
+        ]);
+    }
+
+    public function testItPaginatesHostCategories(): void
+    {
+        $this->insertHostCategory("pg-{$this->tag}-A");
+        $this->insertHostCategory("pg-{$this->tag}-B");
+        $this->insertHostCategory("pg-{$this->tag}-C");
+
+        $this->login();
+
+        // scope to our own rows via the name filter so pre-seeded categories cannot skew the total
+        $response = $this->request('GET', self::BASE_ENDPOINT, [
+            'query' => ['name' => ['lk' => "pg-{$this->tag}-"], 'page' => '1', 'itemsPerPage' => '2'],
+        ]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(2, (array) $response->toArray()['member']);
+        self::assertEquals(3, $response->toArray()['totalItems']);
+    }
+
+    public function testItRestrictsListingToAccessibleCategoriesForARestrictedUser(): void
+    {
+        $accessibleId = $this->insertHostCategory("acl-in-{$this->tag}");
+        $this->insertHostCategory("acl-out-{$this->tag}");
+        // a severity granted through the same resource must stay excluded (it is not a category)
+        $severityId = $this->insertHostCategory("acl-sev-{$this->tag}", level: 1);
+
+        $username = bin2hex(random_bytes(8));
+        $contactId = $this->createNonAdminContact($username);
+        $this->grantHostCategoryReadTopologyRole($contactId);
+        $this->restrictContactToHostCategories($contactId, [$accessibleId, $severityId]);
+
+        $this->login($username);
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        // only the accessible levelless category is returned; the inaccessible category, the granted
+        // severity, and any pre-seeded categories are excluded.
+        self::assertSame(
+            ["acl-in-{$this->tag}"],
+            array_column((array) $response->toArray()['member'], 'name')
+        );
+    }
+
+    public function testItIgnoresAnEmptyNameFilter(): void
+    {
+        $this->insertHostCategory("empty-{$this->tag}");
+
+        $this->login();
+
+        // an empty "like" value must be ignored (not applied, not rejected, not a 500 from the VO)
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '']]]);
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testItFiltersByANameOfLiteralZero(): void
+    {
+        $this->insertHostCategory('0');
+
+        $this->login();
+
+        // "0" is a legitimate name; the criteria's Assert::stringNotEmpty must not reject it
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '0']]]);
+        self::assertResponseIsSuccessful();
+        self::assertContains('0', array_column((array) $response->toArray()['member'], 'name'));
+    }
+
+    public function testItRejectsAScalarNameFilter(): void
+    {
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => "cat-{$this->tag}"]]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testItRejectsZeroItemsPerPage(): void
+    {
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['itemsPerPage' => '0']]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    private function insertHostCategory(string $name, ?int $level = null): int
+    {
+        // a host category with a level is a host "severity"; a levelless one is a regular category
+        $this->connection->insert('hostcategories', ['hc_name' => $name, 'hc_activate' => '1', 'level' => $level]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function createNonAdminContact(string $alias): int
+    {
+        $this->createApiUser($this->connection, $alias, admin: false);
+
+        $contactId = $this->connection->fetchOne(
+            'SELECT contact_id FROM contact WHERE contact_alias = :alias',
+            ['alias' => $alias]
+        );
+        Assert::notFalse($contactId);
+        Assert::scalar($contactId);
+
+        return (int) $contactId;
+    }
+
+    private function grantHostCategoryReadTopologyRole(int $contactId): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => "topology-group-{$this->tag}",
+            'acl_group_alias' => "topology-group-{$this->tag}",
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_topology', [
+            'acl_topo_name' => "topology-rule-{$this->tag}",
+            'acl_topo_alias' => "topology-rule-{$this->tag}",
+            'acl_topo_activate' => '1',
+        ]);
+        $aclTopoId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_topology_relations', [
+            'acl_group_id' => $aclGroupId,
+            'acl_topology_id' => $aclTopoId,
+        ]);
+
+        foreach (self::HOST_CATEGORY_READ_TOPOLOGY_PAGES as $topologyPage) {
+            $topologyId = $this->connection->fetchOne(
+                'SELECT topology_id FROM topology WHERE topology_page = :page',
+                ['page' => $topologyPage]
+            );
+            Assert::notFalse($topologyId, "topology_page {$topologyPage} not found in fixtures");
+            Assert::scalar($topologyId);
+
+            $this->connection->insert('acl_topology_relations', [
+                'topology_topology_id' => (int) $topologyId,
+                'acl_topo_id' => $aclTopoId,
+                'access_right' => 2, // read-only
+            ]);
+        }
+    }
+
+    /**
+     * @param list<int> $hostCategoryIds
+     */
+    private function restrictContactToHostCategories(int $contactId, array $hostCategoryIds): void
+    {
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => "hc-scope-{$this->tag}",
+            'acl_res_alias' => "hc-scope-{$this->tag}",
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $aclGroupId = $this->connection->fetchOne(
+            'SELECT acl_group_id FROM acl_group_contacts_relations WHERE contact_contact_id = :contactId',
+            ['contactId' => $contactId]
+        );
+        Assert::notFalse($aclGroupId);
+        Assert::scalar($aclGroupId);
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => (int) $aclGroupId,
+        ]);
+
+        foreach ($hostCategoryIds as $hostCategoryId) {
+            $this->connection->insert('acl_resources_hc_relations', [
+                'acl_res_id' => $aclResId,
+                'hc_id' => $hostCategoryId,
+            ]);
+        }
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostCategoryRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostCategoryRepositoryTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategory;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostCategoryCriteria;
+use App\MonitoringConfiguration\Infrastructure\Dbal\DbalHostCategoryRepository;
+use App\MonitoringConfiguration\Infrastructure\Dbal\HostCategoryTransformer;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Infrastructure\Dbal\DbalResourceAccessRepository;
+use App\Shared\Domain\Repository\Paginator;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class DbalHostCategoryRepositoryTest extends KernelTestCase
+{
+    private Connection $connection;
+
+    private DbalHostCategoryRepository $repository;
+
+    private string $tag;
+
+    protected function setUp(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // The repository has no ApiPlatform consumer yet (that lands with the Provider), so the
+        // container would prune it; construct it directly from the always-public DBAL connection.
+        $this->repository = new DbalHostCategoryRepository(
+            $this->connection,
+            new HostCategoryTransformer(),
+            new DbalResourceAccessRepository($this->connection),
+        );
+
+        // unique per test run so assertions are isolated from any pre-seeded host categories
+        $this->tag = Uuid::v4()->toRfc4122();
+    }
+
+    public function testFindAllReturnsCategoriesAndExcludesSeverities(): void
+    {
+        $categoryName = "cat-{$this->tag}";
+        $severityName = "sev-{$this->tag}";
+        $this->insertHostCategory($categoryName);
+        $this->insertHostCategory($severityName, level: 1);
+
+        $names = $this->names($this->repository->findAll());
+
+        self::assertContains($categoryName, $names);
+        self::assertNotContains($severityName, $names, 'A host severity (level IS NOT NULL) must not appear among host categories.');
+    }
+
+    public function testFindAllFiltersByNameUsingLike(): void
+    {
+        $this->insertHostCategory("match-{$this->tag}");
+        $this->insertHostCategory("other-{$this->tag}");
+
+        $names = $this->names($this->repository->findAll((new HostCategoryCriteria())->withName("match-{$this->tag}")));
+
+        self::assertSame(["match-{$this->tag}"], $names);
+    }
+
+    public function testFindAllPaginatesAndReturnsATotalAcrossAllPages(): void
+    {
+        $this->insertHostCategory("pg-{$this->tag}-A");
+        $this->insertHostCategory("pg-{$this->tag}-B");
+        $this->insertHostCategory("pg-{$this->tag}-C");
+
+        // scope to our own rows via the name filter so pre-seeded categories cannot skew the total.
+        // page 2 @ 1 item/page proves the OFFSET arithmetic (a page-1 request cannot).
+        $result = $this->repository->findAll(
+            (new HostCategoryCriteria())->withName("pg-{$this->tag}-")->withPagination(2, 1)
+        );
+
+        self::assertInstanceOf(Paginator::class, $result);
+        self::assertSame(3, $result->getTotalItems());
+        // rows are ordered by hc_id (insertion order A, B, C), so page 2 is the second row
+        self::assertSame(["pg-{$this->tag}-B"], $this->names($result));
+    }
+
+    public function testFindAllRestrictsToAccessibleCategoriesForARestrictedViewer(): void
+    {
+        $accessibleName = "acl-in-{$this->tag}";
+        $accessibleId = $this->insertHostCategory($accessibleName);
+        $inaccessibleName = "acl-out-{$this->tag}";
+        $this->insertHostCategory($inaccessibleName);
+        // a severity whose id is granted to the viewer: it must stay excluded because it is a
+        // severity, proving a severity id in the ACL set is inert against the level IS NULL filter.
+        $severityName = "acl-sev-{$this->tag}";
+        $severityId = $this->insertHostCategory($severityName, level: 1);
+
+        $viewerId = new UserId($this->createContactRestrictedToHostCategories([$accessibleId, $severityId]));
+
+        $names = $this->names($this->repository->findAll((new HostCategoryCriteria())->withViewerId($viewerId)));
+
+        self::assertContains($accessibleName, $names);
+        self::assertNotContains($inaccessibleName, $names, 'A category not in the viewer ACL is excluded.');
+        self::assertNotContains($severityName, $names, 'A severity is excluded even when its id is granted in the ACL.');
+    }
+
+    public function testFindAllReturnsAllCategoriesForAViewerWithNoCategoryRestriction(): void
+    {
+        $categoryName = "acl-any-{$this->tag}";
+        $this->insertHostCategory($categoryName);
+
+        // ACL resource without any host-category relation → no restriction → sees every category
+        $viewerId = new UserId($this->createContactRestrictedToHostCategories([]));
+
+        $names = $this->names($this->repository->findAll((new HostCategoryCriteria())->withViewerId($viewerId)));
+
+        self::assertContains($categoryName, $names);
+    }
+
+    public function testFindAllReturnsNoCategoryForAViewerGrantedOnlySeverities(): void
+    {
+        $severityId = $this->insertHostCategory("sev-only-{$this->tag}", level: 1);
+        $this->insertHostCategory("cat-{$this->tag}"); // a real category, but not granted to the viewer
+
+        // the viewer's ACL grants only a severity → restricted, but to zero regular categories
+        $viewerId = new UserId($this->createContactRestrictedToHostCategories([$severityId]));
+
+        $names = $this->names($this->repository->findAll((new HostCategoryCriteria())->withViewerId($viewerId)));
+
+        self::assertSame([], $names, 'A viewer granted only severities is restricted and sees no category.');
+    }
+
+    /**
+     * @param \IteratorAggregate<int, HostCategory>&\Countable $result
+     *
+     * @return list<string>
+     */
+    private function names(\IteratorAggregate&\Countable $result): array
+    {
+        return array_values(array_map(
+            static fn (HostCategory $hostCategory): string => $hostCategory->name->value,
+            iterator_to_array($result)
+        ));
+    }
+
+    private function insertHostCategory(string $name, ?int $level = null): int
+    {
+        // a host category with a level is a host "severity"; a levelless one is a regular category
+        $this->connection->insert('hostcategories', ['hc_name' => $name, 'hc_activate' => '1', 'level' => $level]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    /**
+     * @param list<int> $accessibleHostCategoryIds empty means the ACL resource carries no host-category restriction
+     */
+    private function createContactRestrictedToHostCategories(array $accessibleHostCategoryIds): int
+    {
+        $alias = "viewer-{$this->tag}";
+        $this->connection->insert('contact', [
+            'contact_name' => $alias,
+            'contact_alias' => $alias,
+            'contact_admin' => '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => $alias . '@email.com',
+        ]);
+        $contactId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => "group-{$this->tag}",
+            'acl_group_alias' => "group-{$this->tag}",
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => "resource-{$this->tag}",
+            'acl_res_alias' => "resource-{$this->tag}",
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($accessibleHostCategoryIds as $hostCategoryId) {
+            $this->connection->insert('acl_resources_hc_relations', [
+                'acl_res_id' => $aclResId,
+                'hc_id' => $hostCategoryId,
+            ]);
+        }
+
+        return $contactId;
+    }
+}

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\App\Security\Infrastructure\Dbal;
 
+use App\MonitoringConfiguration\Domain\Aggregate\HostCategory\HostCategoryId;
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
 use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
@@ -194,6 +195,65 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
         $accessiblePollerIds = $this->repository->findAccessiblePollerIds($userId);
         self::assertNotNull($accessiblePollerIds);
         self::assertEquals([101], array_map(static fn (PollerId $id): int => $id->value, iterator_to_array($accessiblePollerIds)));
+    }
+
+    public function testUserWithNoAclGroupSeesNoHostCategory(): void
+    {
+        // Tier 1 fail-closed: a user with no accessible ACL resource is fully restricted, returning
+        // an empty Collection ("sees nothing"), not the null "see all".
+        $userId = new UserId($this->createContact('user-no-acl-hc'));
+
+        $accessibleCategories = $this->repository->findAccessibleHostCategoryIds($userId);
+
+        self::assertNotNull($accessibleCategories);
+        self::assertSame([], $accessibleCategories->toArray());
+    }
+
+    public function testUserWithAclResourceHavingNoHostCategoryRestrictionReturnsNull(): void
+    {
+        $contactId = $this->createContact('user-unrestricted-hc');
+        $this->linkContactToHostSeverityAclResource($contactId, restrictToHostSeverityIds: []);
+
+        self::assertNull($this->repository->findAccessibleHostCategoryIds(new UserId($contactId)));
+    }
+
+    public function testUserWithAclResourceRestrictedToHostCategoriesReturnsOnlyCategoryIds(): void
+    {
+        $categoryA = $this->insertHostCategory('HC-A');
+        $categoryB = $this->insertHostCategory('HC-B');
+        $this->insertHostCategory('HC-C'); // not linked to the user
+        // a severity (levelled category) granted through the same resource must be filtered out
+        $severity = $this->insertHostSeverity('HS-mixed');
+
+        $contactId = $this->createContact('user-restricted-hc');
+        $this->linkContactToHostSeverityAclResource(
+            $contactId,
+            restrictToHostSeverityIds: [$categoryA, $categoryB, $severity]
+        );
+
+        $accessibleCategories = $this->repository->findAccessibleHostCategoryIds(new UserId($contactId));
+
+        self::assertNotNull($accessibleCategories);
+        $accessibleIds = array_map(
+            static fn (HostCategoryId $hostCategoryId): int => $hostCategoryId->value,
+            $accessibleCategories->toArray()
+        );
+        self::assertEqualsCanonicalizing([$categoryA, $categoryB], $accessibleIds);
+    }
+
+    public function testUserGrantedOnlyHostSeveritiesIsRestrictedToNoHostCategory(): void
+    {
+        // the user IS restricted (a host-category ACL relation exists) but it points only at a
+        // severity, so no regular category is accessible: an EMPTY (non-null) collection, not "see all".
+        $severity = $this->insertHostSeverity('HS-only');
+
+        $contactId = $this->createContact('user-severity-only');
+        $this->linkContactToHostSeverityAclResource($contactId, restrictToHostSeverityIds: [$severity]);
+
+        $accessibleCategories = $this->repository->findAccessibleHostCategoryIds(new UserId($contactId));
+
+        self::assertNotNull($accessibleCategories, 'A severity-only grant is a restriction, not "see all".');
+        self::assertSame([], $accessibleCategories->toArray());
     }
 
     public function testUserWithNoAclGroupHasAccessToNoHostGroups(): void


### PR DESCRIPTION
## Description

Adds a new API Platform endpoint `GET /configuration/host_categories` — a lightweight **host category selector** for the Host form _Relations > Host Categories_ field. Returns a slim `{id, name}` projection, supports name filtering (`name[lk]` → SQL `LIKE`), and is paginated.

Introduces a minimal `HostCategory` aggregate (id + name ≤ 200) in the `MonitoringConfiguration` bounded context, modeled on the host-template selector sibling (#11545). A host **category** and a host **severity** share the `hostcategories` table but are distinct domain objects, discriminated by `hc.level` (NULL = category); this selector returns **categories only**. Non-admin results are scoped to the user's accessible host categories via a new `ResourceAccessRepository::findAccessibleHostCategoryIds` port (same fail-closed 3-tier contract as the host-severity port). Faithfully matches the legacy `Core\HostCategory\...\FindHostCategories` read path — which is **not modified** and keeps serving `/api/latest/configuration/hosts/categories`.

Built as 5 layered commits: Domain → legacy-role permission bridge → host-category ACL scoping (Security) → Dbal repository → API Platform resource.

**Fixes** MON-208498

## Type of change

- [x] New functionality (non-breaking change)

## Target serie

- [x] master

## How this pull request can be tested ?

1. As an **admin** (super admin or Cloud tenant admin), `GET /api/configuration/host_categories` returns all host categories as `{id, name}`, paginated (`page`, `itemsPerPage`), filterable via `name[lk]=<substring>`. Host severities never appear.
2. As a **non-admin** with the _Configuration > Hosts > Categories_ read role, the listing is restricted to the user's accessible host categories; a user granted only severities, or with no accessible ACL resource, sees none.
3. Without the topology role → **403**; unauthenticated → **401**.
4. The legacy endpoint still behaves as before: `GET /api/latest/configuration/hosts/categories`.

Covered by the integration and full-HTTP suites for this endpoint.
