### PR TITLE
fix(e2e): backport Platform-upgrade-update mysql fixes to dev-24.10.x

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -188,7 +188,9 @@ export default (on: Cypress.PluginEvents): void => {
       name,
       portBindings = []
     }: StartContainerProps) => {
-      let container = await new GenericContainer(image).withName(name);
+      let container = await new GenericContainer(image)
+        .withName(name)
+        .withAddedCapabilities('SYS_NICE');
 
       portBindings.forEach(({ source, destination }) => {
         container = container.withExposedPorts({

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -123,7 +123,7 @@ const getDatabaseService = (engine: DatabaseEngine): string => {
   return isAlma() ? 'mysqld' : 'mysql';
 };
 
-const mysqlRootGrant = `mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'centreon'; GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION"`;
+const mysqlRootGrant = `mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'centreon'; GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION"`;
 const mariadbRootGrant = `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`;
 
 const rootGrantCommand = (engine: DatabaseEngine): string =>


### PR DESCRIPTION
## What
Backports #11585 to `dev-24.10.x`: two independent fixes for `Platform-upgrade-update/01-platform-update.feature` on the MySQL combos (`alma8-mysql:8.0`, `bookworm-mysql:8.4`). Clean cherry-pick, no conflicts, same two one-line changes.

### 1. `systemctl start mysqld` fails with `ExecStartPre control process exited with error code`
Adds `SYS_NICE` to the container capabilities used by `cy.startContainer()` ([tasks.ts](centreon/packages/js-config/cypress/e2e/tasks.ts)).

`mysql-server` (`8.0.46-1.module_el8.10.0`) sets the `cap_sys_nice` file capability on `/usr/libexec/mysqld`. The `web` container is started via testcontainers `GenericContainer` with Docker's default capability set, which doesn't include `CAP_SYS_NICE`, so the kernel refuses to `execve()` the binary -> `ExecStartPre=/usr/libexec/mysql-prepare-db-dir` fails -> `systemctl start mysqld` fails.

### 2. Install wizard stuck on step 6 on `bookworm-mysql:8.4`
Forces `caching_sha2_password` for the mysql root grant in [common.ts](centreon/tests/e2e/features/Platform-upgrade-update/common.ts) (`mysqlRootGrant`).

Debian's `mysql-community-server` package defaults `root@localhost` to the `auth_socket` plugin. `ALTER USER ... IDENTIFIED BY '...'` alone doesn't switch the plugin. The `mysql` CLI masks this (`-h localhost` always uses the socket), but PDO (used by the install wizard) makes a real TCP connection, which `auth_socket` unconditionally rejects.

## Verification
Both root causes reproduced and both fixes confirmed locally against the real dependency images before #11585 was opened; #11585 was further confirmed green in CI across all 3 OS/DB combos (`alma9-mariadb`, `alma8-mysql`, `bookworm-mysql`) before merging to `dev-25.10.x`. This backport is the identical, unmodified diff — see #11585 for full investigation details.