### PR TITLE
fix(activity-logging): log command changes under the canonical 'command' object type

### DIFF
--- a/centreon/src/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepository.php
+++ b/centreon/src/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepository.php
@@ -45,7 +45,11 @@ final readonly class DbalActivityLogRepository extends DbalRepository implements
     private const TABLE_NAME = 'log_action';
     private const DETAIL_TABLE_NAME = 'log_action_modification';
     private const TARGET_TYPE_VALUE_MAP = [
-        TargetTypeEnum::Command->value => 'commands',
+        // The whole platform stores command changes under the singular
+        // 'command' token (ActionLog::OBJECT_TYPE_COMMAND, the legacy pages,
+        // the CLAPI and the Administration > Logs filter). Writing the plural
+        // 'commands' here made the audited rows unreachable through that filter.
+        TargetTypeEnum::Command->value => 'command',
         TargetTypeEnum::Poller->value => 'poller',
         TargetTypeEnum::ServiceCategory->value => 'servicecategories',
     ];

--- a/centreon/src/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepository.php
+++ b/centreon/src/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepository.php
@@ -46,9 +46,9 @@ final readonly class DbalActivityLogRepository extends DbalRepository implements
     private const DETAIL_TABLE_NAME = 'log_action_modification';
     private const TARGET_TYPE_VALUE_MAP = [
         // The whole platform stores command changes under the singular
-        // 'command' token (ActionLog::OBJECT_TYPE_COMMAND, the legacy pages,
-        // the CLAPI and the Administration > Logs filter). Writing the plural
-        // 'commands' here made the audited rows unreachable through that filter.
+        // 'command' token (ActionLog::OBJECT_TYPE_COMMAND, the CLAPI and the
+        // Administration > Logs filter). Writing the plural 'commands' here
+        // made the audited rows unreachable through that filter.
         TargetTypeEnum::Command->value => 'command',
         TargetTypeEnum::Poller->value => 'poller',
         TargetTypeEnum::ServiceCategory->value => 'servicecategories',

--- a/centreon/src/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepository.php
+++ b/centreon/src/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepository.php
@@ -45,10 +45,6 @@ final readonly class DbalActivityLogRepository extends DbalRepository implements
     private const TABLE_NAME = 'log_action';
     private const DETAIL_TABLE_NAME = 'log_action_modification';
     private const TARGET_TYPE_VALUE_MAP = [
-        // The whole platform stores command changes under the singular
-        // 'command' token (ActionLog::OBJECT_TYPE_COMMAND, the CLAPI and the
-        // Administration > Logs filter). Writing the plural 'commands' here
-        // made the audited rows unreachable through that filter.
         TargetTypeEnum::Command->value => 'command',
         TargetTypeEnum::Poller->value => 'poller',
         TargetTypeEnum::ServiceCategory->value => 'servicecategories',

--- a/centreon/tests/e2e/features/Logs/06-commands-changes-log/index.ts
+++ b/centreon/tests/e2e/features/Logs/06-commands-changes-log/index.ts
@@ -87,7 +87,7 @@ Then(
       .find('tr.list_one')
       .find('td')
       .eq(2)
-      .should('contain.text', 'commands');
+      .should('contain.text', 'command');
   }
 );
 

--- a/centreon/tests/e2e/features/Logs/06-commands-changes-log/index.ts
+++ b/centreon/tests/e2e/features/Logs/06-commands-changes-log/index.ts
@@ -87,7 +87,8 @@ Then(
       .find('tr.list_one')
       .find('td')
       .eq(2)
-      .should('contain.text', 'command');
+      .invoke('text')
+      .then((text) => expect(text.trim()).to.equal('command'));
   }
 );
 

--- a/centreon/tests/php/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepositoryTest.php
+++ b/centreon/tests/php/App/ActivityLogging/Infrastructure/Dbal/DbalActivityLogRepositoryTest.php
@@ -33,6 +33,7 @@ use App\ActivityLogging\Domain\Aggregate\TargetId;
 use App\ActivityLogging\Domain\Aggregate\TargetName;
 use App\ActivityLogging\Domain\Aggregate\TargetTypeEnum;
 use App\ActivityLogging\Infrastructure\Dbal\DbalActivityLogRepository;
+use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class DbalActivityLogRepositoryTest extends KernelTestCase
@@ -70,6 +71,40 @@ final class DbalActivityLogRepositoryTest extends KernelTestCase
         $this->repository->add($activityLog);
 
         self::assertEquals($activityLog, $this->repository->find($activityLog->id()));
+    }
+
+    public function testCommandTargetIsStoredWithTheCanonicalSingularToken(): void
+    {
+        $activityLog = new ActivityLog(
+            id: null,
+            action: ActionEnum::Add,
+            actor: new Actor(
+                id: new ActorId(1),
+            ),
+            target: new Target(
+                id: new TargetId(1),
+                name: new TargetName('a_command'),
+                type: TargetTypeEnum::Command,
+            ),
+            performedAt: (new \DateTimeImmutable())->setTime(0, 0),
+            details: [],
+        );
+
+        $this->repository->add($activityLog);
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.realtime_connection');
+        $objectType = $connection->createQueryBuilder()
+            ->select('object_type')
+            ->from('log_action')
+            ->where('action_log_id = :id')
+            ->setParameter('id', $activityLog->id()->value)
+            ->executeQuery()
+            ->fetchOne();
+
+        // The Administration > Logs Type filter binds ActionLog::OBJECT_TYPE_COMMAND
+        // ('command'), so command activity must be stored under that exact token.
+        self::assertSame('command', $objectType);
     }
 
     public function testFind(): void

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/CreateCommandProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/CreateCommandProcessorTest.php
@@ -215,6 +215,18 @@ final class CreateCommandProcessorTest extends ApiTestCase
         self::assertResponseIsSuccessful();
 
         self::assertSame($count + 1, $repository->count());
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.realtime_connection');
+        $objectType = $connection->fetchOne(
+            'SELECT object_type FROM log_action WHERE object_name = ? ORDER BY action_log_id DESC LIMIT 1',
+            ['CommandNotif']
+        );
+
+        // The command audit entry must use the canonical singular 'command' token,
+        // otherwise the Administration > Logs Type filter (bound on that token)
+        // cannot match it.
+        self::assertSame('command', $objectType);
     }
 
     /**

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -234,7 +234,7 @@ $realignCommandActionLogObjectType = function () use ($pearDBO, &$errorMessage, 
     // The ActivityLogging system used to store command changes under the plural
     // 'commands' token, which the Administration > Logs Type filter (bound on the
     // canonical singular 'command') could never match. Realign the existing rows.
-    $pearDBO->executeStatement(
+    $pearDBO->update(
         <<<'SQL'
             UPDATE `log_action` SET `object_type` = 'command' WHERE `object_type` = 'commands'
             SQL

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -227,11 +227,30 @@ $populateCentralAddress = function () use ($pearDB, &$errorMessage, $version, $r
     LoggerUpgrade::create()->info($version, 'Successfully populated central_address for all platforms');
 };
 
+$realignCommandActionLogObjectType = function () use ($pearDBO, &$errorMessage, $version): void {
+    $errorMessage = "Unable to realign command audit logs to the 'command' object type";
+    LoggerUpgrade::create()->info($version, "Realigning command audit logs from 'commands' to 'command'");
+
+    // The ActivityLogging system used to store command changes under the plural
+    // 'commands' token, which the Administration > Logs Type filter (bound on the
+    // canonical singular 'command') could never match. Realign the existing rows.
+    $pearDBO->executeStatement(
+        <<<'SQL'
+            UPDATE `log_action` SET `object_type` = 'command' WHERE `object_type` = 'commands'
+            SQL
+    );
+
+    LoggerUpgrade::create()->info($version, "Successfully realigned command audit logs to 'command'");
+};
+
 try {
     LoggerUpgrade::create()->info($version, "Starting upgrade script for version {$version}");
 
     $addCentralAddressColumn();
     $fixGorgoneCommunicationTypeComment();
+
+    // Data realignment for real time database (single idempotent statement)
+    $realignCommandActionLogObjectType();
 
     $errorMessage = 'Unable to start the configuration database transaction';
     if (! $pearDB->isTransactionActive()) {

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -249,7 +249,6 @@ try {
     $addCentralAddressColumn();
     $fixGorgoneCommunicationTypeComment();
 
-    // Data realignment for real time database (single idempotent statement)
     $realignCommandActionLogObjectType();
 
     $errorMessage = 'Unable to start the configuration database transaction';


### PR DESCRIPTION
## Description

- Command changes are audited by the ActivityLogging system under the plural `object_type = 'commands'`, whereas the rest of the platform (`ActionLog::OBJECT_TYPE_COMMAND`, the legacy pages, the CLAPI and the Administration > Logs **Type** filter) uses the singular `'command'`.
- Consequence: audited rows appear in the list but the **Command** Type filter (bound on `'command'`) never matches them — command changes cannot be filtered.
- Fix:
  - align `DbalActivityLogRepository::TARGET_TYPE_VALUE_MAP` to `'command'`;
  - realign already-written rows via the upgrade script (`Update-next.php`, idempotent);
  - add a regression test pinning the persisted `object_type` to `'command'`.
- Regression introduced by the commands rework (#8328). Poller / Service categories are unaffected — their tokens were already correct.

## How to test

1. On a develop platform, create/edit/delete a command (Configuration > Commands, or `POST /api/latest/configuration/commands`).
2. Go to **Administration > Logs**, set the **Type** filter to **Command** and search.
3. The command change now appears in the filtered results. Before the fix, the filtered list was empty even though the row showed as "Command" without any filter.
4. Upgrade path: on a platform that already holds rows with `object_type = 'commands'`, run the upgrade — `Update-next.php` realigns them to `'command'` so they become filterable.

## Links

### Jira ticket

Resolves: [MON-209062](https://centreon.atlassian.net/browse/MON-209062)

### PR Github

- Blocks: #11453 — unblocks the changelog listing salvage; once merged, that PR can drop its `'commands'` display workaround.


[MON-209062]: https://centreon.atlassian.net/browse/MON-209062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
