### PR TITLE
feat(api): expose API Platform resources under bare /api

### DIFF
--- a/centreon/config.new/packages/security.yaml
+++ b/centreon/config.new/packages/security.yaml
@@ -6,11 +6,11 @@ security:
         ROLE_ADMIN: ROLE_USER
     firewalls:
         dev:
-            pattern: '/api/latest/_(profiler|wdt)'
+            pattern: '^/api(/latest)?/_(profiler|wdt)'
             security: false
 
         api:
-            pattern: '/api/latest'
+            pattern: '^/api'
             stateless: true
             entry_point: App\Security\Infrastructure\Security\Legacy\LegacyTokenApiAuthenticatorWrapper
             custom_authenticators:
@@ -19,10 +19,10 @@ security:
                 - App\Security\Infrastructure\Security\SessionAuthenticator
 
     access_control:
-        - { path: '/api/latest$', roles: PUBLIC_ACCESS }         # Allows accessing the Swagger UI
-        - { path: '/api/latest/docs', roles: PUBLIC_ACCESS }     # Allows accessing the Swagger UI docs
-        - { path: '/api/latest/contexts', roles: PUBLIC_ACCESS } # Allows accessing the Swagger UI contexts
-        - { path: '/api/latest/login', roles: PUBLIC_ACCESS }    # Allows accessing the login
+        - { path: '^/api(/latest)?$', roles: PUBLIC_ACCESS }         # Allows accessing the Swagger UI
+        - { path: '^/api(/latest)?/docs', roles: PUBLIC_ACCESS }     # Allows accessing the Swagger UI docs
+        - { path: '^/api(/latest)?/contexts', roles: PUBLIC_ACCESS } # Allows accessing the Swagger UI contexts
+        - { path: '^/api(/latest)?/login', roles: PUBLIC_ACCESS }    # Allows accessing the login (implemented by the legacy kernel, exposed at both prefixes)
         - { path: '/', roles: IS_AUTHENTICATED_FULLY }
 
 when@test:

--- a/centreon/config.new/routes/api_platform.yaml
+++ b/centreon/config.new/routes/api_platform.yaml
@@ -1,4 +1,9 @@
 api_platform:
     resource: .
     type: api_platform
-    prefix: '/api/latest'
+    prefix: '/api'
+
+# Backward-compat alias: only already-migrated operations are duplicated under /api/latest, see LegacyApiPrefixAliasLoader.
+api_platform_legacy:
+    resource: 'App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiPrefixAliasLoader'
+    type: service

--- a/centreon/config.new/routes/web_profiler.yaml
+++ b/centreon/config.new/routes/web_profiler.yaml
@@ -1,8 +1,18 @@
 when@dev:
     web_profiler_wdt:
         resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
-        prefix: /api/latest/_wdt
+        prefix: /api/_wdt
 
     web_profiler_profiler:
         resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
+        prefix: /api/_profiler
+
+    web_profiler_wdt_legacy:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
+        prefix: /api/latest/_wdt
+        name_prefix: 'legacy_'
+
+    web_profiler_profiler_legacy:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
         prefix: /api/latest/_profiler
+        name_prefix: 'legacy_'

--- a/centreon/config/packages/security.yaml
+++ b/centreon/config/packages/security.yaml
@@ -9,24 +9,24 @@ security:
             id: contact.provider
     firewalls:
         dev:
-            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)/(_(profiler|wdt)|css|images|js)/
+            pattern: ^.*/api/(?:%api.version.pattern%)/(_(profiler|wdt)|css|images|js)/
             security: false
         free:
             stateless: true
-            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)(/it-edition-extensions/login_page|/platform/(?:versions|features|installation/status))$
+            pattern: ^.*/api/(?:%api.version.pattern%)(/it-edition-extensions/login_page|/platform/(?:versions|features|installation/status))$
             security: false
         publicPlaylist:
-            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)(/it-edition-extensions/monitoring/dashboards/playlists/[1-9A-HJ-NP-Za-km-z]{22}(?:/dashboards/\d+(?:/widgets/\d+)?)?)$
+            pattern: ^.*/api/(?:%api.version.pattern%)(/it-edition-extensions/monitoring/dashboards/playlists/[1-9A-HJ-NP-Za-km-z]{22}(?:/dashboards/\d+(?:/widgets/\d+)?)?)$
             security: false
         authentication:
             pattern: ^.*(?<!administration)/authentication/(providers/configurations|users)(.*)$
             security: false
         saml:
-            pattern: ^.*/saml/(login|acs|sls)(.*)$
+            pattern: ^.*/(login/saml|saml/(acs|sls))(.*)$
             security: false
         api:
             stateless: true
-            pattern: ^(?!.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)/login)/.*
+            pattern: ^(?!.*/api/(?:(?:%api.version.pattern%)/)?login)/.*
             security: true
             custom_authenticators:
                 - security.provider.websso
@@ -34,7 +34,7 @@ security:
                 - security.provider.sessionapi
             entry_point: security.provider.tokenapi
         login:
-            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)/login$
+            pattern: ^.*/api/(?:(?:%api.version.pattern%)/)?login$
             security: false
 
     # Easy way to control access for large sections of your site

--- a/centreon/config/routes/centreon.yaml
+++ b/centreon/config/routes/centreon.yaml
@@ -5,6 +5,13 @@ centreon:
         version: "latest"
     requirements:
         base_uri: ".*"
+        version: '%api.version.pattern%'
+centreon_authentication_bare_api:
+    resource: "./Centreon/authentication.yaml"
+    prefix: "{base_uri}api"
+    name_prefix: "bare_api_"
+    requirements:
+        base_uri: ".*"
 security:
     resource: "./Security/**/*.yaml"
     prefix: "{base_uri}authentication"
@@ -17,6 +24,7 @@ core:
         version: "latest"
     requirements:
         base_uri: ".*"
+        version: '%api.version.pattern%'
 core_attribute:
     resource: "./../../src/Core/**/Infrastructure/**/*Controller.php"
     type: attribute
@@ -25,3 +33,4 @@ core_attribute:
       version: "latest"
     requirements:
         base_uri: ".*"
+        version: '%api.version.pattern%'

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -8,6 +8,7 @@ parameters:
     locale: en
     api.header: "Api-Version"
     api.version.latest: "26.10"
+    api.version.pattern: !php/const Centreon\Domain\VersionHelper::API_VERSION_PATTERN
     database_host: "%env(hostCentreon)%"
     database_port: "%env(int:port)%"
     database_db: "%env(db)%"

--- a/centreon/libinstall/functions
+++ b/centreon/libinstall/functions
@@ -1414,11 +1414,11 @@ ServerTokens Prod
 
     AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
 
-    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+    <LocationMatch ^\${base_uri}/?(?!api/(?![^/]+\.php(?:/|$)))(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>
 
-    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+    <LocationMatch ^\${base_uri}/?(authentication|api(?!/[^/]+\.php(?:/|$))(/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))?)(/.*)?$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
     </LocationMatch>
 

--- a/centreon/packaging/src/centreon-apache-https.conf
+++ b/centreon/packaging/src/centreon-apache-https.conf
@@ -46,11 +46,11 @@ ServerTokens Prod
         ProxyPass "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
         ProxyPassReverse "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>
-    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+    <LocationMatch ^\${base_uri}/?(?!api/(?![^/]+\.php(?:/|$)))(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>
 
-    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+    <LocationMatch ^\${base_uri}/?(authentication|api(?!/[^/]+\.php(?:/|$))(/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))?)(/.*)?$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
     </LocationMatch>
 

--- a/centreon/packaging/src/centreon-apache.conf
+++ b/centreon/packaging/src/centreon-apache.conf
@@ -29,11 +29,11 @@ ServerTokens Prod
         ProxyPassReverse "${base_uri}/gorgone/pullwss/websocket"  "ws://localhost:8087/"
     </IfModule>
 
-    <LocationMatch ^\${base_uri}/?(?!api/latest/|api/beta/|api/v[0-9]+/|api/v[0-9]+\.[0-9]+/)(.*\.php(/.*)?)$>
+    <LocationMatch ^\${base_uri}/?(?!api/(?![^/]+\.php(?:/|$)))(.*\.php(/.*)?)$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/www/$1"
     </LocationMatch>
 
-    <LocationMatch ^\${base_uri}/?(authentication|api/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))/.*$>
+    <LocationMatch ^\${base_uri}/?(authentication|api(?!/[^/]+\.php(?:/|$))(/(latest|beta|v[0-9]+|v[0-9]+\.[0-9]+))?)(/.*)?$>
         ProxyPassMatch "fcgi://127.0.0.1:9042${install_dir}/api/index.php/$1"
     </LocationMatch>
 

--- a/centreon/src/Adaptation/Log/LoggerAuthentication.php
+++ b/centreon/src/Adaptation/Log/LoggerAuthentication.php
@@ -149,7 +149,7 @@ final class LoggerAuthentication
         $line = date('Y-m-d H:i:s') . '|' . ($userId ?? 0) . '|0|0|' . $sanitizedMessage;
 
         try {
-            $written = file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
+            $written = @file_put_contents($logDir . '/login.log', $line . "\n", FILE_APPEND | LOCK_EX);
             if ($written === false) {
                 error_log(sprintf('LoggerAuthentication: unable to mirror login event to %s/login.log', $logDir));
             }

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/CoreLegacyApiAliasOperations.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/CoreLegacyApiAliasOperations.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\ApiPlatform\Routing;
+
+/**
+ * Core monorepo operations that keep their backward-compatible /api/latest alias.
+ */
+final class CoreLegacyApiAliasOperations implements LegacyApiAliasOperationProviderInterface
+{
+    public function getOperationNames(): array
+    {
+        return [
+            '_api_/configuration/agent-configurations/installation-command/{pollerId}_get',
+            '_api_/configuration/commands_get_collection',
+            '_api_/configuration/commands_post',
+            '_api_/configuration/commands/_duplicate_post',
+            '_api_/configuration/commands/{id}_get',
+            '_api_/configuration/commands/{id}_patch',
+            '_api_/configuration/commands/{id}_delete',
+            '_api_/configuration/connectors_get_collection',
+            '_api_/configuration/connectors/{id}_get',
+            '_api_/configuration/global-macros_get_collection',
+            '_api_/configuration/plugins_get_collection',
+            '_api_/configuration/plugins/{plugin_name}_get',
+            '_api_/configuration/pollers_post',
+            '_api_/configuration/pollers/installation-command/{id}_get',
+            '_api_/configuration/services/categories_post',
+            '_api_/configuration/standard-macros_get_collection',
+            '_api_/platform/updates_post',
+        ];
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiAliasOperationProviderInterface.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiAliasOperationProviderInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\ApiPlatform\Routing;
+
+/**
+ * Contributes API Platform operation names that must keep a backward-compatible /api/latest alias.
+ *
+ * The core provides its own implementation; any module may ship one too. Every service implementing
+ * this interface is collected by {@see LegacyApiPrefixAliasLoader} through the {@see self::TAG} tag
+ * (applied automatically by the new kernel's autoconfiguration), so a module extends the allowlist
+ * without touching core code.
+ */
+interface LegacyApiAliasOperationProviderInterface
+{
+    /**
+     * Autoconfiguration tag collecting every provider for the legacy alias loader.
+     */
+    public const TAG = 'app.legacy_api_alias_operation_provider';
+
+    /**
+     * Allowlist operation names (the route default `_api_operation_name`) rather than resources: a
+     * resource also carries the item operations API Platform generates on its own (/pollers/{id},
+     * /global_macros/{id}, ...), which never existed under /api/latest and must not be aliased there.
+     *
+     * @return list<string>
+     */
+    public function getOperationNames(): array;
+}

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoader.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoader.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\ApiPlatform\Routing;
+
+use ApiPlatform\Symfony\Routing\ApiLoader;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Duplicates the routes of already-migrated API Platform operations under the legacy /api/latest
+ * prefix, for backward compatibility with clients still calling that prefix.
+ */
+final readonly class LegacyApiPrefixAliasLoader implements RouteLoaderInterface
+{
+    /**
+     * Allowlisted per operation rather than per resource: a resource also carries the item
+     * operations API Platform generates on its own (/pollers/{id}, /global_macros/{id}, ...),
+     * which never existed under /api/latest and must not be aliased there.
+     *
+     * @var list<string>
+     */
+    private const LEGACY_ALIAS_OPERATION_NAMES = [
+        '_api_/configuration/agent-configurations/installation-command/{pollerId}_get',
+        '_api_/configuration/commands_get_collection',
+        '_api_/configuration/commands_post',
+        '_api_/configuration/commands/_duplicate_post',
+        '_api_/configuration/commands/{id}_get',
+        '_api_/configuration/commands/{id}_patch',
+        '_api_/configuration/commands/{id}_delete',
+        '_api_/configuration/connectors_get_collection',
+        '_api_/configuration/connectors/{id}_get',
+        '_api_/configuration/global-macros_get_collection',
+        '_api_/configuration/plugins_get_collection',
+        '_api_/configuration/plugins/{plugin_name}_get',
+        '_api_/configuration/pollers_post',
+        '_api_/configuration/pollers/installation-command/{id}_get',
+        '_api_/configuration/services/categories_post',
+        '_api_/configuration/standard-macros_get_collection',
+        '_api_/platform/updates_post',
+    ];
+
+    public function __construct(
+        #[Autowire(service: 'api_platform.route_loader')]
+        private ApiLoader $apiLoader,
+    ) {
+    }
+
+    public function __invoke(): RouteCollection
+    {
+        $aliasedRoutes = new RouteCollection();
+
+        foreach ($this->apiLoader->load('.', 'api_platform') as $name => $route) {
+            $operationName = $route->getDefault('_api_operation_name');
+
+            // Keep auxiliary/meta routes (docs, entrypoint, genid, jsonld context)
+            if ($operationName !== null && ! in_array($operationName, self::LEGACY_ALIAS_OPERATION_NAMES, true)) {
+                continue;
+            }
+
+            $aliasedRoutes->add($name, $route);
+        }
+
+        $aliasedRoutes->addPrefix('/api/latest');
+        $aliasedRoutes->addNamePrefix('legacy_');
+
+        return $aliasedRoutes;
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoader.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoader.php
@@ -23,59 +23,58 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\ApiPlatform\Routing;
 
-use ApiPlatform\Symfony\Routing\ApiLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Duplicates the routes of already-migrated API Platform operations under the legacy /api/latest
  * prefix, for backward compatibility with clients still calling that prefix.
+ *
+ * The allowlist of operations to alias is contributed by {@see LegacyApiAliasOperationProviderInterface}
+ * services (core plus any module), so a module keeps its released endpoints reachable under
+ * /api/latest without touching this loader.
  */
 final readonly class LegacyApiPrefixAliasLoader implements RouteLoaderInterface
 {
-    /**
-     * Allowlisted per operation rather than per resource: a resource also carries the item
-     * operations API Platform generates on its own (/pollers/{id}, /global_macros/{id}, ...),
-     * which never existed under /api/latest and must not be aliased there.
-     *
-     * @var list<string>
-     */
-    private const LEGACY_ALIAS_OPERATION_NAMES = [
-        '_api_/configuration/agent-configurations/installation-command/{pollerId}_get',
-        '_api_/configuration/commands_get_collection',
-        '_api_/configuration/commands_post',
-        '_api_/configuration/commands/_duplicate_post',
-        '_api_/configuration/commands/{id}_get',
-        '_api_/configuration/commands/{id}_patch',
-        '_api_/configuration/commands/{id}_delete',
-        '_api_/configuration/connectors_get_collection',
-        '_api_/configuration/connectors/{id}_get',
-        '_api_/configuration/global-macros_get_collection',
-        '_api_/configuration/plugins_get_collection',
-        '_api_/configuration/plugins/{plugin_name}_get',
-        '_api_/configuration/pollers_post',
-        '_api_/configuration/pollers/installation-command/{id}_get',
-        '_api_/configuration/services/categories_post',
-        '_api_/configuration/standard-macros_get_collection',
-        '_api_/platform/updates_post',
-    ];
+    /** @var list<string> */
+    private array $allowlist;
 
+    /**
+     * @param iterable<LegacyApiAliasOperationProviderInterface> $operationProviders
+     */
     public function __construct(
         #[Autowire(service: 'api_platform.route_loader')]
-        private ApiLoader $apiLoader,
+        private LoaderInterface $apiLoader,
+        #[AutowireIterator(LegacyApiAliasOperationProviderInterface::TAG)]
+        iterable $operationProviders,
     ) {
+        $operationNames = [];
+        foreach ($operationProviders as $provider) {
+            foreach ($provider->getOperationNames() as $operationName) {
+                $operationNames[] = $operationName;
+            }
+        }
+
+        $this->allowlist = array_values(array_unique($operationNames));
     }
 
     public function __invoke(): RouteCollection
     {
         $aliasedRoutes = new RouteCollection();
 
-        foreach ($this->apiLoader->load('.', 'api_platform') as $name => $route) {
+        // api_platform.route_loader (ApiPlatform's ApiLoader) always returns a RouteCollection;
+        // LoaderInterface::load() only widens the declared return to mixed.
+        $apiRoutes = $this->apiLoader->load('.', 'api_platform');
+        \assert($apiRoutes instanceof RouteCollection);
+
+        foreach ($apiRoutes as $name => $route) {
             $operationName = $route->getDefault('_api_operation_name');
 
             // Keep auxiliary/meta routes (docs, entrypoint, genid, jsonld context)
-            if ($operationName !== null && ! in_array($operationName, self::LEGACY_ALIAS_OPERATION_NAMES, true)) {
+            if ($operationName !== null && ! in_array($operationName, $this->allowlist, true)) {
                 continue;
             }
 

--- a/centreon/src/App/Shared/Infrastructure/Symfony/Kernel.php
+++ b/centreon/src/App/Shared/Infrastructure/Symfony/Kernel.php
@@ -26,6 +26,7 @@ namespace App\Shared\Infrastructure\Symfony;
 use App\Shared\Application\Command\AsCommandHandler;
 use App\Shared\Application\Query\AsQueryHandler;
 use App\Shared\Domain\Event\AsEventHandler;
+use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiAliasOperationProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -85,6 +86,9 @@ final class Kernel extends BaseKernel
         $container->registerAttributeForAutoconfiguration(AsEventHandler::class, static function (ChildDefinition $definition): void {
             $definition->addTag('messenger.message_handler', ['bus' => 'event.bus']);
         });
+
+        $container->registerForAutoconfiguration(LegacyApiAliasOperationProviderInterface::class)
+            ->addTag(LegacyApiAliasOperationProviderInterface::TAG);
     }
 
     /**

--- a/centreon/src/Centreon/Domain/VersionHelper.php
+++ b/centreon/src/Centreon/Domain/VersionHelper.php
@@ -35,6 +35,7 @@ class VersionHelper
     public const GT = '>';
     public const LE = '<=';
     public const GE = '>=';
+    public const API_VERSION_PATTERN = 'latest|beta|v\d+(\.\d+)?';
 
     /**
      * Compare two version numbers.

--- a/centreon/src/Core/Common/Infrastructure/Routing/ModuleRouteLoader.php
+++ b/centreon/src/Core/Common/Infrastructure/Routing/ModuleRouteLoader.php
@@ -38,6 +38,8 @@ abstract readonly class ModuleRouteLoader implements RouteLoaderInterface
         private AttributeFileLoader $loader,
         #[Autowire(param: 'kernel.project_dir')]
         private string $projectDir,
+        #[Autowire(param: 'api.version.pattern')]
+        private string $versionPattern,
         private ModuleInstallationVerifier $moduleInstallationVerifier,
         private InstallationVerifierInterface $centreonInstallationVerifier,
     ) {
@@ -75,7 +77,7 @@ abstract readonly class ModuleRouteLoader implements RouteLoaderInterface
         if ($routeCollections instanceof RouteCollection) {
             $routeCollections->addPrefix('/{base_uri}api/{version}');
             $routeCollections->addDefaults(['base_uri' => 'centreon/', 'version' => 'latest']);
-            $routeCollections->addRequirements(['base_uri' => '(.+/)|.{0}']);
+            $routeCollections->addRequirements(['base_uri' => '(.+/)|.{0}', 'version' => $this->versionPattern]);
 
             return $routeCollections;
         }
@@ -84,7 +86,7 @@ abstract readonly class ModuleRouteLoader implements RouteLoaderInterface
         }
         $routes->addPrefix('/{base_uri}api/{version}');
         $routes->addDefaults(['base_uri' => 'centreon/', 'version' => 'latest']);
-        $routes->addRequirements(['base_uri' => '(.+/)|.{0}']);
+        $routes->addRequirements(['base_uri' => '(.+/)|.{0}', 'version' => $this->versionPattern]);
 
         return $routes;
     }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/SLSController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/SAML/SLSController.php
@@ -47,8 +47,10 @@ final class SLSController extends AbstractController
         $this->info('SAML SLS invoked');
 
         // The IdP callback relies on the native PHP session ($_SESSION['LogoutRequestID']).
+        // Suppressed: session_start() can still warn (e.g. headers already sent) even after
+        // this guard, in which case the empty/missing session below already yields a controlled error.
         if (session_status() !== PHP_SESSION_ACTIVE) {
-            session_start();
+            @session_start();
         }
 
         try {

--- a/centreon/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/centreon/src/EventSubscriber/CentreonEventSubscriber.php
@@ -246,8 +246,12 @@ class CentreonEventSubscriber implements EventSubscriberInterface
         $event->getRequest()->attributes->set('version.not_beta', true);
 
         $uri = $event->getRequest()->getRequestUri();
-        if (preg_match('/\/api\/([^\/]+)/', $uri, $matches)) {
-            $requestApiVersion = $matches[1];
+        if (preg_match('/\/api(?:\/([^\/]+))?/', $uri, $matches)) {
+            $requestApiVersion = $matches[1] ?? '';
+            if (preg_match('/^(?:' . VersionHelper::API_VERSION_PATTERN . ')$/', $requestApiVersion) !== 1) {
+                $requestApiVersion = 'latest';
+            }
+
             if ($requestApiVersion[0] === 'v') {
                 $requestApiVersion = mb_substr($requestApiVersion, 1);
                 $requestApiVersion = VersionHelper::regularizeDepthVersion(

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/AgentConfiguration/GetInstallationCommandProviderTest.php
@@ -29,7 +29,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class GetInstallationCommandProviderTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/agent-configurations/installation-command';
+    private const BASE_ENDPOINT = '/api/configuration/agent-configurations/installation-command';
     private const POLLER_ADDRESS = '192.168.1.100';
     private const AGENT_PORT = 4317;
     private const CERTIFICATE_SHA = 'abc123sha456def789';

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/CreateCommandProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/CreateCommandProcessorTest.php
@@ -42,13 +42,13 @@ final class CreateCommandProcessorTest extends ApiTestCase
 
         $this->login();
 
-        $response = $this->request('POST', '/api/latest/configuration/commands', [
+        $response = $this->request('POST', '/api/configuration/commands', [
             'json' => [
                 'name' => 'CommandNotif',
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
                 'comment' => 'coucou',
             ],
         ]);
@@ -73,7 +73,7 @@ final class CreateCommandProcessorTest extends ApiTestCase
     public function testCannotCreateSameCommand(): void
     {
         $this->login();
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
@@ -82,13 +82,13 @@ final class CreateCommandProcessorTest extends ApiTestCase
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
                 'comment' => 'coucou',
             ],
         ]);
         self::assertResponseIsSuccessful();
 
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
@@ -97,7 +97,7 @@ final class CreateCommandProcessorTest extends ApiTestCase
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
                 'comment' => 'coucou',
             ],
         ]);
@@ -108,7 +108,7 @@ final class CreateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
@@ -117,7 +117,7 @@ final class CreateCommandProcessorTest extends ApiTestCase
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
                 'comment' => 'coucou',
             ],
         ]);
@@ -133,13 +133,13 @@ final class CreateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'json' => [
                 'name' => true,
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
                 'comment' => 'coucou',
             ],
         ]);
@@ -153,7 +153,7 @@ final class CreateCommandProcessorTest extends ApiTestCase
 
     public function testCannotCreateCommandIfNotLogged(): void
     {
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'json' => [
                 'name' => 'NAME',
                 'alias' => 'ALIAS',
@@ -173,13 +173,13 @@ final class CreateCommandProcessorTest extends ApiTestCase
         $this->createApiUser($connection, $username, admin: false);
         $this->login($username);
 
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'json' => [
                 'name' => 'CommandNotif',
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
                 'comment' => 'coucou',
             ],
         ]);
@@ -198,12 +198,36 @@ final class CreateCommandProcessorTest extends ApiTestCase
 
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/commands', [
+        $this->request('POST', '/api/configuration/commands', [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
             'json' => [
                 'name' => 'CommandNotif',
+                'type' => 'Notification',
+                'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
+                'is_shell_enabled' => true,
+                'connector' => '/api/configuration/connectors/1',
+                'comment' => 'coucou',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        self::assertSame($count + 1, $repository->count());
+    }
+
+    /**
+     * Non-regression: the historical /api/latest prefix (with an old-style relation IRI) must keep working
+     * once /api becomes the canonical prefix for API Platform resources.
+     */
+    public function testCreateCommandViaLegacyApiPrefixStillWorks(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/latest/configuration/commands', [
+            'json' => [
+                'name' => 'CommandNotifLegacyPrefix',
                 'type' => 'Notification',
                 'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
                 'is_shell_enabled' => true,
@@ -213,7 +237,62 @@ final class CreateCommandProcessorTest extends ApiTestCase
         ]);
 
         self::assertResponseIsSuccessful();
+        self::assertJsonContains(['name' => 'CommandNotifLegacyPrefix']);
 
-        self::assertSame($count + 1, $repository->count());
+        /** @var CommandRepository $repository */
+        $repository = self::getContainer()->get(CommandRepository::class);
+        self::assertNotNull($repository->findOneByName(new CommandName('CommandNotifLegacyPrefix')));
+    }
+
+    /**
+     * Non-regression: a relation IRI expressed with the old /api/latest prefix must still resolve when the
+     * request itself targets the new /api prefix (mixed old/new IRIs must keep working during migration).
+     */
+    public function testCreateCommandViaNewApiPrefixAcceptsLegacyConnectorIri(): void
+    {
+        $this->login();
+
+        $this->request('POST', '/api/configuration/commands', [
+            'json' => [
+                'name' => 'CommandNotifLegacyConnector',
+                'type' => 'Notification',
+                'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
+                'is_shell_enabled' => true,
+                'connector' => '/api/latest/configuration/connectors/1',
+                'comment' => 'coucou',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains(['name' => 'CommandNotifLegacyConnector']);
+    }
+
+    /**
+     * The whole point of this migration: Hydra links (@id) must point to /api, never /api/latest, so that
+     * clients following them are naturally steered towards the new prefix.
+     */
+    public function testCommandHydraIriPointsToNewApiPrefix(): void
+    {
+        $this->login();
+
+        $response = $this->request('POST', '/api/configuration/commands', [
+            'headers' => [
+                'Accept' => 'application/ld+json',
+            ],
+            'json' => [
+                'name' => 'CommandNotifIriCheck',
+                'type' => 'Notification',
+                'command_line' => 'toto $ARG1$ $ARG2$ $_HOSTMAC1$ $_SERVICEMAC2$',
+                'is_shell_enabled' => true,
+                'connector' => '/api/configuration/connectors/1',
+                'comment' => 'coucou',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $payload = $response->toArray();
+        self::assertArrayHasKey('@id', $payload);
+        self::assertIsString($payload['@id']);
+        self::assertStringStartsWith('/api/configuration/commands/', $payload['@id']);
     }
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/DeleteCommandProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/DeleteCommandProcessorTest.php
@@ -50,7 +50,7 @@ final class DeleteCommandProcessorTest extends ApiTestCase
 
         $this->login();
 
-        $this->request('DELETE', '/api/latest/configuration/commands/1');
+        $this->request('DELETE', '/api/configuration/commands/1');
 
         self::assertResponseIsSuccessful();
     }
@@ -59,7 +59,7 @@ final class DeleteCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('DELETE', '/api/latest/configuration/commands/999999');
+        $this->request('DELETE', '/api/configuration/commands/999999');
 
         self::assertResponseStatusCodeSame(404);
         self::assertJsonContains([
@@ -89,7 +89,7 @@ final class DeleteCommandProcessorTest extends ApiTestCase
 
         $this->login();
 
-        $this->request('DELETE', '/api/latest/configuration/commands/' . $id);
+        $this->request('DELETE', '/api/configuration/commands/' . $id);
 
         self::assertResponseStatusCodeSame(400);
         self::assertJsonContains([
@@ -99,7 +99,7 @@ final class DeleteCommandProcessorTest extends ApiTestCase
 
     public function testDeleteCommandWithoutAuthentication(): void
     {
-        $this->request('DELETE', '/api/latest/configuration/commands/1');
+        $this->request('DELETE', '/api/configuration/commands/1');
 
         self::assertResponseStatusCodeSame(401);
     }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/DuplicateCommandsProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/DuplicateCommandsProcessorTest.php
@@ -37,7 +37,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class DuplicateCommandsProcessorTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/commands/_duplicate';
+    private const BASE_ENDPOINT = '/api/configuration/commands/_duplicate';
 
     public function testDuplicateCommandSuccessfully(): void
     {
@@ -75,7 +75,7 @@ final class DuplicateCommandsProcessorTest extends ApiTestCase
         self::assertCount(1, $responseData['member']);
         self::assertIsArray($responseData['member'][0]);
         self::assertIsString($responseData['member'][0]['command']);
-        self::assertStringContainsString('/api/latest/configuration/commands/', $responseData['member'][0]['command']);
+        self::assertStringContainsString('/api/configuration/commands/', $responseData['member'][0]['command']);
         self::assertEquals(204, $responseData['member'][0]['status']);
         self::assertIsString($responseData['member'][0]['message']);
         self::assertStringContainsString('Command duplicated successfully', $responseData['member'][0]['message']);

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/FindCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/FindCommandProviderTest.php
@@ -50,7 +50,7 @@ final class FindCommandProviderTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('GET', '/api/latest/configuration/commands/1');
+        $this->request('GET', '/api/configuration/commands/1');
         self::assertResponseIsSuccessful();
         self::assertMatchesResourceItemJsonSchema(CommandResource::class);
     }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
@@ -29,7 +29,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class ListCommandsProviderTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/commands';
+    private const BASE_ENDPOINT = '/api/configuration/commands';
 
     protected function setUp(): void
     {
@@ -170,7 +170,7 @@ final class ListCommandsProviderTest extends ApiTestCase
         $this->login();
 
         // call PATCH to deactivate a command
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/UpdateCommandProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/UpdateCommandProcessorTest.php
@@ -50,7 +50,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -81,16 +81,16 @@ final class UpdateCommandProcessorTest extends ApiTestCase
         $this->login();
 
         // first make sure connector is not existing in command
-        $response = $this->request('GET', '/api/latest/configuration/commands/1');
+        $response = $this->request('GET', '/api/configuration/commands/1');
         self::assertArrayNotHasKey('connector', $response->toArray());
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
             'json' => [
                 'name' => 'Command with Connector',
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
             ],
         ]);
 
@@ -106,19 +106,19 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
             'json' => [
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
             ],
         ]);
 
-        $response = $this->request('GET', '/api/latest/configuration/commands/1');
+        $response = $this->request('GET', '/api/configuration/commands/1');
         self::assertArrayHasKey('connector', $response->toArray());
 
-        $response = $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $response = $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -136,13 +136,13 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
             'json' => [
                 'name' => 'Command with Invalid Connector',
-                'connector' => '/api/latest/configuration/connectors/9999',
+                'connector' => '/api/configuration/connectors/9999',
             ],
         ]);
 
@@ -157,12 +157,12 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
             'json' => [
-                'connector' => '/api/latest/configuration/connectors/1',
+                'connector' => '/api/configuration/connectors/1',
             ],
         ]);
 
@@ -172,7 +172,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
             'connector' => ['id' => 1, 'name' => 'Perl Connector'],
         ]);
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -193,7 +193,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -202,10 +202,10 @@ final class UpdateCommandProcessorTest extends ApiTestCase
             ],
         ]);
 
-        $response = $this->request('GET', '/api/latest/configuration/commands/1');
+        $response = $this->request('GET', '/api/configuration/commands/1');
         self::assertTrue($response->toArray()['is_activated']);
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -225,7 +225,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -234,10 +234,10 @@ final class UpdateCommandProcessorTest extends ApiTestCase
             ],
         ]);
 
-        $response = $this->request('GET', '/api/latest/configuration/commands/1');
+        $response = $this->request('GET', '/api/configuration/commands/1');
         self::assertFalse($response->toArray()['is_activated']);
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -257,7 +257,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/999999', [
+        $this->request('PATCH', '/api/configuration/commands/999999', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -276,7 +276,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -291,7 +291,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],
@@ -308,7 +308,7 @@ final class UpdateCommandProcessorTest extends ApiTestCase
 
     public function testUpdateCommandWithoutAuthentication(): void
     {
-        $this->request('PATCH', '/api/latest/configuration/commands/1', [
+        $this->request('PATCH', '/api/configuration/commands/1', [
             'headers' => [
                 'Content-Type' => 'application/merge-patch+json',
             ],

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/CreateServiceCategoryProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/CreateServiceCategoryProcessorTest.php
@@ -43,7 +43,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
 
         $this->login();
 
-        $response = $this->request('POST', '/api/latest/configuration/services/categories', [
+        $response = $this->request('POST', '/api/configuration/services/categories', [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],
@@ -72,7 +72,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'json' => [
                 'name' => 'NAME',
                 'alias' => 'ALIAS',
@@ -82,7 +82,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
 
         self::assertResponseIsSuccessful();
 
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'json' => [
                 'name' => 'NAME',
                 'alias' => 'ALIAS',
@@ -97,7 +97,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'json' => [
                 'name' => '',
                 'alias' => '',
@@ -116,7 +116,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'json' => [
                 'name' => true,
                 'alias' => 0,
@@ -135,7 +135,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
 
     public function testCannotCreateServiceCategoryIfNotLogged(): void
     {
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'json' => [
                 'name' => 'NAME',
                 'alias' => 'ALIAS',
@@ -155,7 +155,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
         $this->createApiUser($connection, $username, admin: false);
         $this->login($username);
 
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'json' => [
                 'name' => 'NAME',
                 'alias' => 'ALIAS',
@@ -177,7 +177,7 @@ final class CreateServiceCategoryProcessorTest extends ApiTestCase
         $count = $repository->count();
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/services/categories', [
+        $this->request('POST', '/api/configuration/services/categories', [
             'headers' => [
                 'Content-Type' => 'application/json',
             ],

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/FindConnectorProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/FindConnectorProviderTest.php
@@ -42,7 +42,7 @@ final class FindConnectorProviderTest extends ApiTestCase
     public function testGetConnector(): void
     {
         $this->login();
-        $this->request('GET', '/api/latest/configuration/connectors/1');
+        $this->request('GET', '/api/configuration/connectors/1');
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertJsonContains([
@@ -63,7 +63,7 @@ final class FindConnectorProviderTest extends ApiTestCase
         $this->createApiUser($connection, $username, admin: false);
         $this->login($username);
 
-        $this->request('GET', '/api/latest/configuration/connectors/1');
+        $this->request('GET', '/api/configuration/connectors/1');
 
         $this->assertResponseStatusCodeSame(403);
     }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/FindPluginProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/FindPluginProviderTest.php
@@ -61,7 +61,7 @@ final class FindPluginProviderTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('GET', '/api/latest/configuration/plugins/check_dhcp');
+        $this->request('GET', '/api/configuration/plugins/check_dhcp');
         self::assertResponseIsSuccessful();
         self::assertMatchesResourceItemJsonSchema(PluginResource::class);
         self::assertJsonContains(
@@ -73,13 +73,13 @@ final class FindPluginProviderTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('GET', '/api/latest/configuration/plugins/unknown_plugin');
+        $this->request('GET', '/api/configuration/plugins/unknown_plugin');
         self::assertResponseStatusCodeSame(404);
     }
 
     public function testItRequiresAuthentication(): void
     {
-        $this->request('GET', '/api/latest/configuration/plugins/check_dhcp');
+        $this->request('GET', '/api/configuration/plugins/check_dhcp');
         self::assertResponseStatusCodeSame(401);
     }
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListConnectorsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListConnectorsProviderTest.php
@@ -30,7 +30,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class ListConnectorsProviderTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/connectors';
+    private const BASE_ENDPOINT = '/api/configuration/connectors';
 
     public function testItFindAllConnectorsWithoutParameter(): void
     {

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListGlobalMacrosProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListGlobalMacrosProviderTest.php
@@ -30,7 +30,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class ListGlobalMacrosProviderTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/global-macros';
+    private const BASE_ENDPOINT = '/api/configuration/global-macros';
 
     protected function setUp(): void
     {

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListPluginsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListPluginsProviderTest.php
@@ -63,7 +63,7 @@ final class ListPluginsProviderTest extends ApiTestCase
     {
         $this->login();
 
-        $response = $this->request('GET', '/api/latest/configuration/plugins');
+        $response = $this->request('GET', '/api/configuration/plugins');
 
         self::assertResponseIsSuccessful();
         self::assertMatchesResourceCollectionJsonSchema(ListPluginResource::class);

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListStandardMacrosProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/ListStandardMacrosProviderTest.php
@@ -29,7 +29,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class ListStandardMacrosProviderTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/standard-macros';
+    private const BASE_ENDPOINT = '/api/configuration/standard-macros';
 
     protected function setUp(): void
     {

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/CreatePollerProcessorTest.php
@@ -77,7 +77,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
 
         $address = '10.' . mt_rand(0, 255) . '.' . mt_rand(0, 255) . '.' . mt_rand(1, 254);
 
-        $response = $this->request('POST', '/api/latest/configuration/pollers', [
+        $response = $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $name,
                 'poller_type' => 'vm',
@@ -117,7 +117,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
         $name = $this->uniqueName('WithAddr');
         $address = '10.' . mt_rand(0, 255) . '.' . mt_rand(0, 255) . '.' . mt_rand(1, 254);
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $name,
                 'poller_type' => 'vm',
@@ -138,7 +138,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('Docker'),
                 'poller_type' => 'docker',
@@ -159,7 +159,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
         $this->login();
         $name = $this->uniqueName('Dup');
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $name,
                 'poller_type' => 'vm',
@@ -170,7 +170,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
         ]);
         self::assertResponseIsSuccessful();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $name,
                 'poller_type' => 'vm',
@@ -186,7 +186,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('Invalid'),
                 'poller_type' => 'invalid',
@@ -203,7 +203,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => '',
                 'poller_type' => 'vm',
@@ -220,7 +220,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => str_repeat('a', 41),
                 'poller_type' => 'vm',
@@ -237,7 +237,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('NoToken'),
                 'poller_type' => 'vm',
@@ -253,7 +253,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('UnknownToken'),
                 'poller_type' => 'vm',
@@ -268,7 +268,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
 
     public function testCannotCreatePollerIfNotLogged(): void
     {
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('Unauth'),
                 'poller_type' => 'vm',
@@ -294,7 +294,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
 
         $name = $this->uniqueName('NonAdmin');
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $name,
                 'poller_type' => 'vm',
@@ -319,7 +319,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
         $this->createApiUser($connection, $username, admin: false);
         $this->login($username);
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('Forbidden'),
                 'poller_type' => 'vm',
@@ -339,7 +339,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('NoCentral'),
                 'poller_type' => 'vm',
@@ -355,7 +355,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('EmptyCentral'),
                 'poller_type' => 'vm',
@@ -372,7 +372,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('WsCentral'),
                 'poller_type' => 'vm',
@@ -389,7 +389,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('LongCentral'),
                 'poller_type' => 'vm',
@@ -406,7 +406,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('SchemeCentral'),
                 'poller_type' => 'vm',
@@ -423,7 +423,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $this->request('POST', '/api/latest/configuration/pollers', [
+        $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('SchemeAddress'),
                 'poller_type' => 'vm',
@@ -440,7 +440,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $response = $this->request('POST', '/api/latest/configuration/pollers', [
+        $response = $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('BasePath'),
                 'poller_type' => 'vm',
@@ -465,7 +465,7 @@ final class CreatePollerProcessorTest extends ApiTestCase
     {
         $this->login();
 
-        $response = $this->request('POST', '/api/latest/configuration/pollers', [
+        $response = $this->request('POST', '/api/configuration/pollers', [
             'json' => [
                 'name' => $this->uniqueName('TrailingSlash'),
                 'poller_type' => 'vm',

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/GetInstallationCommandProviderTest.php
@@ -28,7 +28,7 @@ use Tests\App\Shared\ApiTestCase;
 
 final class GetInstallationCommandProviderTest extends ApiTestCase
 {
-    private const BASE_ENDPOINT = '/api/latest/configuration/pollers/installation-command';
+    private const BASE_ENDPOINT = '/api/configuration/pollers/installation-command';
     private const POLLER_UID = 123456789012345;
     private const POLLER_NAME = 'test-poller';
     private const POLLER_TYPE = 'vm';
@@ -115,6 +115,25 @@ final class GetInstallationCommandProviderTest extends ApiTestCase
             self::POLLER_TYPE,
         );
         self::assertSame($expected, $data['installation_command']);
+    }
+
+    /**
+     * Non-regression: this resource is on LegacyApiPrefixAliasLoader's allowlist, so it must
+     * stay reachable at the legacy /api/latest prefix too, not just /api.
+     */
+    public function testItIsAlsoReachableAtTheLegacyApiPrefix(): void
+    {
+        $pollerId = $this->insertPoller(self::POLLER_NAME);
+        $tokenValue = $this->insertPollerToken('named-token');
+        $this->login();
+
+        $legacyEndpoint = str_replace('/api/', '/api/latest/', self::BASE_ENDPOINT);
+        $response = $this->request('GET', sprintf('%s/%d?token-name=named-token', $legacyEndpoint, $pollerId));
+
+        self::assertResponseIsSuccessful();
+        /** @var array{installation_command: string} $data */
+        $data = $response->toArray();
+        self::assertStringContainsString($tokenValue, $data['installation_command']);
     }
 
     private function insertPoller(string $name): int

--- a/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\ApiPlatform\Routing;
+
+use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiPrefixAliasLoader;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
+{
+    public function testAllowlistedOperationKeepsItsLegacyAlias(): void
+    {
+        $routes = $this->getRouteCollection();
+
+        $canonical = $this->findRouteByOperationAndPath(
+            $routes,
+            '_api_/configuration/commands/{id}_get',
+            '/api/configuration/commands/{id}',
+        );
+        $legacyAlias = $this->findRouteByOperationAndPath(
+            $routes,
+            '_api_/configuration/commands/{id}_get',
+            '/api/latest/configuration/commands/{id}',
+        );
+
+        self::assertNotNull($canonical, 'The command item operation should be reachable under /api.');
+        self::assertNotNull($legacyAlias, 'The command item operation is on the legacy allowlist, it should also be reachable under /api/latest.');
+    }
+
+    public function testOperationsApiPlatformGeneratesOnItsOwnAreNotAliased(): void
+    {
+        $routes = $this->getRouteCollection();
+
+        // API Platform derives this item operation from PollerResource to build IRIs, it is not
+        // an endpoint the legacy /api/latest prefix ever exposed.
+        $generatedOperation = '_api_/pollers/{id}{._format}_get';
+
+        self::assertNotNull(
+            $this->findRouteByOperationAndPath($routes, $generatedOperation, '/api/pollers/{id}.{_format}'),
+            'The generated item operation is expected under /api, otherwise this test no longer covers anything.',
+        );
+        self::assertNull(
+            $this->findRouteByOperationAndPath($routes, $generatedOperation, '/api/latest/pollers/{id}.{_format}'),
+            'A generated item operation must not be duplicated under /api/latest.',
+        );
+    }
+
+    public function testOnlyAllowlistedOperationsAppearInTheLegacyAlias(): void
+    {
+        $allowlist = new \ReflectionClassConstant(LegacyApiPrefixAliasLoader::class, 'LEGACY_ALIAS_OPERATION_NAMES');
+        /** @var list<string> $allowlistedOperations */
+        $allowlistedOperations = $allowlist->getValue();
+        self::assertNotEmpty($allowlistedOperations);
+
+        $routes = $this->getRouteCollection();
+        foreach ($routes as $name => $route) {
+            if (! str_starts_with($name, 'legacy_')) {
+                continue;
+            }
+
+            $operationName = $route->getDefault('_api_operation_name');
+            if ($operationName === null) {
+                continue; // docs, entrypoint, genid, jsonld context.
+            }
+            self::assertIsString($operationName);
+
+            self::assertContains(
+                $operationName,
+                $allowlistedOperations,
+                "Route \"{$name}\" is prefixed /api/latest but its operation ({$operationName}) "
+                . 'is not on LegacyApiPrefixAliasLoader::LEGACY_ALIAS_OPERATION_NAMES.',
+            );
+        }
+    }
+
+    public function testAuxiliaryDocumentationRoutesAreDuplicatedRegardlessOfOperations(): void
+    {
+        $routes = $this->getRouteCollection();
+
+        self::assertNotNull($routes->get('api_entrypoint'));
+        self::assertNotNull($routes->get('legacy_api_entrypoint'));
+        self::assertNotNull($routes->get('api_doc'));
+        self::assertNotNull($routes->get('legacy_api_doc'));
+    }
+
+    private function getRouteCollection(): RouteCollection
+    {
+        self::bootKernel();
+        /** @var RouterInterface $router */
+        $router = self::getContainer()->get('router');
+
+        return $router->getRouteCollection();
+    }
+
+    private function findRouteByOperationAndPath(
+        RouteCollection $routes,
+        string $operationName,
+        string $path,
+    ): ?Route {
+        foreach ($routes as $route) {
+            if ($route->getDefault('_api_operation_name') === $operationName && $route->getPath() === $path) {
+                return $route;
+            }
+        }
+
+        return null;
+    }
+}

--- a/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/Routing/LegacyApiPrefixAliasLoaderTest.php
@@ -23,8 +23,11 @@ declare(strict_types=1);
 
 namespace Tests\App\Shared\Infrastructure\ApiPlatform\Routing;
 
+use App\Shared\Infrastructure\ApiPlatform\Routing\CoreLegacyApiAliasOperations;
+use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiAliasOperationProviderInterface;
 use App\Shared\Infrastructure\ApiPlatform\Routing\LegacyApiPrefixAliasLoader;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
@@ -70,9 +73,9 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
 
     public function testOnlyAllowlistedOperationsAppearInTheLegacyAlias(): void
     {
-        $allowlist = new \ReflectionClassConstant(LegacyApiPrefixAliasLoader::class, 'LEGACY_ALIAS_OPERATION_NAMES');
-        /** @var list<string> $allowlistedOperations */
-        $allowlistedOperations = $allowlist->getValue();
+        // In the test kernel only the core provider is registered (no module), so the aliased
+        // operations must all come from the core allowlist.
+        $allowlistedOperations = (new CoreLegacyApiAliasOperations())->getOperationNames();
         self::assertNotEmpty($allowlistedOperations);
 
         $routes = $this->getRouteCollection();
@@ -91,9 +94,41 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
                 $operationName,
                 $allowlistedOperations,
                 "Route \"{$name}\" is prefixed /api/latest but its operation ({$operationName}) "
-                . 'is not on LegacyApiPrefixAliasLoader::LEGACY_ALIAS_OPERATION_NAMES.',
+                . 'is not contributed by any LegacyApiAliasOperationProviderInterface.',
             );
         }
+    }
+
+    /**
+     * A module extends the /api/latest allowlist purely by shipping a
+     * LegacyApiAliasOperationProviderInterface service (auto-tagged by the new kernel). This is the
+     * regression fix for MON-208750: released module endpoints must keep their /api/latest alias.
+     */
+    public function testModuleContributedProviderExtendsTheLegacyAlias(): void
+    {
+        $routes = new RouteCollection();
+        $routes->add('core_op', $this->apiRoute('/configuration/commands', '_api_/configuration/commands_get_collection'));
+        $routes->add('module_op', $this->apiRoute('/bam/configuration/business-activities', '_api_/bam/configuration/business-activities_get_collection'));
+        $routes->add('generated_op', $this->apiRoute('/pollers/{id}', '_api_/pollers/{id}_get'));
+        $routes->add('api_doc', $this->apiRoute('/docs', null));
+
+        $apiLoader = $this->createMock(LoaderInterface::class);
+        $apiLoader->method('load')->willReturn($routes);
+
+        $loader = new LegacyApiPrefixAliasLoader($apiLoader, [
+            new CoreLegacyApiAliasOperations(),
+            $this->providerFor('_api_/bam/configuration/business-activities_get_collection'),
+        ]);
+
+        $aliased = ($loader)();
+
+        $moduleRoute = $aliased->get('legacy_module_op');
+
+        self::assertNotNull($aliased->get('legacy_core_op'), 'A core-listed operation must be aliased.');
+        self::assertNotNull($moduleRoute, 'A module-contributed operation must be aliased.');
+        self::assertNotNull($aliased->get('legacy_api_doc'), 'Meta routes (no operation) are always aliased.');
+        self::assertNull($aliased->get('legacy_generated_op'), 'An operation no provider lists must not be aliased.');
+        self::assertSame('/api/latest/bam/configuration/business-activities', $moduleRoute->getPath());
     }
 
     public function testAuxiliaryDocumentationRoutesAreDuplicatedRegardlessOfOperations(): void
@@ -127,5 +162,27 @@ final class LegacyApiPrefixAliasLoaderTest extends KernelTestCase
         }
 
         return null;
+    }
+
+    private function apiRoute(string $path, ?string $operationName): Route
+    {
+        return new Route($path, $operationName !== null ? ['_api_operation_name' => $operationName] : []);
+    }
+
+    private function providerFor(string ...$operationNames): LegacyApiAliasOperationProviderInterface
+    {
+        return new class (array_values($operationNames)) implements LegacyApiAliasOperationProviderInterface {
+            /**
+             * @param list<string> $operationNames
+             */
+            public function __construct(private readonly array $operationNames)
+            {
+            }
+
+            public function getOperationNames(): array
+            {
+                return $this->operationNames;
+            }
+        };
     }
 }

--- a/centreon/tests/php/App/Shared/Infrastructure/Legacy/BareApiAuthenticationFallbackIntegrationTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/Legacy/BareApiAuthenticationFallbackIntegrationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\Legacy;
+
+use Tests\App\Shared\ApiTestCase;
+
+final class BareApiAuthenticationFallbackIntegrationTest extends ApiTestCase
+{
+    private const ADMIN_PASSWORD = 'Centreon!2021';
+
+    public function testLoginWithInvalidCredentialsAtBarePrefix(): void
+    {
+        $response = $this->request('POST', '/api/login', [
+            'json' => ['security' => ['credentials' => ['login' => 'admin', 'password' => 'wrong-password']]],
+        ]);
+
+        self::assertSame(401, $response->getStatusCode(), $response->getContent(false));
+    }
+
+    public function testLoginThenLogoutAtBarePrefix(): void
+    {
+        $loginResponse = $this->request('POST', '/api/login', [
+            'json' => ['security' => ['credentials' => ['login' => 'admin', 'password' => self::ADMIN_PASSWORD]]],
+        ]);
+        self::assertSame(200, $loginResponse->getStatusCode(), $loginResponse->getContent(false));
+
+        /** @var array{security: array{token: string}} $body */
+        $body = $loginResponse->toArray();
+        self::assertNotEmpty($body['security']['token']);
+
+        $logoutResponse = $this->request('GET', '/api/logout', [
+            'headers' => ['X-AUTH-TOKEN' => $body['security']['token']],
+        ]);
+        self::assertSame(200, $logoutResponse->getStatusCode(), $logoutResponse->getContent(false));
+    }
+
+    public function testLoginSamlBehavesIdenticallyOnBothPrefixes(): void
+    {
+        // Core\Infrastructure\Common\Api\Router / HttpUrlTrait read $_SERVER directly instead of the Request object.
+        $_SERVER['REQUEST_SCHEME'] = 'http';
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $_SERVER['HTTP_HOST'] = 'localhost';
+
+        $legacyResponse = $this->request('GET', '/api/latest/login/saml');
+        $bareResponse = $this->request('GET', '/api/login/saml');
+
+        self::assertSame($legacyResponse->getStatusCode(), $bareResponse->getStatusCode());
+    }
+}

--- a/centreon/tests/php/Core/Integration/Authentication/Login/LoginBarePrefixIntegrationTest.php
+++ b/centreon/tests/php/Core/Integration/Authentication/Login/LoginBarePrefixIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Integration\Authentication\Login;
+
+use Tests\Core\Integration\CoreApiTestCase;
+
+final class LoginBarePrefixIntegrationTest extends CoreApiTestCase
+{
+    private const PASSWORD = 'Centreon!2021';
+
+    public function testLoginAtLegacyPrefixWithValidCredentials(): void
+    {
+        $response = $this->request('POST', '/api/latest/login', [
+            'body' => json_encode([
+                'security' => ['credentials' => ['login' => 'admin', 'password' => self::PASSWORD]],
+            ]),
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{security?: array{token?: string}} $body */
+        $body = json_decode((string) $response->getContent(), associative: true);
+        $this->assertArrayHasKey('security', $body);
+        $this->assertNotEmpty($body['security']['token'] ?? null);
+    }
+
+    public function testLoginAtBareApiPrefixWithValidCredentials(): void
+    {
+        $response = $this->request('POST', '/api/login', [
+            'body' => json_encode([
+                'security' => ['credentials' => ['login' => 'admin', 'password' => self::PASSWORD]],
+            ]),
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{security?: array{token?: string}} $body */
+        $body = json_decode((string) $response->getContent(), associative: true);
+        $this->assertArrayHasKey('security', $body);
+        $this->assertNotEmpty($body['security']['token'] ?? null);
+    }
+
+    public function testLoginAtBareApiPrefixWithInvalidCredentialsReturns401(): void
+    {
+        $response = $this->request('POST', '/api/login', [
+            'body' => json_encode([
+                'security' => ['credentials' => ['login' => 'admin', 'password' => 'wrong-password']],
+            ]),
+        ]);
+
+        $this->assertSame(401, $response->getStatusCode(), (string) $response->getContent());
+    }
+}

--- a/centreon/tests/php/Core/Integration/Authentication/Logout/LogoutBarePrefixIntegrationTest.php
+++ b/centreon/tests/php/Core/Integration/Authentication/Logout/LogoutBarePrefixIntegrationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Integration\Authentication\Logout;
+
+use Tests\Core\Integration\CoreApiTestCase;
+
+final class LogoutBarePrefixIntegrationTest extends CoreApiTestCase
+{
+    public function testLogoutAtLegacyPrefixRevokesToken(): void
+    {
+        $this->login('admin');
+        $token = $this->token;
+
+        $response = $this->request('GET', '/api/latest/logout');
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+        $this->assertTokenIsRevoked($token);
+    }
+
+    public function testLogoutAtBareApiPrefixRevokesToken(): void
+    {
+        $this->login('admin');
+        $token = $this->token;
+
+        $response = $this->request('GET', '/api/logout');
+
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+        $this->assertTokenIsRevoked($token);
+    }
+
+    public function testLogoutAtBareApiPrefixWithoutTokenReturns401(): void
+    {
+        $response = $this->request('GET', '/api/logout');
+
+        $this->assertSame(401, $response->getStatusCode(), (string) $response->getContent());
+    }
+
+    private function assertTokenIsRevoked(?string $token): void
+    {
+        self::assertNotNull($token);
+        $stmt = self::$db->prepare('SELECT COUNT(*) FROM security_token WHERE token = :token');
+        $stmt->execute([':token' => $token]);
+        self::assertSame(
+            0,
+            (int) $stmt->fetchColumn(),
+            'The token should have been deleted from security_token by /logout.'
+        );
+    }
+}

--- a/centreon/tests/php/Core/Integration/Authentication/Saml/SamlBarePrefixIntegrationTest.php
+++ b/centreon/tests/php/Core/Integration/Authentication/Saml/SamlBarePrefixIntegrationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Integration\Authentication\Saml;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class SamlBarePrefixIntegrationTest extends WebTestCase
+{
+    public function testLoginSamlBehavesIdenticallyOnBothPrefixes(): void
+    {
+        $client = self::createClient();
+        $client->catchExceptions(true);
+
+        $client->request('GET', '/centreon/api/latest/login/saml', server: self::serverParams());
+        $legacyResponse = $client->getResponse();
+
+        $client->request('GET', '/centreon/api/login/saml', server: self::serverParams());
+        $bareResponse = $client->getResponse();
+
+        self::assertSame($legacyResponse->getStatusCode(), $bareResponse->getStatusCode());
+        self::assertSame($legacyResponse->headers->get('Location'), $bareResponse->headers->get('Location'));
+    }
+
+    public function testSamlAcsBehavesIdenticallyOnBothPrefixes(): void
+    {
+        $client = self::createClient();
+        $client->catchExceptions(true);
+
+        $client->request('POST', '/centreon/api/latest/saml/acs', server: self::serverParams());
+        $legacyResponse = $client->getResponse();
+
+        $client->request('POST', '/centreon/api/saml/acs', server: self::serverParams());
+        $bareResponse = $client->getResponse();
+
+        self::assertSame($legacyResponse->getStatusCode(), $bareResponse->getStatusCode());
+        self::assertSame($legacyResponse->headers->get('Location'), $bareResponse->headers->get('Location'));
+    }
+
+    public function testSamlSlsBehavesIdenticallyOnBothPrefixes(): void
+    {
+        $client = self::createClient();
+        $client->catchExceptions(true);
+
+        $client->request('GET', '/centreon/api/latest/saml/sls', server: self::serverParams());
+        $legacyResponse = $client->getResponse();
+
+        $client->request('GET', '/centreon/api/saml/sls', server: self::serverParams());
+        $bareResponse = $client->getResponse();
+
+        self::assertSame($legacyResponse->getStatusCode(), $bareResponse->getStatusCode());
+        self::assertSame($legacyResponse->headers->get('Location'), $bareResponse->headers->get('Location'));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function serverParams(): array
+    {
+        // Core\Infrastructure\Common\Api\Router reads $_SERVER directly instead of the
+        // Request object, so these must also be set on the superglobal (see CoreApiTestCase::request()).
+        $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+        $_SERVER['REQUEST_SCHEME'] = 'http';
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        $_SERVER['HTTP_HOST'] = 'localhost';
+
+        return [
+            'REMOTE_ADDR' => '8.8.8.8',
+            'HTTP_HOST' => 'localhost',
+            'SERVER_NAME' => 'localhost',
+            'REQUEST_SCHEME' => 'http',
+            'HTTPS' => '',
+        ];
+    }
+}

--- a/centreon/tests/php/integration-bootstrap.php
+++ b/centreon/tests/php/integration-bootstrap.php
@@ -72,7 +72,12 @@ $centreonTables = $centreonPdo->query('SHOW TABLES')->fetchAll(PDO::FETCH_COLUMN
 if ($centreonTables === []) {
     $centreonPdo->exec(file_get_contents($projectDir . '/www/install/createTables.sql'));
     $centreonPdo->exec('SET FOREIGN_KEY_CHECKS=0');
-    $centreonPdo->exec(file_get_contents($projectDir . '/www/install/insertBaseConf.sql'));
+    $insertBaseConf = str_replace(
+        '@admin_password@',
+        password_hash('Centreon!2021', PASSWORD_BCRYPT),
+        file_get_contents($projectDir . '/www/install/insertBaseConf.sql')
+    );
+    $centreonPdo->exec($insertBaseConf);
     $centreonPdo->exec(file_get_contents($projectDir . '/www/install/insertTopology.sql'));
     $centreonPdo->exec('SET FOREIGN_KEY_CHECKS=1');
 }


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the bare `/api` migration. Exposes API Platform resources under the canonical bare `/api` prefix and keeps the released `/api/latest` alias extensible by modules.

Bundles two upstream changes (#11078 and #11552) as they form a single behavioural unit — the alias fix directly follows the prefix migration.

**Fixes** MON-208835

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.10.x

## How this pull request can be tested ?

- Call an API Platform resource under bare `/api` (e.g. `GET /api/configuration/pollers`) and confirm it resolves.
- Confirm module endpoints under `/api/latest/...` still resolve (alias remains functional).
- Backend: PHPStan (App src + tests) and the App unit suite are green on the stack top.