### PR TITLE
feat(configuration): add host groups selector endpoint

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -136,6 +136,9 @@ tags:
   -
     name: Upgrade
     description: "Resource 'Upgrade' operations."
+  -
+    name: HostGroup
+    description: "Resource 'HostGroup' operations."
 security:
   -
     Token: []
@@ -4670,6 +4673,90 @@ paths:
             type: integer
             default: 30
             minimum: 0
+            maximum: 30
+          style: form
+          explode: true
+  /configuration/host_groups:
+    get:
+      operationId: api_configurationhost_groups_get_collection
+      tags:
+        - HostGroup
+      responses:
+        '200':
+          description: 'HostGroup collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'HostGroup.HostGroupCollectionOutput.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/HostGroup.HostGroupCollectionOutput.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HostGroup.HostGroupCollectionOutput'
+        '400':
+          description: 'Invalid query parameter (itemsPerPage must be a positive integer, name must use the "name[lk]=value" format)'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {  }
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {  }
+      summary: 'Retrieves the collection of HostGroup resources.'
+      description: 'Retrieves the collection of HostGroup resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by host group name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 1
             maximum: 30
           style: form
           explode: true
@@ -10148,3 +10235,21 @@ components:
               type: string
               example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
               nullable: true
+    HostGroup.HostGroupCollectionOutput:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    HostGroup.HostGroupCollectionOutput.jsonld:
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroup.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroup.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostGroup;
+
+use App\Shared\Domain\Aggregate\AggregateRoot;
+
+/**
+ * @extends AggregateRoot<HostGroupId>
+ */
+final class HostGroup extends AggregateRoot
+{
+    public function __construct(
+        ?HostGroupId $id,
+        public readonly HostGroupName $name,
+    ) {
+        parent::__construct($id);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroupId.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroupId.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostGroup;
+
+use App\Shared\Domain\Aggregate\AggregateRootId;
+
+final readonly class HostGroupId extends AggregateRootId
+{
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroupName.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroupName.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostGroup;
+
+use Webmozart\Assert\Assert;
+
+final readonly class HostGroupName
+{
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        $value = trim($value);
+        Assert::lengthBetween($value, 1, 200);
+        $this->value = $value;
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/HostGroupCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/HostGroupCriteria.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Repository\Criteria;
+
+use App\Security\Domain\Aggregate\UserId;
+use Webmozart\Assert\Assert;
+
+final class HostGroupCriteria
+{
+    private ?int $page = null;
+
+    private ?int $itemsPerPage = null;
+
+    private ?string $name = null;
+
+    private ?UserId $viewerId = null;
+
+    public function withPagination(int $page, int $itemsPerPage): self
+    {
+        Assert::positiveInteger($page);
+        Assert::positiveInteger($itemsPerPage);
+
+        $new = clone $this;
+        $new->page = $page;
+        $new->itemsPerPage = $itemsPerPage;
+
+        return $new;
+    }
+
+    public function withName(string $name): self
+    {
+        Assert::stringNotEmpty($name);
+
+        $new = clone $this;
+        $new->name = $name;
+
+        return $new;
+    }
+
+    public function getPage(): ?int
+    {
+        return $this->page;
+    }
+
+    public function getItemsPerPage(): ?int
+    {
+        return $this->itemsPerPage;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param UserId|null $viewerId the user to scope results for, or null when no ACL restriction applies (e.g. an admin)
+     */
+    public function withViewerId(?UserId $viewerId): self
+    {
+        $new = clone $this;
+        $new->viewerId = $viewerId;
+
+        return $new;
+    }
+
+    public function getViewerId(): ?UserId
+    {
+        return $this->viewerId;
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/HostGroupRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/HostGroupRepository.php
@@ -21,22 +21,15 @@
 
 declare(strict_types=1);
 
-namespace App\Security\Domain\Repository;
+namespace App\MonitoringConfiguration\Domain\Repository;
 
-use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
-use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
-use App\Security\Domain\Aggregate\UserId;
-use App\Shared\Domain\Collection;
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroup;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostGroupCriteria;
 
-interface ResourceAccessRepository
+interface HostGroupRepository
 {
-    public function hasAccessToAllPollers(UserId $userId): bool;
-
-    public function hasAccessToPoller(PollerId $pollerId, UserId $userId): bool;
-
     /**
-     * @return Collection<HostGroupId>|null null means no restriction applies (the user can access
-     *                                      all host groups); an empty Collection means the user can access none
+     * @return \IteratorAggregate<int, HostGroup>&\Countable
      */
-    public function findAccessibleHostGroupIds(UserId $userId): ?Collection;
+    public function findAll(?HostGroupCriteria $criteria = null): \IteratorAggregate&\Countable;
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Security/HostGroupPermissionEnum.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Security/HostGroupPermissionEnum.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Security;
+
+enum HostGroupPermissionEnum: string
+{
+    case CanRead = 'can_read_host_group';
+    case CanReadAndWrite = 'can_read_and_write_host_group';
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostGroup/HostGroupCollectionOutput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostGroup/HostGroupCollectionOutput.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostGroup;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+final class HostGroupCollectionOutput
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostGroup/HostGroupResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostGroup/HostGroupResource.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostGroup;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\OpenApi\Model;
+use App\MonitoringConfiguration\Domain\Security\HostGroupPermissionEnum;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostGroup\ListHostGroupsProvider;
+
+#[ApiResource(
+    shortName: 'HostGroup',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/configuration/host_groups',
+            provider: ListHostGroupsProvider::class,
+            output: HostGroupCollectionOutput::class,
+            openapi: new Model\Operation(
+                parameters: [
+                    new Model\Parameter(
+                        name: 'name[lk]',
+                        in: 'query',
+                        description: 'Filter by host group name using "like" operator',
+                        required: false,
+                        schema: ['type' => 'string'],
+                    ),
+                ],
+            ),
+            security: '
+                is_granted("' . HostGroupPermissionEnum::CanRead->value . '") or
+                is_granted("' . HostGroupPermissionEnum::CanReadAndWrite->value . '")',
+            securityMessage: 'You are not allowed to list host groups',
+        ),
+    ],
+)]
+final class HostGroupResource
+{
+    public function __construct(
+        #[ApiProperty(identifier: true, writable: false)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/HostGroupCollectionOutputTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/HostGroupCollectionOutputTransformer.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostGroup;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroup;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostGroup\HostGroupCollectionOutput;
+use App\Shared\Infrastructure\TransformerInterface;
+
+/**
+ * @implements TransformerInterface<HostGroup, HostGroupCollectionOutput>
+ */
+final readonly class HostGroupCollectionOutputTransformer implements TransformerInterface
+{
+    public function transform(mixed $from): HostGroupCollectionOutput
+    {
+        return new HostGroupCollectionOutput(
+            id: $from->id()->value,
+            name: $from->name->value,
+        );
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/ListHostGroupsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/ListHostGroupsProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostGroup;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroup;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostGroupCriteria;
+use App\MonitoringConfiguration\Domain\Repository\HostGroupRepository;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostGroup\HostGroupCollectionOutput;
+use App\Security\Infrastructure\Security\CredentialUser;
+use App\Shared\Domain\Repository\Paginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Webmozart\Assert\Assert;
+
+/**
+ * @implements ProviderInterface<HostGroupCollectionOutput>
+ */
+final readonly class ListHostGroupsProvider implements ProviderInterface
+{
+    /**
+     * @param TransformerInterface<HostGroup, HostGroupCollectionOutput> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: HostGroupCollectionOutputTransformer::class)]
+        private TransformerInterface $transformer,
+        private HostGroupRepository $repository,
+        private Pagination $pagination,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @return iterable<HostGroupCollectionOutput>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
+    {
+        $credentialUser = $this->security->getUser();
+        Assert::isInstanceOf($credentialUser, CredentialUser::class);
+        $isAdmin = $credentialUser->credential->isAdmin();
+
+        $criteria = new HostGroupCriteria();
+        if ($this->pagination->isEnabled($operation, $context)) {
+            $itemsPerPage = $this->pagination->getLimit($operation, $context);
+            if ($itemsPerPage <= 0) {
+                throw new BadRequestHttpException('itemsPerPage must be a positive integer.');
+            }
+            $criteria = $criteria->withPagination($this->pagination->getPage($context), $itemsPerPage);
+        }
+
+        /** @var array{name?: mixed} $filters */
+        $filters = $context['filters'] ?? [];
+        $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
+        $criteria = $isAdmin ? $criteria : $criteria->withViewerId($credentialUser->credential->userId);
+
+        $hostGroups = $this->repository->findAll($criteria);
+        $resources = [];
+        foreach ($hostGroups as $hostGroup) {
+            $resources[] = $this->transformer->transform($hostGroup);
+        }
+
+        if (! $hostGroups instanceof Paginator) {
+            return $resources;
+        }
+
+        return new TraversablePaginator(
+            new \ArrayIterator($resources),
+            $hostGroups->getCurrentPage(),
+            $hostGroups->getItemsPerPage(),
+            $hostGroups->getTotalItems()
+        );
+    }
+
+    private function handleNameFilter(mixed $nameFilter, HostGroupCriteria $criteria): HostGroupCriteria
+    {
+        if ($nameFilter === null) {
+            return $criteria;
+        }
+
+        // a client sending "?name=foo" instead of "?name[lk]=foo" lands here as a plain string
+        if (! is_array($nameFilter)) {
+            throw new BadRequestHttpException('The "name" filter must use the "name[lk]=value" format.');
+        }
+
+        $likeValue = $nameFilter['lk'] ?? null;
+        if (is_array($likeValue)) {
+            $likeValue = reset($likeValue);
+        }
+
+        if (! is_string($likeValue) || $likeValue === '') {
+            return $criteria;
+        }
+
+        return $criteria->withName($likeValue);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostGroupRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostGroupRepository.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroup;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostGroupCriteria;
+use App\MonitoringConfiguration\Domain\Repository\HostGroupRepository;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Domain\Repository\ResourceAccessRepository;
+use App\Shared\Domain\Collection;
+use App\Shared\Infrastructure\Dbal\DbalRepository;
+use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Webmozart\Assert\Assert;
+
+/**
+ * @phpstan-type RowTypeAlias = array{
+ *   hg_id: int,
+ *   hg_name: string,
+ * }
+ */
+final readonly class DbalHostGroupRepository extends DbalRepository implements HostGroupRepository
+{
+    public const TABLE_NAME = 'hostgroup';
+
+    /**
+     * @param TransformerInterface<RowTypeAlias, HostGroup> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: 'doctrine.dbal.default_connection')]
+        private Connection $connection,
+        #[Autowire(service: DbalHostGroupTransformer::class)]
+        private TransformerInterface $transformer,
+        private ResourceAccessRepository $resourceAccessRepository,
+    ) {
+    }
+
+    public function findAll(?HostGroupCriteria $criteria = null): \IteratorAggregate&\Countable
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select(...self::getSelectColumns())
+            ->from(self::TABLE_NAME, 'hg')
+            ->orderBy('hg.hg_id'); // required for deterministic pagination
+
+        if ($criteria instanceof HostGroupCriteria) {
+            $this->filterByHostGroupCriteria($qb, $criteria);
+        }
+
+        if ($criteria?->getPage() === null || $criteria->getItemsPerPage() === null) {
+            /** @var array<RowTypeAlias> $rows */
+            $rows = $qb->executeQuery()->fetchAllAssociative();
+
+            return new Collection(array_map(fn (array $row): HostGroup => $this->createHostGroup($row), $rows), HostGroup::class);
+        }
+
+        $this->paginate($qb, $criteria);
+
+        $count = $this->countOnQueryBuilder($qb); // must be done before fetching all rows
+
+        /** @var array<RowTypeAlias> $rows */
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        return new InMemoryPaginator(
+            items: new Collection(array_map(fn (array $row): HostGroup => $this->createHostGroup($row), $rows), HostGroup::class),
+            totalItems: $count,
+            currentPage: $criteria->getPage() ?? throw new \LogicException('Unexpected null page'),
+            itemsPerPage: $criteria->getItemsPerPage() ?? throw new \LogicException('Unexpected null items per page'),
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function getSelectColumns(string $alias = 'hg'): array
+    {
+        return [
+            "{$alias}.hg_id AS hg_id",
+            "{$alias}.hg_name AS hg_name",
+        ];
+    }
+
+    private function filterByHostGroupCriteria(QueryBuilder $qb, HostGroupCriteria $criteria): void
+    {
+        if (($name = $criteria->getName()) !== null) {
+            $qb->andWhere($qb->expr()->like('hg.hg_name', $qb->createNamedParameter('%' . $name . '%')));
+        }
+
+        if (($viewerId = $criteria->getViewerId()) instanceof UserId) {
+            $accessibleHostGroupIds = $this->resourceAccessRepository->findAccessibleHostGroupIds($viewerId);
+            if ($accessibleHostGroupIds instanceof Collection) {
+                $ids = [];
+                foreach ($accessibleHostGroupIds as $hostGroupId) {
+                    $ids[] = $hostGroupId->value;
+                }
+
+                $qb->andWhere($qb->expr()->in(
+                    'hg.hg_id',
+                    $qb->createNamedParameter($ids, ArrayParameterType::INTEGER)
+                ));
+            }
+        }
+    }
+
+    private function paginate(QueryBuilder $qb, HostGroupCriteria $criteria): void
+    {
+        if ($criteria->getPage() === null || $criteria->getItemsPerPage() === null) {
+            return;
+        }
+
+        $qb->setFirstResult(($criteria->getPage() - 1) * $criteria->getItemsPerPage())
+            ->setMaxResults($criteria->getItemsPerPage());
+    }
+
+    private function countOnQueryBuilder(QueryBuilder $qb): int
+    {
+        $qb = clone $qb; // avoid modifying the initial query builder
+
+        $count = $qb
+            ->select('COUNT(DISTINCT hg.hg_id)')
+            ->setFirstResult(0) // reset any pagination
+            ->setMaxResults(null)
+            ->executeQuery()
+            ->fetchOne();
+
+        Assert::integer($count);
+
+        return $count;
+    }
+
+    /**
+     * @param RowTypeAlias $row
+     */
+    private function createHostGroup(array $row): HostGroup
+    {
+        return $this->transformer->transform($row);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostGroupTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostGroupTransformer.php
@@ -21,22 +21,25 @@
 
 declare(strict_types=1);
 
-namespace App\Security\Domain\Repository;
+namespace App\MonitoringConfiguration\Infrastructure\Dbal;
 
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroup;
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
-use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
-use App\Security\Domain\Aggregate\UserId;
-use App\Shared\Domain\Collection;
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupName;
+use App\Shared\Infrastructure\TransformerInterface;
 
-interface ResourceAccessRepository
+/**
+ * @phpstan-import-type RowTypeAlias from DbalHostGroupRepository
+ *
+ * @implements TransformerInterface<RowTypeAlias, HostGroup>
+ */
+final readonly class DbalHostGroupTransformer implements TransformerInterface
 {
-    public function hasAccessToAllPollers(UserId $userId): bool;
-
-    public function hasAccessToPoller(PollerId $pollerId, UserId $userId): bool;
-
-    /**
-     * @return Collection<HostGroupId>|null null means no restriction applies (the user can access
-     *                                      all host groups); an empty Collection means the user can access none
-     */
-    public function findAccessibleHostGroupIds(UserId $userId): ?Collection;
+    public function transform(mixed $from): HostGroup
+    {
+        return new HostGroup(
+            id: new HostGroupId($from['hg_id']),
+            name: new HostGroupName($from['hg_name']),
+        );
+    }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Security/HostGroupPermissionVoter.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Security/HostGroupPermissionVoter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Security;
+
+use App\MonitoringConfiguration\Domain\Security\HostGroupPermissionEnum;
+use App\Security\Domain\Aggregate\Permission;
+use App\Security\Infrastructure\Security\CredentialUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<value-of<HostGroupPermissionEnum>, mixed>
+ */
+final class HostGroupPermissionVoter extends Voter
+{
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return HostGroupPermissionEnum::tryFrom($attribute) !== null;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        $user = $token->getUser();
+
+        if (! $user instanceof CredentialUser) {
+            $vote?->addReason('The user is not logged in.');
+
+            return false;
+        }
+
+        if (! $user->credential->isPermissionGranted(new Permission($attribute))) {
+            $vote?->addReason('The user has not the required permission.');
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/centreon/src/App/Security/Domain/Aggregate/Credential.php
+++ b/centreon/src/App/Security/Domain/Aggregate/Credential.php
@@ -70,4 +70,9 @@ final readonly class Credential
     {
         return $this->permissions->contains($permission);
     }
+
+    public function isAdmin(): bool
+    {
+        return $this->roles->contains(new Role('ROLE_ADMIN'));
+    }
 }

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
@@ -27,6 +27,7 @@ use App\MonitoringConfiguration\Domain\Security\AgentConfigurationPermissionEnum
 use App\MonitoringConfiguration\Domain\Security\CommandPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\ConnectorPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\GlobalMacroPermissionEnum;
+use App\MonitoringConfiguration\Domain\Security\HostGroupPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\PollerPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\ServiceCategoryPermissionEnum;
 use App\Security\Domain\Aggregate\Credential;
@@ -53,6 +54,8 @@ final readonly class DbalCredentialTransformer implements TransformerInterface
         'ROLE_CONFIGURATION_COMMANDS_CONNECTORS_R' => ConnectorPermissionEnum::CanRead->value,
         'ROLE_CONFIGURATION_COMMANDS_CONNECTORS_RW' => ConnectorPermissionEnum::CanReadAndWrite->value,
         'ROLE_CONFIGURATION_POLLERS_AGENT_CONFIGURATIONS_RW' => AgentConfigurationPermissionEnum::CanReadAndWrite->value,
+        'ROLE_CONFIGURATION_HOSTS_HOST_GROUPS_R' => HostGroupPermissionEnum::CanRead->value,
+        'ROLE_CONFIGURATION_HOSTS_HOST_GROUPS_RW' => HostGroupPermissionEnum::CanReadAndWrite->value,
     ];
 
     /**

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
@@ -23,9 +23,11 @@ declare(strict_types=1);
 
 namespace App\Security\Infrastructure\Dbal;
 
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\Security\Domain\Aggregate\UserId;
 use App\Security\Domain\Repository\ResourceAccessRepository;
+use App\Shared\Domain\Collection;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -82,6 +84,47 @@ final readonly class DbalResourceAccessRepository implements ResourceAccessRepos
             'contactId' => $userId->value,
             'pollerId' => $pollerId->value,
         ]);
+    }
+
+    public function findAccessibleHostGroupIds(UserId $userId): ?Collection
+    {
+        $accessibleAclResQb = $this->getAccessibleAclResourcesQueryBuilder();
+
+        // Unlike pollers, host groups carry an explicit "all host groups" flag on the ACL resource
+        // itself (acl_resources.all_hostgroups). A resource simply carrying no host-group relation
+        // row is NOT the same thing as this flag — it means that resource grants zero host groups,
+        // not every host group. Legacy (HostGroupRepositoryTrait::hasAccessToAllHostGroups()) only
+        // treats the user as unrestricted when at least one accessible resource has the flag set.
+        $allHostGroupsQb = $this->connection->createQueryBuilder();
+        $allHostGroupsQb
+            ->select('1')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources', 'res', "res.acl_res_id = accessible_res.acl_res_id AND res.all_hostgroups = '1'")
+            ->setParameter('contactId', $userId->value)
+            ->setMaxResults(1);
+
+        if ($this->connection->fetchOne($allHostGroupsQb->getSQL(), ['contactId' => $userId->value]) !== false) {
+            return null;
+        }
+
+        // No "all host groups" flag anywhere: the accessible set is the union of host-group
+        // relations across every accessible resource (legacy findAllByAccessGroupIds()). This is
+        // naturally empty — not "everything" — for a user with no accessible resource at all, or
+        // whose accessible resources carry no host-group relation.
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('DISTINCT arhr.hg_hg_id')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources_hg_relations', 'arhr', 'arhr.acl_res_id = accessible_res.acl_res_id')
+            ->setParameter('contactId', $userId->value);
+
+        /** @var list<array{hg_hg_id: numeric-string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($qb->getSQL(), ['contactId' => $userId->value]);
+
+        return new Collection(
+            array_map(static fn (array $row): HostGroupId => new HostGroupId((int) $row['hg_hg_id']), $rows),
+            HostGroupId::class,
+        );
     }
 
     private function getAccessibleAclResourcesQueryBuilder(): QueryBuilder

--- a/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroupNameTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Domain/Aggregate/HostGroup/HostGroupNameTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Domain\Aggregate\HostGroup;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupName;
+use PHPUnit\Framework\TestCase;
+
+final class HostGroupNameTest extends TestCase
+{
+    public function testItTrimsSurroundingWhitespace(): void
+    {
+        $name = new HostGroupName('  My Host Group  ');
+
+        self::assertSame('My Host Group', $name->value);
+    }
+
+    public function testItRejectsAWhitespaceOnlyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new HostGroupName('   ');
+    }
+
+    public function testItRejectsAnEmptyName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new HostGroupName('');
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/ListHostGroupsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/ListHostGroupsProviderTest.php
@@ -1,0 +1,282 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostGroup;
+
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostGroup\HostGroupResource;
+use Doctrine\DBAL\Connection;
+use Tests\App\Shared\ApiTestCase;
+use Webmozart\Assert\Assert;
+
+final class ListHostGroupsProviderTest extends ApiTestCase
+{
+    private const BASE_ENDPOINT = '/api/configuration/host_groups';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+    }
+
+    public function testItRequiresAuthentication(): void
+    {
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testItIsForbiddenForUserWithoutSufficientAcl(): void
+    {
+        $username = bin2hex(random_bytes(8));
+        $this->createApiUser($this->connection, $username, admin: false);
+        $this->login($username);
+
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testItListsHostGroupsAsAdminWithOnlyIdAndName(): void
+    {
+        $this->insertHostGroup('HostGroup-A');
+        $this->insertHostGroup('HostGroup-B');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertMatchesResourceCollectionJsonSchema(HostGroupResource::class);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'HostGroup-A'],
+                ['name' => 'HostGroup-B'],
+            ],
+        ]);
+
+        /** @var list<array<string, mixed>> $member */
+        $member = $response->toArray()['member'];
+        self::assertEqualsCanonicalizing(['@id', '@type', 'id', 'name'], array_keys($member[0]));
+    }
+
+    public function testItFiltersHostGroupsByNameUsingLikeOperator(): void
+    {
+        $this->insertHostGroup('Linux-Servers');
+        $this->insertHostGroup('Other-B');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => 'Linux']]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Linux-Servers'],
+            ],
+        ]);
+    }
+
+    public function testItPaginatesHostGroups(): void
+    {
+        $this->insertHostGroup('HostGroup-A');
+        $this->insertHostGroup('HostGroup-B');
+        $this->insertHostGroup('HostGroup-C');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['page' => '2', 'itemsPerPage' => '1']]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertEquals(3, $response->toArray()['totalItems']);
+    }
+
+    public function testItRestrictsListingToAccessibleHostGroupsForARestrictedUser(): void
+    {
+        $this->insertHostGroup('HostGroup-A');
+        $hostGroupBId = $this->insertHostGroup('HostGroup-B');
+
+        $username = bin2hex(random_bytes(8));
+        $contactId = $this->createNonAdminContact($username);
+        $this->grantHostGroupReadTopologyRole($contactId);
+        $this->restrictContactToHostGroups($contactId, [$hostGroupBId]);
+
+        $this->login($username);
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'HostGroup-B'],
+            ],
+        ]);
+    }
+
+    public function testItRejectsZeroItemsPerPage(): void
+    {
+        $this->insertHostGroup('HostGroup-A');
+
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['itemsPerPage' => '0']]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testItRejectsAScalarNameFilter(): void
+    {
+        $this->insertHostGroup('HostGroup-A');
+
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => 'HostGroup-A']]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testItIgnoresAnEmptyNameFilter(): void
+    {
+        $this->insertHostGroup('HostGroup-A');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '']]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+    }
+
+    public function testItFiltersByANameOfLiteralZero(): void
+    {
+        $this->insertHostGroup('0');
+        $this->insertHostGroup('HostGroup-A');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '0']]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => '0'],
+            ],
+        ]);
+    }
+
+    private function insertHostGroup(string $name): int
+    {
+        $this->connection->insert('hostgroup', ['hg_name' => $name]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function createNonAdminContact(string $alias): int
+    {
+        $this->createApiUser($this->connection, $alias, admin: false);
+
+        $contactId = $this->connection->fetchOne(
+            'SELECT contact_id FROM contact WHERE contact_alias = :alias',
+            ['alias' => $alias]
+        );
+        Assert::integer($contactId);
+
+        return $contactId;
+    }
+
+    /**
+     * Grants the "Configuration > Hosts > Host Groups" (read-only) topology access, the legacy menu
+     * role bridged to HostGroupPermissionEnum::CanRead via
+     * DbalCredentialTransformer::LEGACY_PERMISSION_MAP (topology_page 60102, parented by 601 "Hosts"
+     * and 6 "Configuration" — see topology fixtures in www/install/insertTopology.sql).
+     */
+    private function grantHostGroupReadTopologyRole(int $contactId): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'topology-group-' . $contactId,
+            'acl_group_alias' => 'topology-group-' . $contactId,
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_topology', [
+            'acl_topo_name' => 'topology-rule-' . $contactId,
+            'acl_topo_alias' => 'topology-rule-' . $contactId,
+            'acl_topo_activate' => '1',
+        ]);
+        $aclTopoId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_topology_relations', [
+            'acl_group_id' => $aclGroupId,
+            'acl_topology_id' => $aclTopoId,
+        ]);
+
+        foreach ([6, 601, 60102] as $topologyPage) {
+            $topologyId = $this->connection->fetchOne(
+                'SELECT topology_id FROM topology WHERE topology_page = :page',
+                ['page' => $topologyPage]
+            );
+            self::assertIsScalar($topologyId, "topology_page {$topologyPage} not found in fixtures");
+
+            $this->connection->insert('acl_topology_relations', [
+                'topology_topology_id' => (int) $topologyId,
+                'acl_topo_id' => $aclTopoId,
+                'access_right' => 2, // read-only
+            ]);
+        }
+    }
+
+    /**
+     * @param list<int> $hostGroupIds
+     */
+    private function restrictContactToHostGroups(int $contactId, array $hostGroupIds): void
+    {
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'host-group-scope-' . $contactId,
+            'acl_res_alias' => 'host-group-scope-' . $contactId,
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        /** @var int $aclGroupId */
+        $aclGroupId = $this->connection->fetchOne(
+            'SELECT acl_group_id FROM acl_group_contacts_relations WHERE contact_contact_id = :contactId',
+            ['contactId' => $contactId]
+        );
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($hostGroupIds as $hostGroupId) {
+            $this->connection->insert('acl_resources_hg_relations', [
+                'acl_res_id' => $aclResId,
+                'hg_hg_id' => $hostGroupId,
+            ]);
+        }
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostGroupRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostGroupRepositoryTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroup;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostGroupCriteria;
+use App\MonitoringConfiguration\Infrastructure\Dbal\DbalHostGroupRepository;
+use App\MonitoringConfiguration\Infrastructure\Dbal\DbalHostGroupTransformer;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Infrastructure\Dbal\DbalResourceAccessRepository;
+use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class DbalHostGroupRepositoryTest extends KernelTestCase
+{
+    private Connection $connection;
+
+    private DbalHostGroupRepository $repository;
+
+    protected function setUp(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // Constructed directly rather than fetched from the container: it keeps the ACL
+        // fixtures this test builds isolated from whatever topology/ACL state other
+        // integration tests may leave around the same connection.
+        $this->repository = new DbalHostGroupRepository(
+            $this->connection,
+            new DbalHostGroupTransformer(),
+            new DbalResourceAccessRepository($this->connection),
+        );
+    }
+
+    public function testFindAllReturnsAllHostGroups(): void
+    {
+        $this->insertHostGroup(301, 'HostGroup-A');
+        $this->insertHostGroup(302, 'HostGroup-B');
+
+        $hostGroups = iterator_to_array($this->repository->findAll());
+
+        self::assertCount(2, $hostGroups);
+        self::assertContainsOnlyInstancesOf(HostGroup::class, $hostGroups);
+    }
+
+    public function testFindAllFiltersByNameUsingLikeOperator(): void
+    {
+        $this->insertHostGroup(301, 'Linux-Servers');
+        $this->insertHostGroup(302, 'Windows-Servers');
+
+        $criteria = (new HostGroupCriteria())->withName('Linux');
+
+        $hostGroups = iterator_to_array($this->repository->findAll($criteria));
+
+        self::assertCount(1, $hostGroups);
+        self::assertSame(['Linux-Servers'], $this->extractNames($hostGroups));
+    }
+
+    public function testFindAllPaginates(): void
+    {
+        $this->insertHostGroup(301, 'HostGroup-A');
+        $this->insertHostGroup(302, 'HostGroup-B');
+        $this->insertHostGroup(303, 'HostGroup-C');
+
+        $criteria = (new HostGroupCriteria())->withPagination(page: 2, itemsPerPage: 1);
+
+        $paginator = $this->repository->findAll($criteria);
+
+        self::assertInstanceOf(InMemoryPaginator::class, $paginator);
+
+        self::assertCount(1, $paginator);
+        self::assertSame(3, $paginator->getTotalItems());
+        self::assertSame(['HostGroup-B'], $this->extractNames(iterator_to_array($paginator)));
+    }
+
+    public function testFindAllRestrictsToAccessibleHostGroupsForARestrictedViewer(): void
+    {
+        $this->insertHostGroup(301, 'HostGroup-A');
+        $this->insertHostGroup(302, 'HostGroup-B');
+
+        $contactId = $this->createContact('restricted-user');
+        $this->restrictContactToHostGroups($contactId, [302]);
+
+        $criteria = (new HostGroupCriteria())->withViewerId(new UserId($contactId));
+
+        $hostGroups = iterator_to_array($this->repository->findAll($criteria));
+
+        self::assertCount(1, $hostGroups);
+        self::assertSame(['HostGroup-B'], $this->extractNames($hostGroups));
+    }
+
+    private function insertHostGroup(int $id, string $name): void
+    {
+        $this->connection->insert('hostgroup', ['hg_id' => $id, 'hg_name' => $name]);
+    }
+
+    /**
+     * @param array<HostGroup> $hostGroups
+     *
+     * @return list<string>
+     */
+    private function extractNames(array $hostGroups): array
+    {
+        return array_values(array_map(static fn (HostGroup $hostGroup): string => $hostGroup->name->value, $hostGroups));
+    }
+
+    private function createContact(string $alias): int
+    {
+        $this->connection->insert('contact', [
+            'contact_name' => $alias,
+            'contact_alias' => $alias,
+            'contact_admin' => '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => $alias . '@email.com',
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    /**
+     * @param list<int> $hostGroupIds
+     */
+    private function restrictContactToHostGroups(int $contactId, array $hostGroupIds): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'group-' . $contactId,
+            'acl_group_alias' => 'group-' . $contactId,
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'resource-' . $contactId,
+            'acl_res_alias' => 'resource-' . $contactId,
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($hostGroupIds as $hostGroupId) {
+            $this->connection->insert('acl_resources_hg_relations', [
+                'acl_res_id' => $aclResId,
+                'hg_hg_id' => $hostGroupId,
+            ]);
+        }
+    }
+}

--- a/centreon/tests/php/App/Security/Domain/Aggregate/CredentialTest.php
+++ b/centreon/tests/php/App/Security/Domain/Aggregate/CredentialTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Security\Domain\Aggregate;
+
+use App\Security\Domain\Aggregate\Credential;
+use App\Security\Domain\Aggregate\CredentialIdentifier;
+use App\Security\Domain\Aggregate\Role;
+use App\Security\Domain\Aggregate\UserId;
+use PHPUnit\Framework\TestCase;
+
+final class CredentialTest extends TestCase
+{
+    public function testIsAdminReturnsFalseByDefault(): void
+    {
+        $credential = new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
+
+        self::assertFalse($credential->isAdmin());
+    }
+
+    public function testIsAdminReturnsTrueAfterRoleAdminIsAssigned(): void
+    {
+        $credential = new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
+        $credential->assignRole(new Role('ROLE_ADMIN'));
+
+        self::assertTrue($credential->isAdmin());
+    }
+
+    public function testIsAdminReturnsFalseForAnyOtherRole(): void
+    {
+        $credential = new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
+        $credential->assignRole(new Role('ROLE_USER'));
+
+        self::assertFalse($credential->isAdmin());
+    }
+}

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Security\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Infrastructure\Dbal\DbalResourceAccessRepository;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class DbalResourceAccessRepositoryTest extends KernelTestCase
+{
+    private Connection $connection;
+
+    // Constructed directly rather than fetched from the container: it keeps the ACL fixtures
+    // this test builds (acl_groups / acl_resources / relations) fully isolated from whatever
+    // topology/ACL state other integration tests may leave around the same connection.
+    private DbalResourceAccessRepository $repository;
+
+    protected function setUp(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->repository = new DbalResourceAccessRepository($this->connection);
+
+        $this->connection->insert('hostgroup', ['hg_id' => 201, 'hg_name' => 'HostGroup-201']);
+        $this->connection->insert('hostgroup', ['hg_id' => 202, 'hg_name' => 'HostGroup-202']);
+    }
+
+    public function testUserWithNoAclGroupHasAccessToNoHostGroups(): void
+    {
+        $userId = new UserId($this->createContact('user-no-acl'));
+
+        $accessibleHostGroupIds = $this->repository->findAccessibleHostGroupIds($userId);
+
+        self::assertNotNull($accessibleHostGroupIds);
+        self::assertCount(0, $accessibleHostGroupIds);
+    }
+
+    public function testUserWithAclResourceCarryingNoRelationAndNoAllFlagHasAccessToNoHostGroups(): void
+    {
+        // A resource that never had its host-group tab configured (no relation rows, flag unset)
+        // grants zero host groups — it must not be mistaken for the "all host groups" flag.
+        $contactId = $this->createContact('user-empty-resource');
+        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [], allHostGroups: false);
+
+        $userId = new UserId($contactId);
+
+        $accessibleHostGroupIds = $this->repository->findAccessibleHostGroupIds($userId);
+
+        self::assertNotNull($accessibleHostGroupIds);
+        self::assertCount(0, $accessibleHostGroupIds);
+    }
+
+    public function testUserWithAclResourceFlaggedAllHostGroupsHasAccessToAllHostGroups(): void
+    {
+        $contactId = $this->createContact('user-all-flag');
+        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [], allHostGroups: true);
+
+        $userId = new UserId($contactId);
+
+        self::assertNull($this->repository->findAccessibleHostGroupIds($userId));
+    }
+
+    public function testUserWithAclResourceRestrictedToASingleHostGroupSeesOnlyThatHostGroup(): void
+    {
+        $contactId = $this->createContact('user-restricted');
+        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [201], allHostGroups: false);
+
+        $userId = new UserId($contactId);
+
+        $accessibleHostGroupIds = $this->repository->findAccessibleHostGroupIds($userId);
+        self::assertNotNull($accessibleHostGroupIds);
+        self::assertEquals([201], array_map(static fn (HostGroupId $id): int => $id->value, iterator_to_array($accessibleHostGroupIds)));
+    }
+
+    /**
+     * Mirrors legacy's OR-across-resources semantics for the "all host groups" flag: a single
+     * accessible resource with the flag set grants everything, even when another accessible
+     * resource restricts to a specific host group.
+     */
+    public function testUserWithOneRestrictedAndOneAllFlagResourceHasAccessToAllHostGroups(): void
+    {
+        $contactId = $this->createContact('user-mixed-resources');
+        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [201], allHostGroups: false);
+        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [], allHostGroups: true);
+
+        $userId = new UserId($contactId);
+
+        self::assertNull($this->repository->findAccessibleHostGroupIds($userId));
+    }
+
+    private function createContact(string $alias): int
+    {
+        $this->connection->insert('contact', [
+            'contact_name' => $alias,
+            'contact_alias' => $alias,
+            'contact_admin' => '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => $alias . '@email.com',
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    /**
+     * @param list<int> $restrictToHostGroupIds host groups explicitly granted through this
+     *                                          resource's relations; irrelevant once $allHostGroups is true
+     */
+    private function linkContactToAclResource(int $contactId, array $restrictToHostGroupIds, bool $allHostGroups): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'group-' . $contactId . '-' . random_int(1, PHP_INT_MAX),
+            'acl_group_alias' => 'group-' . $contactId . '-' . random_int(1, PHP_INT_MAX),
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'resource-' . $aclGroupId,
+            'acl_res_alias' => 'resource-' . $aclGroupId,
+            'acl_res_activate' => '1',
+            'all_hostgroups' => $allHostGroups ? '1' : '0',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($restrictToHostGroupIds as $hostGroupId) {
+            $this->connection->insert('acl_resources_hg_relations', [
+                'acl_res_id' => $aclResId,
+                'hg_hg_id' => $hostGroupId,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the host groups selector: migrates the existing `src/Centreon` endpoint to `src/App` and exposes `GET /configuration/host_groups` (Hydra collection, name `LIKE` filter, pagination).

**Fixes** MON-208754

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.10.x

## How this pull request can be tested ?

- `GET /api/configuration/host_groups` returns a Hydra collection of `{id, name}`.
- Filter with `?name[lk]=<string>` and paginate with `?page=&itemsPerPage=`.
- Backend: PHPStan + App unit suite green.

## Stacked PR

Based on #11592 — merge that first.