### PR TITLE
feat(poller): migrate poller listing endpoint to the new architecture

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -5274,6 +5274,76 @@ paths:
             schema:
               $ref: '#/components/schemas/Poller.CreatePollerInput'
         required: true
+    get:
+      operationId: api_configurationpollers_get_collection
+      tags:
+        - Poller
+      responses:
+        '200':
+          description: 'Poller collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'Poller.PollerCollectionOutput.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/Poller.PollerCollectionOutput.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Poller.PollerCollectionOutput'
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {  }
+      summary: 'Retrieves the collection of Poller resources.'
+      description: 'Retrieves the collection of Poller resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by poller name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
   '/configuration/pollers/installation-command/{id}':
     get:
       operationId: api_configurationpollersinstallation-command_id_get
@@ -10235,6 +10305,24 @@ components:
               type: string
               example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
               nullable: true
+    Poller.PollerCollectionOutput:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    Poller.PollerCollectionOutput.jsonld:
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
     HostGroup.HostGroupCollectionOutput:
       type: object
       properties:

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/PollerCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/PollerCriteria.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Repository\Criteria;
+
+use App\Security\Domain\Aggregate\UserId;
+use Webmozart\Assert\Assert;
+
+final class PollerCriteria
+{
+    private ?int $page = null;
+
+    private ?int $itemsPerPage = null;
+
+    private ?string $name = null;
+
+    private bool $excludeUnknownCentral = false;
+
+    private ?UserId $viewerId = null;
+
+    public function withPagination(int $page, int $itemsPerPage): self
+    {
+        Assert::positiveInteger($page);
+        Assert::positiveInteger($itemsPerPage);
+
+        $new = clone $this;
+        $new->page = $page;
+        $new->itemsPerPage = $itemsPerPage;
+
+        return $new;
+    }
+
+    public function withName(string $name): self
+    {
+        // notEmpty() relies on empty(), which would wrongly reject a legitimate name of "0"
+        Assert::stringNotEmpty($name);
+
+        $new = clone $this;
+        $new->name = $name;
+
+        return $new;
+    }
+
+    public function withExcludeUnknownCentral(bool $exclude): self
+    {
+        $new = clone $this;
+        $new->excludeUnknownCentral = $exclude;
+
+        return $new;
+    }
+
+    /**
+     * @param UserId|null $viewerId the user to scope results for, or null when no ACL restriction applies (e.g. an admin)
+     */
+    public function withViewerId(?UserId $viewerId): self
+    {
+        $new = clone $this;
+        $new->viewerId = $viewerId;
+
+        return $new;
+    }
+
+    public function getPage(): ?int
+    {
+        return $this->page;
+    }
+
+    public function getItemsPerPage(): ?int
+    {
+        return $this->itemsPerPage;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function excludeUnknownCentral(): bool
+    {
+        return $this->excludeUnknownCentral;
+    }
+
+    public function getViewerId(): ?UserId
+    {
+        return $this->viewerId;
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/PollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/PollerRepository.php
@@ -29,6 +29,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Exception\PollerNotFoundException;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\PollerCriteria;
 use App\Shared\Domain\Collection;
 
 interface PollerRepository
@@ -43,6 +44,11 @@ interface PollerRepository
      * @return Collection<Poller>
      */
     public function findAllByGlobalMacro(GlobalMacro $globalMacro): Collection;
+
+    /**
+     * @return \IteratorAggregate<int, Poller>&\Countable
+     */
+    public function findAll(?PollerCriteria $criteria = null): \IteratorAggregate&\Countable;
 
     /**
      * @throws PollerNotFoundException

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerCollectionOutput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerCollectionOutput.php
@@ -21,11 +21,17 @@
 
 declare(strict_types=1);
 
-namespace App\MonitoringConfiguration\Domain\Security;
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller;
 
-enum PollerPermissionEnum: string
+use ApiPlatform\Metadata\ApiProperty;
+
+final class PollerCollectionOutput
 {
-    case CanCreateEdit = 'can_create_edit_poller';
-    case CanRead = 'can_read_poller';
-    case CanReadAndWrite = 'can_read_and_write_poller';
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Poller/PollerResource.php
@@ -25,11 +25,13 @@ namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model;
 use App\MonitoringConfiguration\Domain\Security\PollerPermissionEnum;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Dto\CreatePollerInput;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller\CreatePollerProcessor;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller\ListPollersProvider;
 use App\Shared\Domain\Logging\Attribute\Sensitive;
 
 #[ApiResource(
@@ -48,6 +50,26 @@ use App\Shared\Domain\Logging\Attribute\Sensitive;
             ),
             security: "is_granted('" . PollerPermissionEnum::CanCreateEdit->value . "')",
             securityMessage: 'You are not allowed to create pollers',
+        ),
+        new GetCollection(
+            uriTemplate: '/configuration/pollers',
+            provider: ListPollersProvider::class,
+            output: PollerCollectionOutput::class,
+            openapi: new Model\Operation(
+                parameters: [
+                    new Model\Parameter(
+                        name: 'name[lk]',
+                        in: 'query',
+                        description: 'Filter by poller name using "like" operator',
+                        required: false,
+                        schema: ['type' => 'string'],
+                    ),
+                ],
+            ),
+            security: '
+                is_granted("' . PollerPermissionEnum::CanRead->value . '") or
+                is_granted("' . PollerPermissionEnum::CanReadAndWrite->value . '")',
+            securityMessage: 'You are not allowed to list pollers',
         ),
     ],
 )]

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ListPollersProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ListPollersProvider.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\PollerCriteria;
+use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\PollerCollectionOutput;
+use App\Security\Infrastructure\Security\CredentialUser;
+use App\Shared\Domain\Repository\Paginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Webmozart\Assert\Assert;
+
+/**
+ * @implements ProviderInterface<PollerCollectionOutput>
+ */
+final readonly class ListPollersProvider implements ProviderInterface
+{
+    /**
+     * @param TransformerInterface<Poller, PollerCollectionOutput> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: PollerCollectionOutputTransformer::class)]
+        private TransformerInterface $transformer,
+        private PollerRepository $repository,
+        private Pagination $pagination,
+        private Security $security,
+        #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
+        private bool $isCloudPlatform = false,
+    ) {
+    }
+
+    /**
+     * @return iterable<PollerCollectionOutput>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
+    {
+        $credentialUser = $this->security->getUser();
+        Assert::isInstanceOf($credentialUser, CredentialUser::class);
+        $isAdmin = $credentialUser->credential->isAdmin();
+
+        $criteria = new PollerCriteria();
+        if ($this->pagination->isEnabled($operation, $context)) {
+            $itemsPerPage = $this->pagination->getLimit($operation, $context);
+            if ($itemsPerPage <= 0) {
+                throw new BadRequestHttpException('itemsPerPage must be a positive integer.');
+            }
+            $criteria = $criteria->withPagination($this->pagination->getPage($context), $itemsPerPage);
+        }
+
+        /** @var array{name?: mixed} $filters */
+        $filters = $context['filters'] ?? [];
+        $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
+        $criteria = $criteria->withExcludeUnknownCentral($this->isCloudPlatform && ! $isAdmin);
+        $criteria = $isAdmin ? $criteria : $criteria->withViewerId($credentialUser->credential->userId);
+
+        $pollers = $this->repository->findAll($criteria);
+        $resources = [];
+        foreach ($pollers as $poller) {
+            $resources[] = $this->transformer->transform($poller);
+        }
+
+        if (! $pollers instanceof Paginator) {
+            return $resources;
+        }
+
+        return new TraversablePaginator(
+            new \ArrayIterator($resources),
+            $pollers->getCurrentPage(),
+            $pollers->getItemsPerPage(),
+            $pollers->getTotalItems()
+        );
+    }
+
+    private function handleNameFilter(mixed $nameFilter, PollerCriteria $criteria): PollerCriteria
+    {
+        if ($nameFilter === null) {
+            return $criteria;
+        }
+
+        // a client sending "?name=foo" instead of "?name[lk]=foo" lands here as a plain string
+        if (! is_array($nameFilter)) {
+            throw new BadRequestHttpException('The "name" filter must use the "name[lk]=value" format.');
+        }
+
+        $likeValue = $nameFilter['lk'] ?? null;
+        if (is_array($likeValue)) {
+            $likeValue = reset($likeValue);
+        }
+
+        if (! is_string($likeValue) || $likeValue === '') {
+            return $criteria;
+        }
+
+        return $criteria->withName($likeValue);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/PollerCollectionOutputTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/PollerCollectionOutputTransformer.php
@@ -21,11 +21,22 @@
 
 declare(strict_types=1);
 
-namespace App\MonitoringConfiguration\Domain\Security;
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
 
-enum PollerPermissionEnum: string
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\PollerCollectionOutput;
+use App\Shared\Infrastructure\TransformerInterface;
+
+/**
+ * @implements TransformerInterface<Poller, PollerCollectionOutput>
+ */
+final readonly class PollerCollectionOutputTransformer implements TransformerInterface
 {
-    case CanCreateEdit = 'can_create_edit_poller';
-    case CanRead = 'can_read_poller';
-    case CanReadAndWrite = 'can_read_and_write_poller';
+    public function transform(mixed $from): PollerCollectionOutput
+    {
+        return new PollerCollectionOutput(
+            id: $from->id()->value,
+            name: $from->name->value,
+        );
+    }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepository.php
@@ -33,14 +33,20 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Exception\PollerAlreadyExistsException;
 use App\MonitoringConfiguration\Domain\Exception\PollerNotFoundException;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\PollerCriteria;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\MonitoringConfiguration\Infrastructure\GorgoneCommunicationTypeMapping;
+use App\Security\Domain\Repository\ResourceAccessRepository;
 use App\Shared\Domain\Collection;
 use App\Shared\Infrastructure\Dbal\DbalRepository;
+use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Webmozart\Assert\Assert;
 
 /**
  * @phpstan-import-type RowTypeAlias from DbalGlobalMacroRepository as GlobalMacroRowTypeAlias
@@ -131,6 +137,8 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
 
         #[Autowire(service: DbalGlobalMacroTransformer::class)]
         private TransformerInterface $globalMacroTransformer,
+
+        private ResourceAccessRepository $resourceAccessRepository,
 
         private bool $withCmaCertificates = false,
     ) {
@@ -327,6 +335,42 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
         return $this->createPollers($pollerRows, $globalMacroRows);
     }
 
+    public function findAll(?PollerCriteria $criteria = null): \IteratorAggregate&\Countable
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select(...self::getSelectColumns())
+            // a correlated subquery, not a JOIN: platform_topology.server_id carries no UNIQUE
+            // constraint, and a JOIN fan-out here would corrupt LIMIT/OFFSET-based pagination
+            ->addSelect('(SELECT pt.central_address FROM platform_topology pt WHERE pt.server_id = p.id LIMIT 1) AS central_address')
+            ->from(self::TABLE_NAME, 'p')
+            ->orderBy('p.id'); // required for deterministic pagination
+
+        if ($criteria instanceof PollerCriteria) {
+            $this->filterByPollerCriteria($qb, $criteria);
+        }
+
+        if ($criteria?->getPage() === null || $criteria->getItemsPerPage() === null) {
+            /** @var array<RowTypeAlias> $rows */
+            $rows = $qb->executeQuery()->fetchAllAssociative();
+
+            return $this->createPollers($rows);
+        }
+
+        $this->paginatePollers($qb, $criteria);
+
+        $count = $this->countPollersOnQueryBuilder($qb); // counts a clone, so this order has no effect on either result
+
+        /** @var array<RowTypeAlias> $rows */
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        return new InMemoryPaginator(
+            items: $this->createPollers($rows),
+            totalItems: $count,
+            currentPage: $criteria->getPage() ?? throw new \LogicException('Unexpected null page'),
+            itemsPerPage: $criteria->getItemsPerPage() ?? throw new \LogicException('Unexpected null items per page'),
+        );
+    }
+
     public function get(PollerId $pollerId): Poller
     {
         $qb = $this->connection->createQueryBuilder();
@@ -362,6 +406,7 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
             realTimeConnection: $this->realTimeConnection,
             pollerTransformer: $this->pollerTransformer,
             globalMacroTransformer: $this->globalMacroTransformer,
+            resourceAccessRepository: $this->resourceAccessRepository,
             withCmaCertificates: true,
         );
     }
@@ -401,6 +446,65 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
         ];
     }
 
+    private function filterByPollerCriteria(QueryBuilder $qb, PollerCriteria $criteria): void
+    {
+        if (($name = $criteria->getName()) !== null) {
+            $qb->andWhere($qb->expr()->like('p.name', $qb->createNamedParameter('%' . $name . '%')));
+        }
+
+        if ($criteria->excludeUnknownCentral()) {
+            // a central not registered as a remote server's address is excluded, matching legacy's
+            // "isLocalhost() && address not in remoteServersIps" rule, expressed here in SQL to keep
+            // pagination correct. EXISTS rather than a JOIN: remote_servers.ip carries no UNIQUE
+            // constraint, and a JOIN fan-out here would corrupt LIMIT/OFFSET-based pagination.
+            $qb->andWhere($qb->expr()->or(
+                $qb->expr()->neq('p.localhost', $qb->createNamedParameter('1')),
+                'EXISTS (SELECT 1 FROM remote_servers rs WHERE rs.ip = p.ns_ip_address)',
+            ));
+        }
+
+        if (($viewerId = $criteria->getViewerId()) instanceof \App\Security\Domain\Aggregate\UserId) {
+            $accessiblePollerIds = $this->resourceAccessRepository->findAccessiblePollerIds($viewerId);
+            if ($accessiblePollerIds instanceof Collection) {
+                $ids = [];
+                foreach ($accessiblePollerIds as $pollerId) {
+                    $ids[] = $pollerId->value;
+                }
+
+                $qb->andWhere($qb->expr()->in(
+                    'p.id',
+                    $qb->createNamedParameter($ids, ArrayParameterType::INTEGER)
+                ));
+            }
+        }
+    }
+
+    private function paginatePollers(QueryBuilder $qb, PollerCriteria $criteria): void
+    {
+        if ($criteria->getPage() === null || $criteria->getItemsPerPage() === null) {
+            return;
+        }
+
+        $qb->setFirstResult(($criteria->getPage() - 1) * $criteria->getItemsPerPage())
+            ->setMaxResults($criteria->getItemsPerPage());
+    }
+
+    private function countPollersOnQueryBuilder(QueryBuilder $qb): int
+    {
+        $qb = clone $qb; // avoid modifying the initial query builder
+
+        $count = $qb
+            ->select('COUNT(DISTINCT p.id)')
+            ->setFirstResult(0) // reset any pagination
+            ->setMaxResults(null)
+            ->executeQuery()
+            ->fetchOne();
+
+        Assert::integer($count);
+
+        return $count;
+    }
+
     private function loadCmaCertificates(Poller $poller): void
     {
         $qb = $this->realTimeConnection->createQueryBuilder();
@@ -428,8 +532,8 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
      */
     private function createPollers(array $rows, ?array $globalMacroRowsByPollerId = null): Collection
     {
-        // fetch all global macros of given pollers
-        if ($globalMacroRowsByPollerId !== null && $rows !== []) {
+        // fetch all global macros of given pollers in a single batch, unless the caller already provided them
+        if ($globalMacroRowsByPollerId === null && $rows !== []) {
             $globalMacroQb = $this->connection->createQueryBuilder();
             $globalMacroQb->select('p.id AS poller_id', ...DbalGlobalMacroRepository::getSelectColumns())
                 ->from(self::TABLE_NAME, 'p')
@@ -447,7 +551,7 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
              */
             $globalMacroRowsByPollerId = [];
             foreach ($globalMacroRows as $globalMacrosRow) {
-                $globalMacroRowsByPollerId['poller_id'][] = $globalMacrosRow;
+                $globalMacroRowsByPollerId[$globalMacrosRow['poller_id']][] = $globalMacrosRow;
             }
         }
 
@@ -456,7 +560,7 @@ final readonly class DbalPollerRepository extends DbalRepository implements Poll
             $pollerId = $row['poller_id'];
             $pollers[$pollerId] ??= $this->createPoller(
                 $row,
-                $globalMacroRowsByPollerId[$pollerId] ?? null,
+                $globalMacroRowsByPollerId[$pollerId] ?? [],
             );
         }
 

--- a/centreon/src/App/Security/Domain/Repository/ResourceAccessRepository.php
+++ b/centreon/src/App/Security/Domain/Repository/ResourceAccessRepository.php
@@ -35,6 +35,12 @@ interface ResourceAccessRepository
     public function hasAccessToPoller(PollerId $pollerId, UserId $userId): bool;
 
     /**
+     * @return Collection<PollerId>|null null means no restriction applies (the user can access
+     *                                   all pollers); an empty Collection means the user can access none
+     */
+    public function findAccessiblePollerIds(UserId $userId): ?Collection;
+
+    /**
      * @return Collection<HostGroupId>|null null means no restriction applies (the user can access
      *                                      all host groups); an empty Collection means the user can access none
      */

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
@@ -54,6 +54,8 @@ final readonly class DbalCredentialTransformer implements TransformerInterface
         'ROLE_CONFIGURATION_COMMANDS_CONNECTORS_R' => ConnectorPermissionEnum::CanRead->value,
         'ROLE_CONFIGURATION_COMMANDS_CONNECTORS_RW' => ConnectorPermissionEnum::CanReadAndWrite->value,
         'ROLE_CONFIGURATION_POLLERS_AGENT_CONFIGURATIONS_RW' => AgentConfigurationPermissionEnum::CanReadAndWrite->value,
+        'ROLE_CONFIGURATION_POLLERS_POLLERS_R' => PollerPermissionEnum::CanRead->value,
+        'ROLE_CONFIGURATION_POLLERS_POLLERS_RW' => PollerPermissionEnum::CanReadAndWrite->value,
         'ROLE_CONFIGURATION_HOSTS_HOST_GROUPS_R' => HostGroupPermissionEnum::CanRead->value,
         'ROLE_CONFIGURATION_HOSTS_HOST_GROUPS_RW' => HostGroupPermissionEnum::CanReadAndWrite->value,
     ];

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
@@ -53,29 +53,32 @@ final readonly class DbalResourceAccessRepository implements ResourceAccessRepos
         $qb
             ->select('1')
             ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
-            ->leftJoin('accessible_res', 'acl_resources_poller_relations', 'arpr', 'arpr.acl_res_id = accessible_res.acl_res_id')
-            ->where('arpr.acl_res_id IS NULL')
+            ->innerJoin('accessible_res', 'acl_resources_poller_relations', 'arpr', 'arpr.acl_res_id = accessible_res.acl_res_id')
             ->setParameter('contactId', $userId->value)
             ->setMaxResults(1);
 
-        return (bool) $this->connection->fetchOne($qb->getSQL(), ['contactId' => $userId->value]);
+        // Legacy (centreonACL::setPollers()) unions the poller relations across every accessible
+        // resource and only falls back to "all pollers" when that union is entirely empty — not
+        // as soon as a single resource happens to carry no relation. A user holding one resource
+        // restricted to a poller and another resource with no poller relation at all must still
+        // see only the restricted poller, not everything.
+        return ! (bool) $this->connection->fetchOne($qb->getSQL(), ['contactId' => $userId->value]);
     }
 
     public function hasAccessToPoller(PollerId $pollerId, UserId $userId): bool
     {
+        if ($this->hasAccessToAllPollers($userId)) {
+            return true;
+        }
+
         $accessibleAclResQb = $this->getAccessibleAclResourcesQueryBuilder();
 
         $qb = $this->connection->createQueryBuilder();
         $qb
             ->select('1')
             ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
-            ->leftJoin('accessible_res', 'acl_resources_poller_relations', 'arpr', 'arpr.acl_res_id = accessible_res.acl_res_id')
-            ->where(
-                $qb->expr()->or(
-                    'arpr.acl_res_id IS NULL',
-                    'arpr.poller_id = :pollerId'
-                )
-            )
+            ->innerJoin('accessible_res', 'acl_resources_poller_relations', 'arpr', 'arpr.acl_res_id = accessible_res.acl_res_id')
+            ->where('arpr.poller_id = :pollerId')
             ->setParameter('contactId', $userId->value)
             ->setParameter('pollerId', $pollerId->value)
             ->setMaxResults(1);
@@ -84,6 +87,30 @@ final readonly class DbalResourceAccessRepository implements ResourceAccessRepos
             'contactId' => $userId->value,
             'pollerId' => $pollerId->value,
         ]);
+    }
+
+    public function findAccessiblePollerIds(UserId $userId): ?Collection
+    {
+        if ($this->hasAccessToAllPollers($userId)) {
+            return null;
+        }
+
+        $accessibleAclResQb = $this->getAccessibleAclResourcesQueryBuilder();
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('DISTINCT arpr.poller_id')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources_poller_relations', 'arpr', 'arpr.acl_res_id = accessible_res.acl_res_id')
+            ->setParameter('contactId', $userId->value);
+
+        /** @var list<array{poller_id: numeric-string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($qb->getSQL(), ['contactId' => $userId->value]);
+
+        return new Collection(
+            array_map(static fn (array $row): PollerId => new PollerId((int) $row['poller_id']), $rows),
+            PollerId::class,
+        );
     }
 
     public function findAccessibleHostGroupIds(UserId $userId): ?Collection

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ListPollersProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ListPollersProviderTest.php
@@ -1,0 +1,405 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller;
+
+use ApiPlatform\State\Pagination\Pagination;
+use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Poller\PollerResource;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller\ListPollersProvider;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Poller\PollerCollectionOutputTransformer;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\SecurityBundle\Security;
+use Tests\App\Shared\ApiTestCase;
+use Webmozart\Assert\Assert;
+
+final class ListPollersProviderTest extends ApiTestCase
+{
+    private const BASE_ENDPOINT = '/api/configuration/pollers';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+    }
+
+    public function testItRequiresAuthentication(): void
+    {
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testItIsForbiddenForUserWithoutSufficientAcl(): void
+    {
+        $username = bin2hex(random_bytes(8));
+        $this->createApiUser($this->connection, $username, admin: false);
+        $this->login($username);
+
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testItListsPollersAsAdminWithOnlyIdAndName(): void
+    {
+        $this->insertPoller('Poller-A');
+        $this->insertPoller('Poller-B');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertMatchesResourceCollectionJsonSchema(PollerResource::class);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Poller-A'],
+                ['name' => 'Poller-B'],
+            ],
+        ]);
+
+        /** @var list<array<string, mixed>> $member */
+        $member = $response->toArray()['member'];
+        self::assertEqualsCanonicalizing(['@id', '@type', 'id', 'name'], array_keys($member[0]));
+    }
+
+    public function testItFiltersPollersByNameUsingLikeOperator(): void
+    {
+        $this->insertPoller('Poller-A');
+        $this->insertPoller('Other-B');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => 'Poller']]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Poller-A'],
+            ],
+        ]);
+    }
+
+    public function testItPaginatesPollers(): void
+    {
+        $this->insertPoller('Poller-A');
+        $this->insertPoller('Poller-B');
+        $this->insertPoller('Poller-C');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['page' => '2', 'itemsPerPage' => '1']]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertEquals(3, $response->toArray()['totalItems']);
+    }
+
+    public function testItRestrictsListingToAccessiblePollersForARestrictedUser(): void
+    {
+        $this->insertPoller('Poller-A');
+        $pollerBId = $this->insertPoller('Poller-B');
+
+        $username = bin2hex(random_bytes(8));
+        $contactId = $this->createNonAdminContact($username);
+        $this->grantPollerReadTopologyRole($contactId);
+        $this->restrictContactToPollers($contactId, [$pollerBId]);
+
+        $this->login($username);
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Poller-B'],
+            ],
+        ]);
+    }
+
+    public function testItExcludesCentralForNonAdminOnCloudPlatform(): void
+    {
+        $this->insertPoller('Central', isCentral: true);
+        $this->insertPoller('Poller-A');
+
+        $username = bin2hex(random_bytes(8));
+        $contactId = $this->createNonAdminContact($username);
+        $this->grantPollerReadTopologyRole($contactId);
+        $this->forceCloudPlatform();
+
+        $this->login($username);
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Poller-A'],
+            ],
+        ]);
+    }
+
+    public function testItIncludesCentralForAdminOnCloudPlatform(): void
+    {
+        $this->insertPoller('Central', isCentral: true);
+        $this->insertPoller('Poller-A');
+
+        $this->forceCloudPlatform();
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertCount(2, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Central'],
+                ['name' => 'Poller-A'],
+            ],
+        ]);
+    }
+
+    public function testItIncludesCentralForNonAdminOnPremPlatform(): void
+    {
+        $this->insertPoller('Central', isCentral: true);
+        $this->insertPoller('Poller-A');
+
+        $username = bin2hex(random_bytes(8));
+        $contactId = $this->createNonAdminContact($username);
+        $this->grantPollerReadTopologyRole($contactId);
+        $this->forceOnPremPlatform();
+
+        $this->login($username);
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        self::assertCount(2, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => 'Central'],
+                ['name' => 'Poller-A'],
+            ],
+        ]);
+    }
+
+    public function testItRejectsZeroItemsPerPage(): void
+    {
+        $this->insertPoller('Poller-A');
+
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['itemsPerPage' => '0']]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testItRejectsAScalarNameFilter(): void
+    {
+        $this->insertPoller('Poller-A');
+
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => 'Poller-A']]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testItIgnoresAnEmptyNameFilter(): void
+    {
+        $this->insertPoller('Poller-A');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '']]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+    }
+
+    public function testItFiltersByANameOfLiteralZero(): void
+    {
+        $this->insertPoller('0');
+        $this->insertPoller('Poller-A');
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '0']]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => '0'],
+            ],
+        ]);
+    }
+
+    private function insertPoller(string $name, bool $isCentral = false): int
+    {
+        $this->connection->insert('nagios_server', [
+            'name' => $name,
+            'localhost' => $isCentral ? '1' : '0',
+            'ns_activate' => '1',
+            'ns_ip_address' => '10.0.1.' . random_int(1, 254),
+            'uid' => random_int(300000000000000, 399999999999999),
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function createNonAdminContact(string $alias): int
+    {
+        $this->createApiUser($this->connection, $alias, admin: false);
+
+        $contactId = $this->connection->fetchOne(
+            'SELECT contact_id FROM contact WHERE contact_alias = :alias',
+            ['alias' => $alias]
+        );
+        Assert::integer($contactId);
+
+        return $contactId;
+    }
+
+    /**
+     * Grants the "Configuration > Pollers > Pollers" (read-only) topology access, the legacy menu
+     * role bridged to PollerPermissionEnum::CanRead via DbalCredentialTransformer::LEGACY_PERMISSION_MAP
+     * (topology_page 60901, parented by 609 "Pollers" and 6 "Configuration" — see topology fixtures
+     * in www/install/insertTopology.sql).
+     */
+    private function grantPollerReadTopologyRole(int $contactId): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'topology-group-' . $contactId,
+            'acl_group_alias' => 'topology-group-' . $contactId,
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_topology', [
+            'acl_topo_name' => 'topology-rule-' . $contactId,
+            'acl_topo_alias' => 'topology-rule-' . $contactId,
+            'acl_topo_activate' => '1',
+        ]);
+        $aclTopoId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_topology_relations', [
+            'acl_group_id' => $aclGroupId,
+            'acl_topology_id' => $aclTopoId,
+        ]);
+
+        foreach ([6, 609, 60901] as $topologyPage) {
+            $topologyId = $this->connection->fetchOne(
+                'SELECT topology_id FROM topology WHERE topology_page = :page',
+                ['page' => $topologyPage]
+            );
+            self::assertIsScalar($topologyId, "topology_page {$topologyPage} not found in fixtures");
+
+            $this->connection->insert('acl_topology_relations', [
+                'topology_topology_id' => (int) $topologyId,
+                'acl_topo_id' => $aclTopoId,
+                'access_right' => 2, // read-only
+            ]);
+        }
+    }
+
+    /**
+     * @param list<int> $pollerIds
+     */
+    private function restrictContactToPollers(int $contactId, array $pollerIds): void
+    {
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'poller-scope-' . $contactId,
+            'acl_res_alias' => 'poller-scope-' . $contactId,
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        /** @var int $aclGroupId */
+        $aclGroupId = $this->connection->fetchOne(
+            'SELECT acl_group_id FROM acl_group_contacts_relations WHERE contact_contact_id = :contactId',
+            ['contactId' => $contactId]
+        );
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($pollerIds as $pollerId) {
+            $this->connection->insert('acl_resources_poller_relations', [
+                'acl_res_id' => $aclResId,
+                'poller_id' => $pollerId,
+            ]);
+        }
+    }
+
+    /**
+     * `isCloudPlatform` is a constructor argument autowired from the IS_CLOUD_PLATFORM env var, so the
+     * platform is forced by replacing the Provider itself — same technique as
+     * PollerCreatedBrokerConfigurationTest::forceCloudPlatform(). Must run before the request is made.
+     */
+    private function forceCloudPlatform(): void
+    {
+        $container = self::getContainer();
+
+        /** @var PollerCollectionOutputTransformer $transformer */
+        $transformer = $container->get(PollerCollectionOutputTransformer::class);
+        /** @var PollerRepository $repository */
+        $repository = $container->get(PollerRepository::class);
+        /** @var Pagination $pagination */
+        $pagination = $container->get(Pagination::class);
+        /** @var Security $security */
+        $security = $container->get(Security::class);
+
+        $container->set(
+            ListPollersProvider::class,
+            new ListPollersProvider($transformer, $repository, $pagination, $security, true),
+        );
+    }
+
+    /**
+     * Pins the on-premises platform explicitly rather than relying on the ambient
+     * IS_CLOUD_PLATFORM default: an external test environment could set it to true, which would
+     * silently turn this into a duplicate of testItExcludesCentralForNonAdminOnCloudPlatform.
+     */
+    private function forceOnPremPlatform(): void
+    {
+        $container = self::getContainer();
+
+        /** @var PollerCollectionOutputTransformer $transformer */
+        $transformer = $container->get(PollerCollectionOutputTransformer::class);
+        /** @var PollerRepository $repository */
+        $repository = $container->get(PollerRepository::class);
+        /** @var Pagination $pagination */
+        $pagination = $container->get(Pagination::class);
+        /** @var Security $security */
+        $security = $container->get(Security::class);
+
+        $container->set(
+            ListPollersProvider::class,
+            new ListPollersProvider($transformer, $repository, $pagination, $security, false),
+        );
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalPollerRepositoryTest.php
@@ -40,8 +40,11 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerTypeEnum;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerUid;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\TrapConfiguration;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\PollerCriteria;
 use App\MonitoringConfiguration\Infrastructure\Dbal\DbalPollerRepository;
+use App\Security\Domain\Aggregate\UserId;
 use App\Shared\Domain\Collection;
+use App\Shared\Domain\Repository\Paginator;
 use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -134,5 +137,183 @@ final class DbalPollerRepositoryTest extends KernelTestCase
             )
         );
         self::assertCount(1, $pollers);
+
+        /** @var Poller $poller */
+        $poller = $pollers->toArray()[0];
+        self::assertCount(
+            2,
+            $poller->globalMacros,
+            'Poller #1 is linked to both $USER1$ and $CENTREONPLUGINS$ global macros, batched hydration must attach them by their own poller id, not lose them.'
+        );
+        $globalMacroNames = array_map(
+            static fn (GlobalMacro $globalMacro): string => $globalMacro->name->value,
+            $poller->globalMacros->toArray()
+        );
+        self::assertEqualsCanonicalizing(['$USER1$', '$CENTREONPLUGINS$'], $globalMacroNames);
+    }
+
+    public function testFindAllReturnsAllPollersWhenNoCriteria(): void
+    {
+        $this->insertPoller(2, 'Poller-A');
+        $this->insertPoller(3, 'Poller-B');
+
+        $pollers = $this->repository->findAll();
+
+        self::assertCount(3, $pollers);
+    }
+
+    public function testFindAllFiltersByNameUsingLike(): void
+    {
+        $this->insertPoller(2, 'Poller-A');
+        $this->insertPoller(3, 'Poller-B');
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withName('Poller-'));
+
+        self::assertCount(2, $pollers);
+        self::assertEqualsCanonicalizing(
+            ['Poller-A', 'Poller-B'],
+            array_map(static fn (Poller $poller): string => $poller->name->value, iterator_to_array($pollers))
+        );
+    }
+
+    public function testFindAllPaginatesAndReturnsATotalAcrossAllPages(): void
+    {
+        $this->insertPoller(2, 'Poller-A');
+        $this->insertPoller(3, 'Poller-B');
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withPagination(1, 2));
+
+        self::assertInstanceOf(Paginator::class, $pollers);
+        self::assertCount(2, $pollers);
+        self::assertSame(3, $pollers->getTotalItems());
+    }
+
+    public function testFindAllExcludesCentralNotRegisteredAsARemoteServer(): void
+    {
+        $this->insertPoller(2, 'Poller-A', isCentral: false);
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withExcludeUnknownCentral(true));
+
+        self::assertCount(1, $pollers);
+        self::assertSame('Poller-A', iterator_to_array($pollers)[0]->name->value);
+    }
+
+    public function testFindAllKeepsCentralWhenItsAddressIsARegisteredRemoteServer(): void
+    {
+        $this->insertPoller(2, 'Poller-A', isCentral: false);
+        $this->connection->insert('remote_servers', [
+            'ip' => '127.0.0.1', // matches the Central poller's ns_ip_address from setUp
+            'version' => '24.10',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'server_id' => 2,
+        ]);
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withExcludeUnknownCentral(true));
+
+        self::assertCount(2, $pollers);
+    }
+
+    public function testFindAllIsNotAffectedByDuplicatePlatformTopologyRows(): void
+    {
+        // platform_topology.server_id carries no UNIQUE constraint; a poller with more than one
+        // row there must not be counted or returned more than once, nor corrupt pagination.
+        $this->insertPoller(2, 'Poller-A');
+        $this->insertPoller(3, 'Poller-B');
+        $this->connection->insert('platform_topology', ['address' => '10.0.0.2', 'name' => 'Poller-A', 'type' => 'poller', 'server_id' => 2, 'pending' => '0']);
+        $this->connection->insert('platform_topology', ['address' => '10.0.0.2', 'name' => 'Poller-A-dup', 'type' => 'poller', 'server_id' => 2, 'pending' => '0']);
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withPagination(1, 10));
+
+        self::assertInstanceOf(Paginator::class, $pollers);
+        self::assertCount(3, $pollers); // setUp()'s Central + Poller-A + Poller-B, each counted once
+        self::assertSame(3, $pollers->getTotalItems());
+    }
+
+    public function testFindAllIsNotAffectedByDuplicateRemoteServerIps(): void
+    {
+        // remote_servers.ip carries no UNIQUE constraint either; the exclude-unknown-central EXISTS
+        // check must not fan out the result set when more than one row shares the same ip.
+        $this->insertPoller(2, 'Poller-A', isCentral: false);
+        $this->connection->insert('remote_servers', ['ip' => '127.0.0.1', 'version' => '24.10', 'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'), 'server_id' => 2]);
+        $this->connection->insert('remote_servers', ['ip' => '127.0.0.1', 'version' => '24.10', 'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'), 'server_id' => 2]);
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withExcludeUnknownCentral(true)->withPagination(1, 10));
+
+        self::assertInstanceOf(Paginator::class, $pollers);
+        self::assertCount(2, $pollers); // Central (kept: its address matches a remote server) + Poller-A
+        self::assertSame(2, $pollers->getTotalItems());
+    }
+
+    public function testFindAllRestrictsToAccessiblePollersForARestrictedViewer(): void
+    {
+        $this->insertPoller(2, 'Poller-A');
+        $this->insertPoller(3, 'Poller-B');
+        $viewerId = new UserId($this->createRestrictedContact(accessiblePollerIds: [2]));
+
+        $pollers = $this->repository->findAll((new PollerCriteria())->withViewerId($viewerId));
+
+        self::assertCount(1, $pollers);
+        self::assertSame('Poller-A', iterator_to_array($pollers)[0]->name->value);
+    }
+
+    private function insertPoller(int $id, string $name, bool $isCentral = false): void
+    {
+        $this->connection->insert('nagios_server', [
+            'id' => $id,
+            'name' => $name,
+            'localhost' => $isCentral ? '1' : '0',
+            'ns_activate' => '1',
+            'ns_ip_address' => "10.0.0.{$id}",
+            'uid' => 200000000000000 + $id,
+        ]);
+    }
+
+    /**
+     * @param list<int> $accessiblePollerIds
+     */
+    private function createRestrictedContact(array $accessiblePollerIds): int
+    {
+        $this->connection->insert('contact', [
+            'contact_name' => 'restricted-viewer',
+            'contact_alias' => 'restricted-viewer',
+            'contact_admin' => '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => 'restricted-viewer@email.com',
+        ]);
+        $contactId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'restricted-group',
+            'acl_group_alias' => 'restricted-group',
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'restricted-resource',
+            'acl_res_alias' => 'restricted-resource',
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($accessiblePollerIds as $pollerId) {
+            $this->connection->insert('acl_resources_poller_relations', [
+                'acl_res_id' => $aclResId,
+                'poller_id' => $pollerId,
+            ]);
+        }
+
+        return $contactId;
     }
 }

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Double/FakePollerRepository.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Double/FakePollerRepository.php
@@ -29,6 +29,7 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerAddress;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerName;
 use App\MonitoringConfiguration\Domain\Exception\PollerNotFoundException;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\PollerCriteria;
 use App\MonitoringConfiguration\Domain\Repository\PollerRepository;
 use App\Shared\Domain\Aggregate\AggregateRoot;
 use App\Shared\Domain\Collection;
@@ -76,6 +77,33 @@ final class FakePollerRepository implements PollerRepository
     public function findAllByGlobalMacro(GlobalMacro $globalMacro): Collection
     {
         return new Collection([], Poller::class);
+    }
+
+    /**
+     * Note: viewer-based ACL scoping is not modeled here (it has no equivalent data in this fake) —
+     * it is exercised by DbalPollerRepositoryTest against real ACL tables instead.
+     */
+    public function findAll(?PollerCriteria $criteria = null): \IteratorAggregate&\Countable
+    {
+        $pollers = array_values($this->pollers);
+
+        if ($criteria instanceof PollerCriteria && $criteria->getName() !== null) {
+            $needle = mb_strtolower($criteria->getName());
+            $pollers = array_values(array_filter(
+                $pollers,
+                static fn (Poller $poller): bool => str_contains(mb_strtolower($poller->name->value), $needle)
+            ));
+        }
+
+        if ($criteria instanceof PollerCriteria && $criteria->excludeUnknownCentral()) {
+            $pollers = array_values(array_filter($pollers, static fn (Poller $poller): bool => ! $poller->isCentral));
+        }
+
+        if ($criteria instanceof PollerCriteria && $criteria->getPage() !== null && $criteria->getItemsPerPage() !== null) {
+            $pollers = array_slice($pollers, ($criteria->getPage() - 1) * $criteria->getItemsPerPage(), $criteria->getItemsPerPage());
+        }
+
+        return new Collection($pollers, Poller::class);
     }
 
     public function get(PollerId $pollerId): Poller

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Tests\App\Security\Infrastructure\Dbal;
 
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
+use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\Security\Domain\Aggregate\UserId;
 use App\Security\Infrastructure\Dbal\DbalResourceAccessRepository;
 use Doctrine\DBAL\Connection;
@@ -46,8 +47,71 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
 
         $this->repository = new DbalResourceAccessRepository($this->connection);
 
+        $this->connection->insert('nagios_server', ['id' => 101, 'name' => 'Poller-101', 'localhost' => '0', 'ns_activate' => '1', 'ns_ip_address' => '10.0.0.101', 'uid' => 200000000000101]);
+        $this->connection->insert('nagios_server', ['id' => 102, 'name' => 'Poller-102', 'localhost' => '0', 'ns_activate' => '1', 'ns_ip_address' => '10.0.0.102', 'uid' => 200000000000102]);
         $this->connection->insert('hostgroup', ['hg_id' => 201, 'hg_name' => 'HostGroup-201']);
         $this->connection->insert('hostgroup', ['hg_id' => 202, 'hg_name' => 'HostGroup-202']);
+    }
+
+    public function testUserWithNoAclGroupHasAccessToAllPollers(): void
+    {
+        $userId = new UserId($this->createContact('user-no-acl'));
+
+        self::assertTrue($this->repository->hasAccessToAllPollers($userId));
+        self::assertTrue($this->repository->hasAccessToPoller(new PollerId(101), $userId));
+        self::assertNull($this->repository->findAccessiblePollerIds($userId));
+    }
+
+    public function testUserWithAclResourceHavingNoPollerRestrictionHasAccessToAllPollers(): void
+    {
+        $contactId = $this->createContact('user-unrestricted');
+        $this->linkContactToAclResourceForPollers($contactId, restrictToPollerIds: []);
+
+        $userId = new UserId($contactId);
+
+        self::assertTrue($this->repository->hasAccessToAllPollers($userId));
+        self::assertTrue($this->repository->hasAccessToPoller(new PollerId(102), $userId));
+        self::assertNull($this->repository->findAccessiblePollerIds($userId));
+    }
+
+    public function testUserWithAclResourceRestrictedToASinglePollerSeesOnlyThatPoller(): void
+    {
+        $contactId = $this->createContact('user-restricted');
+        $this->linkContactToAclResourceForPollers($contactId, restrictToPollerIds: [101]);
+
+        $userId = new UserId($contactId);
+
+        self::assertFalse($this->repository->hasAccessToAllPollers($userId));
+        self::assertTrue($this->repository->hasAccessToPoller(new PollerId(101), $userId));
+        self::assertFalse($this->repository->hasAccessToPoller(new PollerId(102), $userId));
+
+        $accessiblePollerIds = $this->repository->findAccessiblePollerIds($userId);
+        self::assertNotNull($accessiblePollerIds);
+        self::assertEquals([101], array_map(static fn (PollerId $id): int => $id->value, iterator_to_array($accessiblePollerIds)));
+    }
+
+    /**
+     * Mirrors centreonACL::setPollers(): the accessible poller set is the union of poller
+     * relations across every accessible ACL resource. A resource that carries no poller
+     * relation contributes nothing to that union and must not, on its own, grant access to
+     * every poller — only an empty union (no accessible resource restricts pollers at all)
+     * does.
+     */
+    public function testUserWithOneRestrictedAndOneUnrestrictedResourceSeesOnlyTheRestrictedPoller(): void
+    {
+        $contactId = $this->createContact('user-mixed-resources');
+        $this->linkContactToAclResourceForPollers($contactId, restrictToPollerIds: [101]);
+        $this->linkContactToAclResourceForPollers($contactId, restrictToPollerIds: []);
+
+        $userId = new UserId($contactId);
+
+        self::assertFalse($this->repository->hasAccessToAllPollers($userId));
+        self::assertTrue($this->repository->hasAccessToPoller(new PollerId(101), $userId));
+        self::assertFalse($this->repository->hasAccessToPoller(new PollerId(102), $userId));
+
+        $accessiblePollerIds = $this->repository->findAccessiblePollerIds($userId);
+        self::assertNotNull($accessiblePollerIds);
+        self::assertEquals([101], array_map(static fn (PollerId $id): int => $id->value, iterator_to_array($accessiblePollerIds)));
     }
 
     public function testUserWithNoAclGroupHasAccessToNoHostGroups(): void
@@ -65,7 +129,7 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
         // A resource that never had its host-group tab configured (no relation rows, flag unset)
         // grants zero host groups — it must not be mistaken for the "all host groups" flag.
         $contactId = $this->createContact('user-empty-resource');
-        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [], allHostGroups: false);
+        $this->linkContactToAclResourceForHostGroups($contactId, restrictToHostGroupIds: [], allHostGroups: false);
 
         $userId = new UserId($contactId);
 
@@ -78,7 +142,7 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
     public function testUserWithAclResourceFlaggedAllHostGroupsHasAccessToAllHostGroups(): void
     {
         $contactId = $this->createContact('user-all-flag');
-        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [], allHostGroups: true);
+        $this->linkContactToAclResourceForHostGroups($contactId, restrictToHostGroupIds: [], allHostGroups: true);
 
         $userId = new UserId($contactId);
 
@@ -88,7 +152,7 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
     public function testUserWithAclResourceRestrictedToASingleHostGroupSeesOnlyThatHostGroup(): void
     {
         $contactId = $this->createContact('user-restricted');
-        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [201], allHostGroups: false);
+        $this->linkContactToAclResourceForHostGroups($contactId, restrictToHostGroupIds: [201], allHostGroups: false);
 
         $userId = new UserId($contactId);
 
@@ -105,8 +169,8 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
     public function testUserWithOneRestrictedAndOneAllFlagResourceHasAccessToAllHostGroups(): void
     {
         $contactId = $this->createContact('user-mixed-resources');
-        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [201], allHostGroups: false);
-        $this->linkContactToAclResource($contactId, restrictToHostGroupIds: [], allHostGroups: true);
+        $this->linkContactToAclResourceForHostGroups($contactId, restrictToHostGroupIds: [201], allHostGroups: false);
+        $this->linkContactToAclResourceForHostGroups($contactId, restrictToHostGroupIds: [], allHostGroups: true);
 
         $userId = new UserId($contactId);
 
@@ -128,10 +192,47 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
     }
 
     /**
+     * @param list<int> $restrictToPollerIds empty means the ACL resource carries no poller restriction at all
+     */
+    private function linkContactToAclResourceForPollers(int $contactId, array $restrictToPollerIds): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'group-' . $contactId,
+            'acl_group_alias' => 'group-' . $contactId,
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'resource-' . $contactId,
+            'acl_res_alias' => 'resource-' . $contactId,
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($restrictToPollerIds as $pollerId) {
+            $this->connection->insert('acl_resources_poller_relations', [
+                'acl_res_id' => $aclResId,
+                'poller_id' => $pollerId,
+            ]);
+        }
+    }
+
+    /**
      * @param list<int> $restrictToHostGroupIds host groups explicitly granted through this
      *                                          resource's relations; irrelevant once $allHostGroups is true
      */
-    private function linkContactToAclResource(int $contactId, array $restrictToHostGroupIds, bool $allHostGroups): void
+    private function linkContactToAclResourceForHostGroups(int $contactId, array $restrictToHostGroupIds, bool $allHostGroups): void
     {
         $this->connection->insert('acl_groups', [
             'acl_group_name' => 'group-' . $contactId . '-' . random_int(1, PHP_INT_MAX),


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the pollers selector: migrates the poller listing endpoint to the new API Platform architecture, exposing `GET /configuration/pollers` as a Hydra collection.

**Fixes** MON-208928

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.10.x

## How this pull request can be tested ?

- `GET /api/configuration/pollers` returns a Hydra collection of pollers.
- Backend: PHPStan + App unit suite green.

## Stacked PR

Based on #11593 — merge that first.