### PR TITLE
enh(openapi): migrate the API documentation to OpenAPI 3.1

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -621,6 +621,40 @@ jobs:
         run: composer symfony:check && composer symfony:new:check
         working-directory: centreon
 
+      - name: 🔧 Setup Node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 24
+
+      - name: 🔧 Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Redocly CLI
+        run: |
+          pnpm install \
+            --frozen-lockfile \
+            --config.trustPolicy=no-downgrade \
+            --config.minimumReleaseAge=2880 \
+            --config.blockExoticSubdeps=true
+        working-directory: centreon/doc/API
+        shell: bash
+
+      - name: 📖 Check the OpenAPI documentation is up to date
+        # Regenerate the spec from the API Platform resources and fail if the committed file drifted.
+        run: |
+          set -e
+          php bin/console.new app:open-api:merge --override
+          git diff --exit-code doc/API/centreon-api.yaml \
+            || { echo "::error::doc/API/centreon-api.yaml is out of date — run 'bin/console.new app:open-api:merge --override' and commit the result."; exit 1; }
+        working-directory: centreon
+
+      - name: 🔍 Validate the OpenAPI documentation
+        run: pnpm exec redocly lint centreon-api.yaml centreon-cloud-api.yaml
+        working-directory: centreon/doc/API
+
       - name: Get changed PHP files
         id: changed-php
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6

--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -37,104 +37,67 @@ servers:
         default: '80'
         description: 'Port used by HTTP server'
 tags:
-  -
-    name: Acknowledgement
+  - name: Acknowledgement
     description: 'Endpoints to manage acknowledgements'
-  -
-    name: Administration
+  - name: Administration
     description: 'Endpoints to manage administration tasks'
-  -
-    name: Authentication
+  - name: Authentication
     description: 'Login and logout endpoints to retrieve authentication token'
-  -
-    name: Command
+  - name: Command
     description: "Resource 'Command' operations."
-  -
-    name: 'Contact group'
+  - name: 'Contact group'
     description: 'Endpoints to manage contact groups'
-  -
-    name: Downtime
+  - name: Downtime
     description: 'Endpoints to manage downtimes'
-  -
-    name: Gorgone
+  - name: Gorgone
     description: 'Endpoints to manage Gorgone'
-  -
-    name: Host
+  - name: Host
     description: 'Endpoints to manage hosts'
-  -
-    name: 'Host category'
+  - name: 'Host category'
     description: 'Endpoints to manage host categories'
-  -
-    name: 'Host group'
+  - name: 'Host group'
     description: 'Endpoints to manage host groups'
-  -
-    name: 'Meta service'
+  - name: 'Meta service'
     description: 'Endpoints to manage meta services'
-  -
-    name: 'Host severity'
-  -
-    name: 'Host template'
-  -
-    name: Media
-  -
-    name: 'Monitoring server'
-  -
-    name: Proxy
-  -
-    name: Service
-  -
-    name: 'Service group'
-  -
-    name: 'Service category'
+  - name: 'Host severity'
+  - name: 'Host template'
+  - name: Media
+  - name: 'Monitoring server'
+  - name: Proxy
+  - name: Service
+  - name: 'Service group'
+  - name: 'Service category'
     description: 'Endpoints to manage service categories'
-  -
-    name: Severity
+  - name: Severity
     description: 'Endpoints to manage severities'
-  -
-    name: 'Time period'
+  - name: 'Time period'
     description: 'Endpoints to manage time periods'
-  -
-    name: Topology
+  - name: Topology
     description: 'Endpoints to manage topologies'
-  -
-    name: GlobalMacroResource
-  -
-    name: ListPlugins
-  -
-    name: ServiceCategory
-  -
-    name: StandardMacroResource
-  -
-    name: ConnectorResource
-  -
-    name: Connector
+  - name: GlobalMacroResource
+  - name: ListPlugins
+  - name: ServiceCategory
+  - name: StandardMacroResource
+  - name: ConnectorResource
+  - name: Connector
     description: "Resource 'Connector' operations."
-  -
-    name: Plugin
+  - name: Plugin
     description: "Resource 'Plugin' operations."
-  -
-    name: 'Agent Configuration'
+  - name: 'Agent Configuration'
     description: "Resource 'Agent Configuration' operations."
-  -
-    name: 'Global Macro'
+  - name: 'Global Macro'
     description: "Resource 'Global Macro' operations."
-  -
-    name: Plugins
+  - name: Plugins
     description: "Resource 'Plugins' operations."
-  -
-    name: 'Service Category'
+  - name: 'Service Category'
     description: "Resource 'Service Category' operations."
-  -
-    name: 'Standard Macro'
+  - name: 'Standard Macro'
     description: "Resource 'Standard Macro' operations."
-  -
-    name: Poller
+  - name: Poller
     description: "Resource 'Poller' operations."
-  -
-    name: Upgrade
+  - name: Upgrade
     description: "Resource 'Upgrade' operations."
-  -
-    name: HostGroup
+  - name: HostGroup
     description: "Resource 'HostGroup' operations."
 security:
   -
@@ -247,8 +210,7 @@ paths:
       tags:
         - Authentication
       parameters:
-        -
-          $ref: '#/components/parameters/providerConfigurationName'
+        - $ref: '#/components/parameters/providerConfigurationName'
       summary: 'Authentication to provider'
       requestBody:
         required: true
@@ -381,8 +343,7 @@ paths:
       description: |
         Get a host category configuration
       parameters:
-        -
-          $ref: '#/components/parameters/HostCategoryId'
+        - $ref: '#/components/parameters/HostCategoryId'
       responses:
         '200':
           description: OK
@@ -404,8 +365,7 @@ paths:
       description: |
         Update a host category
       parameters:
-        -
-          $ref: '#/components/parameters/HostCategoryId'
+        - $ref: '#/components/parameters/HostCategoryId'
       requestBody:
         required: true
         content:
@@ -433,8 +393,7 @@ paths:
       description: |
         Delete a host category configuration
       parameters:
-        -
-          $ref: '#/components/parameters/HostCategoryId'
+        - $ref: '#/components/parameters/HostCategoryId'
       responses:
         '204':
           description: OK
@@ -478,14 +437,10 @@ paths:
         * service_group.id
         * service_group.name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -581,8 +536,7 @@ paths:
       description: |
         Delete a host severity configuration
       parameters:
-        -
-          $ref: '#/components/parameters/HostSeverityId'
+        - $ref: '#/components/parameters/HostSeverityId'
       responses:
         '204':
           description: OK
@@ -600,8 +554,7 @@ paths:
       description: |
         Get a host severity configuration
       parameters:
-        -
-          $ref: '#/components/parameters/HostSeverityId'
+        - $ref: '#/components/parameters/HostSeverityId'
       responses:
         '200':
           description: OK
@@ -623,8 +576,7 @@ paths:
       description: |
         Update a host severity
       parameters:
-        -
-          $ref: '#/components/parameters/HostSeverityId'
+        - $ref: '#/components/parameters/HostSeverityId'
       requestBody:
         required: true
         content:
@@ -680,14 +632,10 @@ paths:
         * servicecategory.id
         * servicecategory.name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -750,8 +698,7 @@ paths:
 
         Delete service group.
       parameters:
-        -
-          $ref: '#/components/parameters/ServiceGroupId'
+        - $ref: '#/components/parameters/ServiceGroupId'
       responses:
         '204':
           description: OK
@@ -852,14 +799,10 @@ paths:
           * address
           * is_activate
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -883,8 +826,7 @@ paths:
       description: |
         Generate and move the configuration files of the monitoring server
       parameters:
-        -
-          $ref: '#/components/parameters/MonitoringServerId'
+        - $ref: '#/components/parameters/MonitoringServerId'
       responses:
         '204':
           description: 'Generation OK'
@@ -903,8 +845,7 @@ paths:
       description: |
         Reload the configuration files of the monitoring server
       parameters:
-        -
-          $ref: '#/components/parameters/MonitoringServerId'
+        - $ref: '#/components/parameters/MonitoringServerId'
       responses:
         '204':
           description: 'Reload OK'
@@ -923,8 +864,7 @@ paths:
       description: |
         Generate, move and reload the configuration files of the monitoring server
       parameters:
-        -
-          $ref: '#/components/parameters/MonitoringServerId'
+        - $ref: '#/components/parameters/MonitoringServerId'
       responses:
         '204':
           description: 'Generation and reload OK'
@@ -1004,14 +944,10 @@ paths:
           * name
           * is_activate
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -1034,8 +970,7 @@ paths:
       summary: 'Get a meta service'
       description: 'Get a meta service configuration by its id'
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       responses:
         '200':
           description: OK
@@ -1065,16 +1000,11 @@ paths:
           * service_description
           * host_name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/MetaId'
       responses:
         '200':
           description: OK
@@ -1097,8 +1027,7 @@ paths:
       summary: 'Get notification policy of a host'
       description: 'Return the notified contacts and contact groups of a host.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       responses:
         '200':
           description: 'Successful request'
@@ -1120,10 +1049,8 @@ paths:
       summary: 'Get notification policy of a service'
       description: 'Return the notified contacts and contact groups of a service.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '200':
           description: 'Successful request'
@@ -1145,8 +1072,7 @@ paths:
       summary: 'Get notification policy of a meta service'
       description: 'Return the notified contacts and contact groups of a meta service.'
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       responses:
         '200':
           description: 'Successful request'
@@ -1175,14 +1101,10 @@ paths:
           * name
           * running
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -1394,8 +1316,7 @@ paths:
 
         List user filters saved for a given page.
       parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterPageName'
       responses:
         '200':
           description: OK
@@ -1421,8 +1342,7 @@ paths:
 
         Add user filter for a given page.
       parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterPageName'
       requestBody:
         required: true
         content:
@@ -1463,10 +1383,8 @@ paths:
 
         Get detailed information of a user filter for a given page.
       parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
       responses:
         '200':
           description: OK
@@ -1489,10 +1407,8 @@ paths:
 
         Update user filter for a given page.
       parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
       requestBody:
         required: true
         content:
@@ -1521,10 +1437,8 @@ paths:
 
         Patch user filter order for a given page.
       parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
       requestBody:
         required: true
         content:
@@ -1560,10 +1474,8 @@ paths:
 
         Delete user filter for a given page.
       parameters:
-        -
-          $ref: '#/components/parameters/FilterPageName'
-        -
-          $ref: '#/components/parameters/FilterId'
+        - $ref: '#/components/parameters/FilterPageName'
+        - $ref: '#/components/parameters/FilterId'
       responses:
         '204':
           description: OK
@@ -1619,40 +1531,23 @@ paths:
         * h.fqdn
         * s.description
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/ResourceFilterType'
-        -
-          $ref: '#/components/parameters/ResourceFilterState'
-        -
-          $ref: '#/components/parameters/ResourceFilterStatus'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostgroupName'
-        -
-          $ref: '#/components/parameters/ResourceFilterServicegroupName'
-        -
-          $ref: '#/components/parameters/ResourceFilterServiceCategoryName'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostCategoryName'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostSeverityName'
-        -
-          $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
-        -
-          $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
-        -
-          $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
-        -
-          $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
-        -
-          $ref: '#/components/parameters/ResourceFilterStatusTypes'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/ResourceFilterType'
+        - $ref: '#/components/parameters/ResourceFilterState'
+        - $ref: '#/components/parameters/ResourceFilterStatus'
+        - $ref: '#/components/parameters/ResourceFilterHostgroupName'
+        - $ref: '#/components/parameters/ResourceFilterServicegroupName'
+        - $ref: '#/components/parameters/ResourceFilterServiceCategoryName'
+        - $ref: '#/components/parameters/ResourceFilterHostCategoryName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityName'
+        - $ref: '#/components/parameters/ResourceFilterHostSeverityLevel'
+        - $ref: '#/components/parameters/ResourceFilterServiceSeverityLevel'
+        - $ref: '#/components/parameters/ResourceFilterMonitoringServerName'
+        - $ref: '#/components/parameters/ResourceFilterStatusTypes'
       responses:
         '200':
           description: OK
@@ -1679,8 +1574,7 @@ paths:
       summary: 'Get a Host resource type detail'
       description: 'Return the full detail of a resource typed Host.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       responses:
         '200':
           description: 'Successful request'
@@ -1702,10 +1596,8 @@ paths:
       summary: 'Get a Service resource type detail'
       description: 'Return the full detail of a resource typed Service.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '200':
           description: 'Successful request'
@@ -1742,16 +1634,11 @@ paths:
         * host.downtime
         * host.criticality
       parameters:
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -1774,8 +1661,7 @@ paths:
       summary: 'Get a host'
       description: 'Return a single host with full details and some details about its services.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       responses:
         '200':
           description: OK
@@ -1820,14 +1706,10 @@ paths:
         * service.downtime
         * service.criticality
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -1865,14 +1747,10 @@ paths:
         * service_category.id
         * service_category.name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -1905,16 +1783,11 @@ paths:
         * service.is_acknowledged
         * service.state
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -1939,10 +1812,8 @@ paths:
       summary: 'Get a service'
       description: 'Return a single service with full details.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '200':
           description: OK
@@ -1964,10 +1835,8 @@ paths:
       summary: 'Get service groups by host id and service id'
       description: 'Return a list of service groups for host-service pair.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '200':
           description: OK
@@ -2005,16 +1874,11 @@ paths:
         * host_category.id
         * host_category.name
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2044,14 +1908,10 @@ paths:
         * host_group.id
         * host_group.name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2089,18 +1949,12 @@ paths:
         * host_category.id
         * host_category.name
       parameters:
-        -
-          $ref: '#/components/parameters/ShowHost'
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/ShowHost'
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2142,18 +1996,12 @@ paths:
         * host_category.id
         * host_category.name
       parameters:
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/ShowHost'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/ShowHost'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2181,14 +2029,10 @@ paths:
         * name
         * level
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2216,14 +2060,10 @@ paths:
         * name
         * level
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2264,14 +2104,10 @@ paths:
         * state
         * type
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2322,8 +2158,7 @@ paths:
 
         Returns either a host or service acknowledgement depending on the resource type.
       parameters:
-        -
-          $ref: '#/components/parameters/AcknowledgementId'
+        - $ref: '#/components/parameters/AcknowledgementId'
       responses:
         '200':
           description: OK
@@ -2361,14 +2196,10 @@ paths:
         * state
         * type
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2432,14 +2263,10 @@ paths:
         * state
         * type
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2501,16 +2328,11 @@ paths:
         * state
         * type
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
       responses:
         '200':
           description: OK
@@ -2534,8 +2356,7 @@ paths:
 
         **Minimum API version:** 21.10
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       requestBody:
         required: true
         content:
@@ -2560,8 +2381,7 @@ paths:
 
         **Minimum API version:** 21.10
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       responses:
         '204':
           description: 'Command Sent'
@@ -2597,18 +2417,12 @@ paths:
         * state
         * type
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '200':
           description: OK
@@ -2632,10 +2446,8 @@ paths:
 
         **Minimum API version:** 21.10
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       requestBody:
         required: true
         content:
@@ -2660,10 +2472,8 @@ paths:
 
         **Minimum API version:** 21.10
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       responses:
         '204':
           description: 'Command Sent'
@@ -2700,16 +2510,11 @@ paths:
         * state
         * type
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/MetaId'
       responses:
         '200':
           description: OK
@@ -2734,8 +2539,7 @@ paths:
 
         **Minimum API version:** 21.10
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       requestBody:
         required: true
         content:
@@ -2761,8 +2565,7 @@ paths:
 
         **Minimum API version:** 21.10
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       responses:
         '204':
           description: 'Command Sent'
@@ -2778,14 +2581,10 @@ paths:
         - Downtime
       summary: 'List all downtimes'
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       description: |
         List all downtimes
 
@@ -2832,8 +2631,7 @@ paths:
       summary: 'Display one downtime'
       description: 'Display one downtime.'
       parameters:
-        -
-          $ref: '#/components/parameters/DowntimeId'
+        - $ref: '#/components/parameters/DowntimeId'
       responses:
         '200':
           description: OK
@@ -2853,8 +2651,7 @@ paths:
       summary: 'Cancel a downtime'
       description: 'Cancel a downtime.'
       parameters:
-        -
-          $ref: '#/components/parameters/DowntimeId'
+        - $ref: '#/components/parameters/DowntimeId'
       responses:
         '204':
           description: 'Command Sent'
@@ -2888,14 +2685,10 @@ paths:
         * contact.id
         * contact.name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -2958,14 +2751,10 @@ paths:
         * contact.id
         * contact.name
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -3005,18 +2794,12 @@ paths:
         - Downtime
       summary: 'List all downtimes of a host'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ShowService'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ShowService'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       description: |
         List all downtimes of a host.
 
@@ -3053,8 +2836,7 @@ paths:
       summary: 'Add a downtime on a host'
       description: 'Add a downtime on a host.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       requestBody:
         required: true
         content:
@@ -3076,18 +2858,12 @@ paths:
         - Downtime
       summary: 'List all downtimes of a service'
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       description: |
         List all downtimes of a service.
 
@@ -3122,10 +2898,8 @@ paths:
       summary: 'Add a downtime on a service'
       description: 'Add a downtime on a service.'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       requestBody:
         required: true
         content:
@@ -3148,16 +2922,11 @@ paths:
         - 'Meta service'
       summary: 'List all downtimes of a metaservice'
       parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/MetaId'
       description: |
         List all downtimes of a metaservice.
 
@@ -3193,8 +2962,7 @@ paths:
       summary: 'Add a downtime on a metaservice'
       description: 'Add a downtime on a metaservice.'
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       requestBody:
         required: true
         content:
@@ -3257,8 +3025,7 @@ paths:
       summary: 'Check host'
       description: 'Schedule immediate check on chosen host'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       requestBody:
         required: true
         content:
@@ -3283,10 +3050,8 @@ paths:
       summary: 'Check service'
       description: 'Schedule immediate check on chosen service'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       requestBody:
         required: true
         content:
@@ -3312,8 +3077,7 @@ paths:
       summary: 'Check metaservice'
       description: 'Schedule immediate check on chosen metaservice'
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       requestBody:
         required: true
         content:
@@ -3361,8 +3125,7 @@ paths:
       summary: 'Submit a result to a single host'
       description: 'Submit a result (check status, output and perfdata) to a single host'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/HostId'
       requestBody:
         required: true
         content:
@@ -3389,10 +3152,8 @@ paths:
       summary: 'Submit a result to a single service'
       description: 'Submit a result (check status, output and perfdata) to a single service'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
       requestBody:
         required: true
         content:
@@ -3420,8 +3181,7 @@ paths:
       summary: 'Submit a result to a single metaservice'
       description: 'Submit a result (check status, output and perfdata) to a single metaservice'
       parameters:
-        -
-          $ref: '#/components/parameters/MetaId'
+        - $ref: '#/components/parameters/MetaId'
       requestBody:
         required: true
         content:
@@ -3493,14 +3253,10 @@ paths:
         - Metrics
       summary: 'Get service metrics'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          $ref: '#/components/parameters/MetricStartDate'
-        -
-          $ref: '#/components/parameters/MetricEndDate'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/MetricStartDate'
+        - $ref: '#/components/parameters/MetricEndDate'
       responses:
         '200':
           description: OK
@@ -3524,14 +3280,10 @@ paths:
         - Metrics
       summary: 'Get service status data'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          $ref: '#/components/parameters/MetricStartDate'
-        -
-          $ref: '#/components/parameters/MetricEndDate'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/MetricStartDate'
+        - $ref: '#/components/parameters/MetricEndDate'
       description: 'Get status data from a service between given interval'
       responses:
         '200':
@@ -3557,10 +3309,8 @@ paths:
         - Metrics
       summary: 'Get service performance data'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
         -
           in: query
           name: start
@@ -3602,10 +3352,8 @@ paths:
         - Metrics
       summary: 'Download performance data as csv file'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
         -
           in: query
           name: start_date
@@ -3640,10 +3388,8 @@ paths:
         - Metrics
       summary: 'Get service status data'
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
         -
           in: query
           name: start
@@ -3695,16 +3441,11 @@ paths:
         * content
         * date
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -3735,18 +3476,12 @@ paths:
         * content
         * date
       parameters:
-        -
-          $ref: '#/components/parameters/HostId'
-        -
-          $ref: '#/components/parameters/ServiceId'
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/HostId'
+        - $ref: '#/components/parameters/ServiceId'
+        - $ref: '#/components/parameters/Search'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/SortBy'
       responses:
         '200':
           description: OK
@@ -3906,8 +3641,7 @@ paths:
       tags:
         - Topology
       parameters:
-        -
-          $ref: '#/components/parameters/PollerId'
+        - $ref: '#/components/parameters/PollerId'
       summary: 'Delete a Platform'
       description: 'Delete a platform from the topology'
       responses:
@@ -3924,10 +3658,8 @@ paths:
       tags:
         - Gorgone
       parameters:
-        -
-          $ref: '#/components/parameters/PollerId'
-        -
-          $ref: '#/components/parameters/GorgoneToken'
+        - $ref: '#/components/parameters/PollerId'
+        - $ref: '#/components/parameters/GorgoneToken'
       summary: 'Gorgone poller responses token'
       responses:
         '200':
@@ -3945,10 +3677,8 @@ paths:
       tags:
         - Gorgone
       parameters:
-        -
-          $ref: '#/components/parameters/PollerId'
-        -
-          $ref: '#/components/parameters/CommandName'
+        - $ref: '#/components/parameters/PollerId'
+        - $ref: '#/components/parameters/CommandName'
       summary: 'Gorgone command on specific poller'
       responses:
         '200':
@@ -6117,8 +5847,7 @@ components:
                   priority: { type: number, description: 'priority of the role', example: 1 }
     ReadAuthenticationSAMLProvider:
       allOf:
-        -
-          $ref: '#/components/schemas/AuthenticationSAMLProvider'
+        - $ref: '#/components/schemas/AuthenticationSAMLProvider'
         -
           properties:
             groups_mapping:
@@ -6135,8 +5864,7 @@ components:
                   items: { type: object, properties: { claim_value: { type: string, description: 'Authorization claim value', example: scope }, access_group: { type: object, description: 'Access group', properties: { id: { type: integer, description: 'Access group ID', example: 1 }, name: { type: string, description: 'Access group name', example: Default } } } } }
     WriteAuthenticationSAMLProvider:
       allOf:
-        -
-          $ref: '#/components/schemas/AuthenticationSAMLProvider'
+        - $ref: '#/components/schemas/AuthenticationSAMLProvider'
         -
           properties:
             groups_mapping:
@@ -6330,8 +6058,7 @@ components:
                 type: object
                 properties:
                   id: { type: integer, description: 'ID of the extra period', example: 1 }
-              -
-                $ref: '#/components/schemas/Configuration.TimePeriod.ExtraTimePeriod'
+              - $ref: '#/components/schemas/Configuration.TimePeriod.ExtraTimePeriod'
     Configuration.TimePeriod.days:
       type: object
       properties:
@@ -6502,8 +6229,7 @@ components:
           description: 'Indicates whether this host severity is enabled or not'
     Configuration.Host.Template:
       allOf:
-        -
-          $ref: '#/components/schemas/Configuration.Host.Template.Add'
+        - $ref: '#/components/schemas/Configuration.Host.Template.Add'
         -
           properties:
             id:
@@ -6776,8 +6502,7 @@ components:
           description: 'Indicates whether the host template is activated or not'
     Configuration.Service.Group:
       allOf:
-        -
-          $ref: '#/components/schemas/Configuration.Service.Group.Add'
+        - $ref: '#/components/schemas/Configuration.Service.Group.Add'
         -
           properties:
             id:
@@ -7255,8 +6980,7 @@ components:
         - object
         - 'null'
       allOf:
-        -
-          $ref: '#/components/schemas/Acknowledgement.Host'
+        - $ref: '#/components/schemas/Acknowledgement.Host'
         -
           type:
             - object
@@ -7269,8 +6993,7 @@ components:
               example: 5
     Acknowledgement.Host.Add:
       allOf:
-        -
-          $ref: '#/components/schemas/Acknowledgement.Service.Add'
+        - $ref: '#/components/schemas/Acknowledgement.Service.Add'
         -
           type: object
           properties:
@@ -7282,10 +7005,8 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Acknowledgement.Host.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Acknowledgement.Host.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Acknowledgement.Service.Add:
       type: object
       properties:
@@ -7309,14 +7030,11 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Acknowledgement.Service.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Acknowledgement.Service.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Downtime.Host.Add:
       allOf:
-        -
-          $ref: '#/components/schemas/Downtime.Service.Add'
+        - $ref: '#/components/schemas/Downtime.Service.Add'
         -
           type: object
           properties:
@@ -7328,10 +7046,8 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Downtime.Host.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Downtime.Host.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Downtime.Service.Add:
       type: object
       properties:
@@ -7359,10 +7075,8 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Downtime.Service.Add'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Downtime.Service.Add'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Downtime.Host:
       type: object
       properties:
@@ -7432,8 +7146,7 @@ components:
           example: true
     Downtime.Service:
       allOf:
-        -
-          $ref: '#/components/schemas/Downtime.Host'
+        - $ref: '#/components/schemas/Downtime.Host'
         -
           type: object
           properties:
@@ -7488,22 +7201,17 @@ components:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Check.Host'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Check.Host'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Check.Service:
       allOf:
-        -
-          $ref: '#/components/schemas/Check.Host'
+        - $ref: '#/components/schemas/Check.Host'
     Check.Services:
       type: array
       items:
         allOf:
-          -
-            $ref: '#/components/schemas/Check.Service'
-          -
-            $ref: '#/components/schemas/Bulk.Resource.Id'
+          - $ref: '#/components/schemas/Check.Service'
+          - $ref: '#/components/schemas/Bulk.Resource.Id'
     Check.Resources:
       type: object
       properties:
@@ -8053,10 +7761,8 @@ components:
           example: All
         host:
           allOf:
-            -
-              $ref: '#/components/schemas/Monitoring.HostMin'
-            -
-              $ref: '#/components/schemas/Monitoring.HostWithService'
+            - $ref: '#/components/schemas/Monitoring.HostMin'
+            - $ref: '#/components/schemas/Monitoring.HostWithService'
     Monitoring.HostMin:
       type: object
       properties:
@@ -8088,8 +7794,7 @@ components:
           example: 0
     Monitoring.HostFull:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.HostMain'
+        - $ref: '#/components/schemas/Monitoring.HostMain'
         -
           type: object
           properties:
@@ -8196,10 +7901,8 @@ components:
                   allOf: [{ $ref: '#/components/schemas/Acknowledgement.Host' }]
     Monitoring.HostMain:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.HostMin'
-        -
-          $ref: '#/components/schemas/Monitoring.HostWithService'
+        - $ref: '#/components/schemas/Monitoring.HostMin'
+        - $ref: '#/components/schemas/Monitoring.HostWithService'
         -
           type: object
           properties:
@@ -8399,8 +8102,7 @@ components:
           example: 0
     Monitoring.ServiceMain:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.ServiceMin'
+        - $ref: '#/components/schemas/Monitoring.ServiceMin'
         -
           type: object
           properties:
@@ -8460,8 +8162,7 @@ components:
               example: '2h 3m'
     Monitoring.ServiceFull:
       allOf:
-        -
-          $ref: '#/components/schemas/Monitoring.ServiceMain'
+        - $ref: '#/components/schemas/Monitoring.ServiceMain'
         -
           type: object
           properties:
@@ -8575,8 +8276,7 @@ components:
                 $ref: '#/components/schemas/Downtime.Service'
             acknowledgement:
               allOf:
-                -
-                  $ref: '#/components/schemas/Acknowledgement.Service'
+                - $ref: '#/components/schemas/Acknowledgement.Service'
               type:
                 - object
                 - 'null'
@@ -8891,8 +8591,7 @@ components:
         '@context':
           readOnly: true
           oneOf:
-            -
-              type: string
+            - type: string
             -
               type: object
               properties:
@@ -8980,8 +8679,7 @@ components:
           type: string
     Error.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9159,8 +8857,7 @@ components:
           type: boolean
     ServiceCategory.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9287,8 +8984,7 @@ components:
             type: integer
     Command.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9367,8 +9063,7 @@ components:
           example: true
     Connector.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9467,8 +9162,7 @@ components:
           example: 'This is the help description of the plugin.'
     Plugin.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9588,8 +9282,7 @@ components:
             - 'null'
     ConstraintViolation.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9671,8 +9364,7 @@ components:
           example: 'This command is used to check the HTTP service'
     CreateCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9741,8 +9433,7 @@ components:
             type: integer
     DuplicateCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9800,8 +9491,7 @@ components:
         - expression
     Global.Macro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9842,8 +9532,7 @@ components:
             - expression
     HydraCollectionBaseSchema:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraCollectionBaseSchemaNoPagination'
+        - $ref: '#/components/schemas/HydraCollectionBaseSchemaNoPagination'
         -
           type: object
           properties:
@@ -9903,8 +9592,7 @@ components:
       properties:
         '@context':
           oneOf:
-            -
-              type: string
+            - type: string
             -
               type: object
               properties:
@@ -9937,8 +9625,7 @@ components:
           example: 'curl -fsSL https://raw.githubusercontent.com/centreon/centreon-collect/refs/tags/[PF_VERSION]-latest/agent/installer/scripts_linux/install_cma.sh -o install_cma.sh && sudo chmod +x install_cma.sh && sudo ./install_cma.sh -e "[poller IP/DNS]:[PORT]" -f "[centreon_storage.instances.cma_certificate_sha]" -N "[centreon_storage.cma_certificate_cn]"'
     InstallationCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -9996,8 +9683,7 @@ components:
           type: boolean
     ListCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10056,8 +9742,7 @@ components:
           example: negate
     Plugins.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           required:
@@ -10089,8 +9774,7 @@ components:
           type: boolean
     Service.Category.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10121,8 +9805,7 @@ components:
             - 'null'
     Standard.Macro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10174,8 +9857,7 @@ components:
         - expression
     GlobalMacro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10264,8 +9946,7 @@ components:
           type: string
     Poller.jsonld-poller.read:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10307,8 +9988,7 @@ components:
             - 'null'
     StandardMacro.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10324,10 +10004,8 @@ components:
       type: object
     Upgrade.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
-        -
-          type: object
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
+        - type: object
     Poller:
       type: object
       properties:
@@ -10389,8 +10067,7 @@ components:
           example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.InstallationCommandResource.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10400,8 +10077,7 @@ components:
               example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10433,8 +10109,7 @@ components:
           type: string
     HostGroup.HostGroupCollectionOutput.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:
@@ -10451,8 +10126,7 @@ components:
           type: string
     Poller.PollerCollectionOutput.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:

--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: 'Centreon Web RestAPI'
   description: |
@@ -22,7 +22,7 @@ externalDocs:
   url: 'https://thewatch.centreon.com/'
 servers:
   -
-    url: '{protocol}://{server}:{port}/centreon/api/{version}'
+    url: '{protocol}://{server}:{port}/centreon'
     variables:
       protocol:
         enum:
@@ -36,9 +36,6 @@ servers:
       port:
         default: '80'
         description: 'Port used by HTTP server'
-      version:
-        default: v25.10
-        description: 'Version of the API'
 tags:
   -
     name: Acknowledgement
@@ -145,7 +142,7 @@ security:
   -
     Cookie: []
 paths:
-  /login:
+  /api/login:
     post:
       tags:
         - Authentication
@@ -172,7 +169,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /logout:
+  /api/logout:
     get:
       tags:
         - Authentication
@@ -192,7 +189,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/authentication/users/{alias}/password':
+  '/api/latest/authentication/users/{alias}/password':
     put:
       tags:
         - Authentication
@@ -229,7 +226,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /authentication/providers/configurations:
+  /api/latest/authentication/providers/configurations:
     get:
       tags:
         - Authentication
@@ -245,7 +242,7 @@ paths:
                 items:
                   type: object
                   properties: { id: { type: integer, description: 'Id of configuration', example: 1 }, type: { type: string, description: 'Type of provider', example: local }, name: { type: string, description: 'Name of provider', example: local }, authentication_uri: { type: string, description: 'Provider Uri used to proceed authentication', example: /centreon/authentication/providers/configurations/local }, is_active: { type: boolean, description: 'Provider active or not', example: true }, is_forced: { type: boolean, description: 'Provider forced or not', example: false } }
-  '/authentication/providers/configurations/{provider_configuration_name}':
+  '/api/latest/authentication/providers/configurations/{provider_configuration_name}':
     post:
       tags:
         - Authentication
@@ -275,7 +272,7 @@ paths:
                   redirect_uri: { type: string, example: '/centreon/main.php?p=50113&o=ldap' }
         '302':
           description: Found
-  /authentication/logout:
+  /api/latest/authentication/logout:
     get:
       tags:
         - Authentication
@@ -295,299 +292,29 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/additional-connector-configurations:
+  /api/latest/configuration/additional-connector-configurations:
     $ref: ./latest/onPremise/Configuration/AdditionalConnectorConfiguration/AddAndFindAccs.yaml
-  '/configuration/additional-connector-configurations/{acc_id}':
+  '/api/latest/configuration/additional-connector-configurations/{acc_id}':
     $ref: ./latest/onPremise/Configuration/AdditionalConnectorConfiguration/DeleteUpdateAndFindAcc.yaml
-  /configuration/agent-configurations:
+  /api/latest/configuration/agent-configurations:
     $ref: ./latest/onPremise/Configuration/AgentConfiguration/AddOrFindAc.yaml
-  '/configuration/agent-configurations/{ac_id}':
+  '/api/latest/configuration/agent-configurations/{ac_id}':
     $ref: ./latest/onPremise/Configuration/AgentConfiguration/DeleteAndUpdateAndFindDetailAc.yaml
-  '/configuration/agent-configurations/{ac_id}/pollers/{poller_id}':
+  '/api/latest/configuration/agent-configurations/{ac_id}/pollers/{poller_id}':
     $ref: ./latest/onPremise/Configuration/AgentConfiguration/DeleteAcPollerLink.yaml
-  '/configuration/broker/{broker_id}/{tag}':
+  '/api/latest/configuration/broker/{broker_id}/{tag}':
     $ref: ./latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml
-  '/configuration/broker/{broker_id}/outputs/{output_id}/file':
+  '/api/latest/configuration/broker/{broker_id}/outputs/{output_id}/file':
     $ref: ./latest/onPremise/Configuration/Broker/UpdateStreamConnectorFile.yaml
-  /configuration/commands:
-    get:
-      operationId: api_configurationcommands_get_collection
-      tags:
-        - Command
-      responses:
-        '403':
-          description: 'You are not allowed to access commands'
-        '200':
-          description: 'Command collection'
-          content:
-            application/ld+json:
-              schema:
-                type: object
-                description: 'ListCommandResource.jsonld collection.'
-                allOf:
-                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
-                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/ListCommandResource.jsonld' } } } }
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ListCommandResource'
-      summary: 'Retrieves the collection of Command resources.'
-      description: 'Retrieves the collection of Command resources.'
-      parameters:
-        -
-          name: name
-          in: query
-          description: 'Filter commands by name (partial or exact match)'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-        -
-          name: type
-          in: query
-          description: 'Filter commands by type. Multiple values can be provided using type[]=Check&type[]=Notification'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: string
-              enum:
-                - Check
-                - Notification
-                - Miscellaneous
-                - Discovery
-          style: form
-          explode: true
-        -
-          name: is_activated
-          in: query
-          description: 'Filter commands by activation status'
-          required: false
-          deprecated: false
-          schema:
-            type: boolean
-          style: form
-          explode: true
-        -
-          name: is_from_monitoring_connector
-          in: query
-          description: 'Filter commands by whether they are from a monitoring connector'
-          required: false
-          deprecated: false
-          schema:
-            type: boolean
-          style: form
-          explode: true
-        -
-          name: page
-          in: query
-          description: 'The collection page number'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 1
-          style: form
-          explode: true
-        -
-          name: itemsPerPage
-          in: query
-          description: 'The number of items per page'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 30
-            minimum: 0
-            maximum: 30
-          style: form
-          explode: true
-    post:
-      operationId: api_configurationcommands_post
-      tags:
-        - Command
-      responses:
-        '409':
-          description: 'Command resource already exists'
-        '403':
-          description: 'You are not allowed to create commands'
-        '201':
-          description: 'Command resource created'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/CreateCommandResource.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateCommandResource'
-          links: {  }
-        '400':
-          description: 'Invalid input'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
-      summary: 'Creates a Command resource.'
-      description: 'Creates a Command resource.'
-      parameters: []
-      requestBody:
-        description: 'The new Command resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/CreateCommandResource'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateCommandResource'
-        required: true
-  /configuration/graphs/templates:
+  /api/latest/configuration/graphs/templates:
     $ref: ./latest/onPremise/Configuration/GraphTemplate/FindGraphTemplates.yaml
-  /configuration/connectors:
-    summary: Connectors
-    description: 'Endpoints to manage connectors'
-    get:
-      operationId: api_configurationconnectors_get_collection
-      tags:
-        - Connector
-      responses:
-        '200':
-          description: 'Connector collection'
-          content:
-            application/ld+json:
-              schema:
-                type: object
-                description: 'Connector.jsonld collection.'
-                allOf:
-                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
-                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/Connector.jsonld' } } } }
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Connector'
-        '403':
-          description: Forbidden
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Retrieves the collection of Connector resources.'
-      description: 'Retrieves the collection of Connector resources.'
-      parameters:
-        -
-          name: 'id[lk]'
-          in: query
-          description: 'Filter by id using "like" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: integer
-          style: form
-          explode: true
-        -
-          name: 'id[eq]'
-          in: query
-          description: 'Filter by id using "equals" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: integer
-          style: form
-          explode: true
-        -
-          name: 'name[lk]'
-          in: query
-          description: 'Filter by name using "like" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-        -
-          name: 'name[eq]'
-          in: query
-          description: 'Filter by name using "equals" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-        -
-          name: page
-          in: query
-          description: 'The collection page number'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 1
-          style: form
-          explode: true
-        -
-          name: itemsPerPage
-          in: query
-          description: 'The number of items per page'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 30
-            minimum: 0
-            maximum: 30
-          style: form
-          explode: true
-  '/configuration/hosts/{host_id}':
-    $ref: ./latest/onPremise/Configuration/Host/GetAndDeleteAndPartialUpdateHost.yaml
-  /configuration/hosts/templates:
+  /api/latest/configuration/hosts/templates:
     $ref: ./latest/onPremise/Configuration/HostTemplate/AddAndFindHostTemplates.yaml
-  '/configuration/hosts/templates/{host_template_id}':
+  '/api/latest/configuration/hosts/templates/{host_template_id}':
     $ref: ./latest/onPremise/Configuration/HostTemplate/DeleteAndPartialUpdateHostTemplate.yaml
-  /configuration/hosts:
+  /api/latest/configuration/hosts:
     $ref: ./latest/onPremise/Configuration/Host/AddAndFindHosts.yaml
-  /configuration/hosts/categories:
+  /api/latest/configuration/hosts/categories:
     get:
       operationId: FindHostCategories
       tags:
@@ -645,7 +372,7 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/categories/{host_category_id}':
+  '/api/latest/configuration/hosts/categories/{host_category_id}':
     get:
       operationId: FindHostCategory
       tags:
@@ -717,151 +444,19 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/{host_id}/services/deploy':
+  '/api/latest/configuration/hosts/{host_id}/services/deploy':
     $ref: ./latest/onPremise/Configuration/Service/DeployServices.yaml
-  /configuration/services/categories:
-    get:
-      tags:
-        - 'Service category'
-      summary: 'List all service categories'
-      description: |
-        Return all service category configurations.
-
-        The available parameters to **search** / **sort_by** are:
-
-        * id
-        * name
-        * alias
-        * is_activated
-        * host.id
-        * host.name
-        * hostgroup.id
-        * hostgroup.name
-        * hostcategory.id
-        * hostcategory.name
-      parameters:
-        -
-          $ref: '#/components/parameters/Search'
-        -
-          $ref: '#/components/parameters/Limit'
-        -
-          $ref: '#/components/parameters/Page'
-        -
-          $ref: '#/components/parameters/SortBy'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result: { type: array, items: { $ref: '#/components/schemas/ServiceCategory' } }
-                  meta: { $ref: '#/components/schemas/Meta' }
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-    post:
-      operationId: api_configurationservicescategories_post
-      tags:
-        - 'Service Category'
-      responses:
-        '409':
-          description: 'ServiceCategory resource already exists'
-        '201':
-          description: 'ServiceCategory resource created'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ServiceCategory.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ServiceCategory'
-          links: {  }
-        '400':
-          description: 'Invalid input'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
-        '403':
-          description: Forbidden
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Creates a ServiceCategory resource.'
-      description: 'Creates a ServiceCategory resource.'
-      parameters: []
-      requestBody:
-        description: 'The new ServiceCategory resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/ServiceCategory'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ServiceCategory'
-        required: true
-  '/configuration/services/categories/{service_category_id}':
-    delete:
-      operationId: DeleteServiceCategory
-      tags:
-        - 'Service category'
-      summary: 'Delete a service category'
-      description: |
-        Delete a service category configuration
-      parameters:
-        -
-          $ref: '#/components/parameters/ServiceCategoryId'
-      responses:
-        '204':
-          description: OK
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /configuration/services/templates:
+  /api/latest/configuration/services/templates:
     $ref: ./latest/onPremise/Configuration/ServiceTemplate/AddOneAndFindServiceTemplates.yaml
-  '/configuration/services/templates/{service_template_id}':
+  '/api/latest/configuration/services/templates/{service_template_id}':
     $ref: ./latest/onPremise/Configuration/ServiceTemplate/PartialUpdateAndDeleteServiceTemplate.yaml
-  '/configuration/services/{service_id}':
+  '/api/latest/configuration/services/{service_id}':
     $ref: ./latest/onPremise/Configuration/Service/PartialUpdateAndDeleteService.yaml
-  /configuration/services:
+  /api/latest/configuration/services:
     $ref: ./latest/onPremise/Configuration/Service/AddServiceAndFindServices.yaml
-  /configuration/services/_delete:
+  /api/latest/configuration/services/_delete:
     $ref: ./latest/onPremise/Configuration/Service/DeleteServices.yaml
-  /monitoring/services/categories:
+  /api/latest/monitoring/services/categories:
     get:
       operationId: FindRealTimeServiceCategories
       tags:
@@ -905,7 +500,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/hosts/severities:
+  /api/latest/configuration/hosts/severities:
     get:
       operationId: FindHostSeverities
       tags:
@@ -977,7 +572,7 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/severities/{host_severity_id}':
+  '/api/latest/configuration/hosts/severities/{host_severity_id}':
     delete:
       operationId: DeleteHostSeverity
       tags:
@@ -1049,19 +644,19 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/hosts/groups:
+  /api/latest/configuration/hosts/groups:
     $ref: ./latest/onPremise/Configuration/HostGroup/AddAndFindHostGroups.yaml
-  '/configuration/hosts/groups/{hostgroup_id}':
+  '/api/latest/configuration/hosts/groups/{hostgroup_id}':
     $ref: ./latest/onPremise/Configuration/HostGroup/GetAndDeleteAndUpdateHostGroup.yaml
-  /configuration/hosts/groups/_delete:
+  /api/latest/configuration/hosts/groups/_delete:
     $ref: ./latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
-  /configuration/hosts/groups/_enable:
+  /api/latest/configuration/hosts/groups/_enable:
     $ref: ./latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
-  /configuration/hosts/groups/_disable:
+  /api/latest/configuration/hosts/groups/_disable:
     $ref: ./latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
-  /configuration/hosts/groups/_duplicate:
+  /api/latest/configuration/hosts/groups/_duplicate:
     $ref: ./latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
-  /configuration/services/groups:
+  /api/latest/configuration/services/groups:
     get:
       operationId: FindServiceGroups
       tags:
@@ -1142,7 +737,7 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/services/groups/{servicegroup_id}':
+  '/api/latest/configuration/services/groups/{servicegroup_id}':
     delete:
       operationId: DeleteServiceGroup
       tags:
@@ -1166,11 +761,11 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/services/severities:
+  /api/latest/configuration/services/severities:
     $ref: ./latest/onPremise/Configuration/ServiceSeverity/AddAndFindServiceSeverities.yaml
-  '/configuration/services/severities/{service_severity_id}':
+  '/api/latest/configuration/services/severities/{service_severity_id}':
     $ref: ./latest/onPremise/Configuration/ServiceSeverity/DeleteAndUpdateServiceSeverity.yaml
-  /configuration/icons:
+  /api/latest/configuration/icons:
     get:
       operationId: centreon_application_configuration_icon_getIcons
       tags:
@@ -1197,13 +792,13 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/medias:
+  /api/latest/configuration/medias:
     $ref: ./latest/onPremise/Configuration/Media/AddAndFindMedia.yaml
-  /configuration/media/folders:
+  /api/latest/configuration/media/folders:
     $ref: ./latest/onPremise/Configuration/Media/FindImageFolders.yaml
-  '/configuration/medias/{media_id}/content':
+  '/api/latest/configuration/medias/{media_id}/content':
     $ref: ./latest/onPremise/Configuration/Media/UpdateMedia.yaml
-  /configuration/proxy:
+  /api/latest/configuration/proxy:
     get:
       operationId: configuration.proxy.getProxy
       tags:
@@ -1240,7 +835,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers:
+  /api/latest/configuration/monitoring-servers:
     get:
       operationId: configuration.monitoring-servers.findServer
       tags:
@@ -1279,7 +874,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/monitoring-servers/{monitoring_server_id}/generate':
+  '/api/latest/configuration/monitoring-servers/{monitoring_server_id}/generate':
     get:
       operationId: configuration_monitoring_server_generate
       tags:
@@ -1299,7 +894,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/monitoring-servers/{monitoring_server_id}/reload':
+  '/api/latest/configuration/monitoring-servers/{monitoring_server_id}/reload':
     get:
       operationId: configuration_monitoring_server_reload
       tags:
@@ -1319,7 +914,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/monitoring-servers/{monitoring_server_id}/generate-and-reload':
+  '/api/latest/configuration/monitoring-servers/{monitoring_server_id}/generate-and-reload':
     get:
       operationId: configuration_monitoring_server_generate_and_reload
       tags:
@@ -1339,7 +934,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers/generate:
+  /api/latest/configuration/monitoring-servers/generate:
     get:
       operationId: configuration_monitoring_server_generate_all
       tags:
@@ -1356,7 +951,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers/reload:
+  /api/latest/configuration/monitoring-servers/reload:
     get:
       operationId: configuration_monitoring_server_reload_all
       tags:
@@ -1375,7 +970,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/monitoring-servers/generate-and-reload:
+  /api/latest/configuration/monitoring-servers/generate-and-reload:
     get:
       operationId: configuration_monitoring_server_generate_and_reload_all
       tags:
@@ -1394,7 +989,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/metaservices:
+  /api/latest/configuration/metaservices:
     get:
       operationId: centreon_application_find_meta_services_configurations
       tags:
@@ -1431,7 +1026,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/metaservices/{meta_id}':
+  '/api/latest/configuration/metaservices/{meta_id}':
     get:
       operationId: centreon_application_find_meta_service_configuration
       tags:
@@ -1454,7 +1049,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/metrics':
+  '/api/latest/monitoring/metaservices/{meta_id}/metrics':
     get:
       operationId: centreon_application_find_meta_service_metrics
       tags:
@@ -1494,7 +1089,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/{host_id}/notification-policy':
+  '/api/latest/configuration/hosts/{host_id}/notification-policy':
     get:
       operationId: configuration.host.notification-policy
       tags:
@@ -1517,7 +1112,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/hosts/{host_id}/services/{service_id}/notification-policy':
+  '/api/latest/configuration/hosts/{host_id}/services/{service_id}/notification-policy':
     get:
       operationId: configuration.service.notification-policy
       tags:
@@ -1542,7 +1137,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/configuration/metaservices/{meta_id}/notification-policy':
+  '/api/latest/configuration/metaservices/{meta_id}/notification-policy':
     get:
       operationId: configuration.metaservice.notification-policy
       tags:
@@ -1565,7 +1160,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/servers:
+  /api/latest/monitoring/servers:
     get:
       operationId: centreon_application_find_real_time_monitoring_servers
       tags:
@@ -1602,7 +1197,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /users/acl/actions:
+  /api/latest/users/acl/actions:
     get:
       operationId: centreon_application_user_getActionsAuthorization
       tags:
@@ -1623,9 +1218,9 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/timeperiods:
+  /api/latest/configuration/timeperiods:
     $ref: ./latest/onPremise/Configuration/TimePeriod/AddOneAndFindTimePeriods.yaml
-  '/configuration/timeperiods/{id}':
+  '/api/latest/configuration/timeperiods/{id}':
     delete:
       operationId: DeleteTimePeriod
       tags:
@@ -1710,11 +1305,11 @@ paths:
           $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/users:
+  /api/latest/configuration/users:
     $ref: ./latest/onPremise/Configuration/Users/Users.yaml
-  /configuration/users/current/parameters:
+  /api/latest/configuration/users/current/parameters:
     $ref: ./latest/onPremise/Configuration/Users/CurrentParameters.yaml
-  /configuration/contacts/templates:
+  /api/latest/configuration/contacts/templates:
     get:
       operationId: centreon_application_configuration_contact_template_getContactTemplates
       tags:
@@ -1737,35 +1332,35 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/contacts/groups:
+  /api/latest/configuration/contacts/groups:
     $ref: ./latest/onPremise/Configuration/ContactGroup/FindContactGroups.yaml
-  /configuration/dashboards:
+  /api/latest/configuration/dashboards:
     $ref: ./latest/onPremise/Configuration/Dashboard/Dashboards.yaml
-  '/configuration/dashboards/{dashboard_id}':
+  '/api/latest/configuration/dashboards/{dashboard_id}':
     $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.yaml
-  '/configuration/dashboards/{dashboard_id}/favorites':
+  '/api/latest/configuration/dashboards/{dashboard_id}/favorites':
     $ref: ./latest/onPremise/Configuration/Dashboard/DeleteDashboardFromFavorites.yaml
-  /configuration/dashboards/favorites:
+  /api/latest/configuration/dashboards/favorites:
     $ref: ./latest/onPremise/Configuration/Dashboard/FavoriteDashboards.yaml
-  '/configuration/dashboards/{dashboard_id}/shares':
+  '/api/latest/configuration/dashboards/{dashboard_id}/shares':
     $ref: ./latest/onPremise/Configuration/Dashboard/ShareDashboard.yaml
-  '/configuration/dashboards/{dashboard_id}/access_rights/contacts/{contact_id}':
+  '/api/latest/configuration/dashboards/{dashboard_id}/access_rights/contacts/{contact_id}':
     $ref: ./latest/onPremise/Configuration/Dashboard/DashboardShareContact.yaml
-  '/configuration/dashboards/{dashboard_id}/access_rights/contactgroups/{contact_group_id}':
+  '/api/latest/configuration/dashboards/{dashboard_id}/access_rights/contactgroups/{contact_group_id}':
     $ref: ./latest/onPremise/Configuration/Dashboard/DashboardShareContactGroup.yaml
-  /configuration/dashboards/contacts:
+  /api/latest/configuration/dashboards/contacts:
     $ref: ./latest/onPremise/Configuration/Dashboard/Contacts.yaml
-  /configuration/dashboards/contactgroups:
+  /api/latest/configuration/dashboards/contactgroups:
     $ref: ./latest/onPremise/Configuration/Dashboard/ContactGroups.yaml
-  /monitoring/dashboard/metrics/performances:
+  /api/latest/monitoring/dashboard/metrics/performances:
     $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsPerformances.yaml
-  /monitoring/dashboard/metrics/performances/data:
+  /api/latest/monitoring/dashboard/metrics/performances/data:
     $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
-  /monitoring/dashboard/metrics/top:
+  /api/latest/monitoring/dashboard/metrics/top:
     $ref: ./latest/onPremise/Configuration/Dashboard/Dashboard.MetricsTop.yaml
-  /monitoring/resources/hosts:
+  /api/latest/monitoring/resources/hosts:
     $ref: ./latest/onPremise/Realtime/Resources/FindResourcesByParent.yaml
-  /configuration/access-groups:
+  /api/latest/configuration/access-groups:
     get:
       tags:
         - 'Access Control'
@@ -1787,7 +1382,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/users/filters/{page_name}':
+  '/api/latest/users/filters/{page_name}':
     get:
       tags:
         - User
@@ -1856,7 +1451,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/users/filters/{page_name}/{filter_id}':
+  '/api/latest/users/filters/{page_name}/{filter_id}':
     get:
       tags:
         - User
@@ -1976,7 +1571,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources:
+  /api/latest/monitoring/resources:
     get:
       operationId: FindResources
       tags:
@@ -2067,23 +1662,16 @@ paths:
                 type: object
                 properties:
                   result: { type: array, items: { $ref: '#/components/schemas/Monitoring.ResourceMain' } }
-                  meta:
-                    allOf:
-                      - $ref: '#/components/schemas/Meta'
-                      - type: object
-                        properties:
-                          is_approximate:
-                            type: boolean
-                            description: 'True when the result set exceeds 1,000 matching resources and the full count was not computed to avoid a costly full-table scan. meta.total is capped at 1,000. Call GET /monitoring/resources/count with all_pages=true and the same filters to retrieve the exact count.'
+                  meta: { allOf: [{ $ref: '#/components/schemas/Meta' }, { type: object, properties: { is_approximate: { type: boolean, description: 'True when the result set exceeds 1,000 matching resources and the full count was not computed to avoid a costly full-table scan. meta.total is capped at 1,000. Call GET /monitoring/resources/count with all_pages=true and the same filters to retrieve the exact count.' } } }] }
         '403':
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/count:
+  /api/latest/monitoring/resources/count:
     $ref: ./latest/onPremise/Realtime/Resources/CountResources.yaml
-  /monitoring/resources/export:
+  /api/latest/monitoring/resources/export:
     $ref: ./latest/onPremise/Realtime/Resources/ExportResources.yaml
-  '/monitoring/resources/hosts/{host_id}':
+  '/api/latest/monitoring/resources/hosts/{host_id}':
     get:
       operationId: centreon_application_monitoring_resource_details_host
       tags:
@@ -2106,7 +1694,7 @@ paths:
           $ref: '#/components/responses/HostNotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/resources/hosts/{host_id}/services/{service_id}':
+  '/api/latest/monitoring/resources/hosts/{host_id}/services/{service_id}':
     get:
       operationId: centreon_application_monitoring_resource_details_service
       tags:
@@ -2131,7 +1719,7 @@ paths:
           $ref: '#/components/responses/NotFoundHostOrService'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts:
+  /api/latest/monitoring/hosts:
     get:
       operationId: centreon_application_monitoring_gethosts
       tags:
@@ -2178,7 +1766,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}':
+  '/api/latest/monitoring/hosts/{host_id}':
     get:
       operationId: centreon_application_monitoring_getonehost
       tags:
@@ -2201,11 +1789,11 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/status:
+  /api/latest/monitoring/hosts/status:
     $ref: ./latest/onPremise/Realtime/Hosts/FindHostsStatus.yaml
-  /monitoring/services/status:
+  /api/latest/monitoring/services/status:
     $ref: ./latest/onPremise/Realtime/Services/FindServicesStatus.yaml
-  /monitoring/services:
+  /api/latest/monitoring/services:
     get:
       operationId: centreon_application_monitoring_getservices
       tags:
@@ -2254,7 +1842,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/names:
+  /api/latest/monitoring/services/names:
     get:
       operationId: FindRealTimeUniqueServiceNames
       tags:
@@ -2299,7 +1887,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services':
+  '/api/latest/monitoring/hosts/{host_id}/services':
     get:
       operationId: centreon_application_monitoring_getservicesbyhost
       tags:
@@ -2343,7 +1931,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}':
     get:
       operationId: centreon_application_monitoring_getoneservice
       tags:
@@ -2368,7 +1956,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/servicegroups':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/servicegroups':
     get:
       operationId: centreon_application_monitoring_getservicegroupsbyhostandservice
       tags:
@@ -2393,7 +1981,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/hostgroups':
+  '/api/latest/monitoring/hosts/{host_id}/hostgroups':
     get:
       operationId: centreon_application_monitoring_gethostgroupsbyhost
       tags:
@@ -2441,7 +2029,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/categories:
+  /api/latest/monitoring/hosts/categories:
     get:
       tags:
         - 'Host category'
@@ -2478,7 +2066,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hostgroups:
+  /api/latest/monitoring/hostgroups:
     get:
       tags:
         - 'Host group'
@@ -2527,7 +2115,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/servicegroups:
+  /api/latest/monitoring/servicegroups:
     get:
       tags:
         - 'Service group'
@@ -2580,7 +2168,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/severities/service:
+  /api/latest/monitoring/severities/service:
     get:
       tags:
         - Severity
@@ -2615,7 +2203,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/severities/host:
+  /api/latest/monitoring/severities/host:
     get:
       tags:
         - Severity
@@ -2650,7 +2238,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/acknowledgements:
+  /api/latest/monitoring/acknowledgements:
     get:
       tags:
         - Acknowledgement
@@ -2698,7 +2286,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/acknowledgements:
+  /api/latest/monitoring/resources/acknowledgements:
     delete:
       tags:
         - Acknowledgement
@@ -2722,7 +2310,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/acknowledgements/{acknowledgement_id}':
+  '/api/latest/monitoring/acknowledgements/{acknowledgement_id}':
     get:
       tags:
         - Acknowledgement
@@ -2749,7 +2337,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/acknowledgements:
+  /api/latest/monitoring/hosts/acknowledgements:
     get:
       tags:
         - Acknowledgement
@@ -2818,7 +2406,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/acknowledgements:
+  /api/latest/monitoring/services/acknowledgements:
     get:
       tags:
         - Acknowledgement
@@ -2889,7 +2477,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/acknowledgements':
+  '/api/latest/monitoring/hosts/{host_id}/acknowledgements':
     get:
       tags:
         - Acknowledgement
@@ -2983,7 +2571,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/acknowledgements':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/acknowledgements':
     get:
       tags:
         - Acknowledgement
@@ -3085,7 +2673,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/acknowledgements':
+  '/api/latest/monitoring/metaservices/{meta_id}/acknowledgements':
     get:
       tags:
         - Acknowledgement
@@ -3184,7 +2772,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/downtimes:
+  /api/latest/monitoring/downtimes:
     get:
       tags:
         - Downtime
@@ -3237,7 +2825,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/downtimes/{downtime_id}':
+  '/api/latest/monitoring/downtimes/{downtime_id}':
     get:
       tags:
         - Downtime
@@ -3278,7 +2866,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/downtimes:
+  /api/latest/monitoring/hosts/downtimes:
     get:
       tags:
         - Downtime
@@ -3341,7 +2929,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/downtimes:
+  /api/latest/monitoring/services/downtimes:
     get:
       tags:
         - Downtime
@@ -3411,7 +2999,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/downtimes':
+  '/api/latest/monitoring/hosts/{host_id}/downtimes':
     get:
       tags:
         - Downtime
@@ -3482,7 +3070,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/downtimes':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/downtimes':
     get:
       tags:
         - Downtime
@@ -3553,7 +3141,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/downtimes':
+  '/api/latest/monitoring/metaservices/{meta_id}/downtimes':
     get:
       tags:
         - Downtime
@@ -3622,7 +3210,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/hosts/check:
+  /api/latest/monitoring/hosts/check:
     post:
       tags:
         - Check
@@ -3642,7 +3230,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/services/check:
+  /api/latest/monitoring/services/check:
     post:
       tags:
         - Check
@@ -3662,7 +3250,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/check':
+  '/api/latest/monitoring/hosts/{host_id}/check':
     post:
       tags:
         - Check
@@ -3688,7 +3276,7 @@ paths:
           description: 'Host not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/check':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/check':
     post:
       tags:
         - Check
@@ -3716,7 +3304,7 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/check':
+  '/api/latest/monitoring/metaservices/{meta_id}/check':
     post:
       tags:
         - Check
@@ -3743,7 +3331,7 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/check:
+  /api/latest/monitoring/resources/check:
     post:
       tags:
         - Check
@@ -3766,7 +3354,7 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/submit':
+  '/api/latest/monitoring/hosts/{host_id}/submit':
     post:
       tags:
         - Submit
@@ -3794,7 +3382,7 @@ paths:
           description: 'Host not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/submit':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/submit':
     post:
       tags:
         - Submit
@@ -3824,7 +3412,7 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/metaservices/{meta_id}/submit':
+  '/api/latest/monitoring/metaservices/{meta_id}/submit':
     post:
       tags:
         - Submit
@@ -3851,7 +3439,7 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/submit:
+  /api/latest/monitoring/resources/submit:
     post:
       tags:
         - Submit
@@ -3874,7 +3462,7 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/comments:
+  /api/latest/monitoring/resources/comments:
     post:
       tags:
         - Comment
@@ -3897,9 +3485,9 @@ paths:
           description: 'Host or service not found'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/metrics':
     $ref: ./latest/onPremise/Realtime/Metrics/FindMetricsByService.yaml
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/start/{start}/end/{end}':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/metrics/start/{start}/end/{end}':
     get:
       tags:
         - Metrics
@@ -3922,7 +3510,7 @@ paths:
                 type: object
                 properties:
                   global: { type: object, properties: { title: { type: string, description: 'title of the graph', example: 'graph title' }, start: { type: integer, description: 'timestamp of the start interval', example: 1594504800 }, end: { type: integer, description: 'timestamp of the end interval', example: 1594591200 }, vertical-label: { type: string, description: 'vertical label (should not be used cause multiple y-axis possible)', example: Value }, base: { type: string, description: 'base scale', example: '1024' }, width: { type: string, description: 'width of the graph (should not be used)', example: '550' }, height: { type: string, description: 'height of the graph (should not be used)', example: '140' }, lower-limit: { type: string, description: 'lower value of the graph', example: '0' }, scaled: { type: integer, description: 'if the graph needs to be automatically scaled', example: 1 }, multiple_services: { type: boolean, description: 'if multiple services are selected (always false)', example: false } } }
-                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, last_value: { type: number, nullable: true, description: 'last value', example: 5.0 }, minimum_value: { type: number, nullable: true, description: 'minimum value', example: 0.0 }, maximum_value: { type: number, nullable: true, description: 'maximum value', example: 10.0 }, average_value: { type: number, nullable: true, description: 'average value', example: 5.64 } } } }
+                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: [string, 'null'], description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: [string, 'null'], description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: [string, 'null'], description: 'warning threshold', example: null }, warn_low: { type: [string, 'null'], description: 'low warning threshold', example: null }, crit: { type: [string, 'null'], description: 'critical threshold', example: null }, crit_low: { type: [string, 'null'], description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, last_value: { type: [number, 'null'], description: 'last value', example: 5.0 }, minimum_value: { type: [number, 'null'], description: 'minimum value', example: 0.0 }, maximum_value: { type: [number, 'null'], description: 'maximum value', example: 10.0 }, average_value: { type: [number, 'null'], description: 'average value', example: 5.64 } } } }
                   times: { type: array, items: { type: string, format: timestamp, description: 'timestamp of the tick' }, example: ['1594505100', '1594505400', '1594505700'] }
         '403':
           $ref: '#/components/responses/Forbidden'
@@ -3930,7 +3518,7 @@ paths:
           $ref: '#/components/responses/NotFoundHostOrService'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/status/start/{start}/end/{end}':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/status/start/{start}/end/{end}':
     get:
       tags:
         - Metrics
@@ -3963,7 +3551,7 @@ paths:
           $ref: '#/components/responses/NotFoundHostOrService'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance':
     get:
       tags:
         - Metrics
@@ -4000,7 +3588,7 @@ paths:
                 type: object
                 properties:
                   base: { type: string, description: 'base scale', example: 1024 }
-                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: string, nullable: true, description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: string, nullable: true, description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: string, nullable: true, description: 'warning threshold', example: null }, warn_low: { type: string, nullable: true, description: 'low warning threshold', example: null }, crit: { type: string, nullable: true, description: 'critical threshold', example: null }, crit_low: { type: string, nullable: true, description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, format: float, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, minimum_value: { type: number, format: float, description: 'minimum value', example: 1.0 }, maximum_value: { type: number, format: float, description: 'maximum value', example: 1.0 } } } }
+                  metrics: { type: array, items: { type: object, properties: { index_id: { type: string, description: 'index id in centreon_storage.index_data table', example: '4' }, metric_id: { type: string, description: 'metric id in centreon_storage.metrics table', example: '29' }, metric: { type: string, description: 'name of the metric', example: cpu }, metric_legend: { type: string, description: 'name of the metric in legend', example: cpu }, unit: { type: string, description: 'metric unit', example: '%' }, hidden: { type: integer, description: 'if the metric is hidden', example: 0 }, min: { type: string, description: 'min value', example: '0' }, max: { type: string, description: 'max value', example: '100' }, virtual: { type: integer, description: 'if the metric is virtual', example: 0 }, ds_data: { type: object, description: 'metric line properties', properties: { ds_min: { type: string, description: 'minimum value', example: '1' }, ds_max: { type: string, description: 'maximum value', example: '1' }, ds_minmax_int: { type: [string, 'null'], description: unknown, example: null }, ds_last: { type: string, description: 'last value', example: '1' }, ds_average: { type: string, description: 'average value', example: '1' }, ds_total: { type: [string, 'null'], description: unknown, example: null }, ds_tickness: { type: string, description: unknown, example: '1' }, ds_color_line_mode: { type: string, description: unknown, example: '1' }, ds_color_line: { type: string, description: 'color of the line', example: '#666600' } } }, legend: { type: string, description: 'metric name in legend', example: 'cpu (%)' }, stack: { type: integer, description: 'if the metric is stacked with other metrics', example: 0 }, warn: { type: [string, 'null'], description: 'warning threshold', example: null }, warn_low: { type: [string, 'null'], description: 'low warning threshold', example: null }, crit: { type: [string, 'null'], description: 'critical threshold', example: null }, crit_low: { type: [string, 'null'], description: 'low critical threshold', example: null }, ds_color_area_warn: { type: string, description: 'color of the area under warning threshold', example: '#ff9a13' }, ds_color_area_crit: { type: string, description: 'color of the area under critical threshold', example: '#e00b3d' }, ds_order: { type: integer, description: 'order used for stacking', example: 0 }, data: { type: array, items: { type: number, format: float, description: 'value of the metric' }, example: [1.0, null, 1.0] }, prints: { type: array, items: { type: array, items: { type: string, description: 'label to display in legend', example: 'Last:1.00' } } }, minimum_value: { type: number, format: float, description: 'minimum value', example: 1.0 }, maximum_value: { type: number, format: float, description: 'maximum value', example: 1.0 } } } }
                   times: { type: array, items: { type: string, format: timestamp, description: 'datetime of the tick' }, example: ['1690965300'] }
         '403':
           $ref: '#/components/responses/Forbidden'
@@ -4008,7 +3596,7 @@ paths:
           $ref: '#/components/responses/NotFoundHostOrService'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance/download':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/metrics/performance/download':
     get:
       tags:
         - Metrics
@@ -4046,7 +3634,7 @@ paths:
                 format: string
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/status':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/metrics/status':
     get:
       tags:
         - Metrics
@@ -4093,7 +3681,7 @@ paths:
           $ref: '#/components/responses/NotFoundHostOrService'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/timeline':
+  '/api/latest/monitoring/hosts/{host_id}/timeline':
     get:
       tags:
         - Timeline
@@ -4133,7 +3721,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/timeline':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/timeline':
     get:
       tags:
         - Timeline
@@ -4175,11 +3763,11 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/monitoring/hosts/{host_id}/services/{service_id}/metrics/{metricName}':
+  '/api/latest/monitoring/hosts/{host_id}/services/{service_id}/metrics/{metricName}':
     $ref: ./latest/onPremise/Realtime/Metrics/FindSingleMetric.yaml
-  '/monitoring/metaService/{metaServiceId}/metrics/{metricName}':
+  '/api/latest/monitoring/metaService/{metaServiceId}/metrics/{metricName}':
     $ref: ./latest/onPremise/Realtime/Metrics/FindSingleMetaMetric.yaml
-  /monitoring/resources/acknowledge:
+  /api/latest/monitoring/resources/acknowledge:
     post:
       tags:
         - Acknowledgement
@@ -4203,7 +3791,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /monitoring/resources/downtime:
+  /api/latest/monitoring/resources/downtime:
     post:
       tags:
         - Downtime
@@ -4223,7 +3811,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /platform:
+  /api/latest/platform:
     patch:
       tags:
         - Platform
@@ -4243,80 +3831,11 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /platform/features:
+  /api/latest/platform/features:
     $ref: ./latest/onPremise/Platform/Features.yaml
-  /platform/versions:
+  /api/latest/platform/versions:
     $ref: ./latest/onPremise/Platform/Versions.yaml
-  /platform/updates:
-    $ref: ./latest/onPremise/Administration/Update/updates.yaml
-    post:
-      operationId: api_platformupdates_post
-      tags:
-        - Upgrade
-      responses:
-        '204':
-          description: 'Upgrade resource created'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Upgrade.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Upgrade'
-          links: {  }
-        '400':
-          description: 'Invalid input'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-        '422':
-          description: 'An error occurred'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
-        '403':
-          description: Forbidden
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Creates a Upgrade resource.'
-      description: 'Creates a Upgrade resource.'
-      parameters: []
-      requestBody:
-        description: 'The new Upgrade resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/Upgrade'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Upgrade'
-        required: true
-  /platform/installation/status:
+  /api/latest/platform/installation/status:
     get:
       tags:
         - Platform
@@ -4337,7 +3856,7 @@ paths:
                   has_upgrade_available: { type: boolean, description: "upgrade available or not\n", example: true }
         '500':
           description: 'centreon is not properly installed'
-  /platform/topology:
+  /api/latest/platform/topology:
     post:
       tags:
         - Topology
@@ -4382,7 +3901,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/platform/topology/{poller_id}':
+  '/api/latest/platform/topology/{poller_id}':
     delete:
       tags:
         - Topology
@@ -4400,7 +3919,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/gorgone/pollers/{poller_id}/responses/{token}':
+  '/api/latest/gorgone/pollers/{poller_id}/responses/{token}':
     get:
       tags:
         - Gorgone
@@ -4421,7 +3940,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  '/gorgone/pollers/{poller_id}/commands/{command_name}':
+  '/api/latest/gorgone/pollers/{poller_id}/commands/{command_name}':
     post:
       tags:
         - Gorgone
@@ -4446,7 +3965,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /administration/authentication/providers/local:
+  /api/latest/administration/authentication/providers/local:
     get:
       tags:
         - Administration
@@ -4481,9 +4000,9 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /administration/authentication/providers/openid:
+  /api/latest/administration/authentication/providers/openid:
     $ref: ./latest/onPremise/Administration/Authentication/OpenIdProvider/OpenIdProvider.yaml
-  /administration/authentication/providers/saml:
+  /api/latest/administration/authentication/providers/saml:
     get:
       tags:
         - Administration
@@ -4518,7 +4037,7 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /administration/authentication/providers/web-sso:
+  /api/latest/administration/authentication/providers/web-sso:
     get:
       tags:
         - Administration
@@ -4553,13 +4072,13 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /administration/tokens:
+  /api/latest/administration/tokens:
     $ref: ./latest/onPremise/Administration/Token/AddTokenAndFindTokens.yaml
-  '/administration/tokens/{token_name}':
+  '/api/latest/administration/tokens/{token_name}':
     $ref: ./latest/onPremise/Administration/Token/GetAndDeleteToken.yaml
-  '/administration/tokens/{token_name}/users/{user_id}':
+  '/api/latest/administration/tokens/{token_name}/users/{user_id}':
     $ref: ./latest/onPremise/Administration/Token/GetAndPartialUpdateAndDeleteTokenByUser.yaml
-  /administration/parameters:
+  /api/latest/administration/parameters:
     post:
       tags:
         - Administration
@@ -4587,51 +4106,38 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /administration/vaults/configurations:
+  /api/latest/administration/vaults/configurations:
     $ref: ./latest/onPremise/Administration/Vault/VaultConfiguration.yaml
-  /configuration/global-macros:
-    summary: 'global macros'
-    description: 'global macros configuration'
+  /api/configuration/commands:
     get:
-      operationId: api_configurationglobal-macros_get_collection
+      operationId: api_configurationcommands_get_collection
       tags:
-        - 'Global Macro'
+        - Command
       responses:
+        '403':
+          description: 'You are not allowed to access commands'
         '200':
-          description: 'GlobalMacro collection'
+          description: 'Command collection'
           content:
             application/ld+json:
               schema:
                 type: object
-                description: 'GlobalMacro.jsonld collection.'
+                description: 'ListCommandResource.jsonld collection.'
                 allOf:
                   - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
-                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/GlobalMacro.jsonld' } } } }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/ListCommandResource.jsonld' } } } }
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/GlobalMacro'
-        '403':
-          description: Forbidden
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Retrieves the collection of GlobalMacro resources.'
-      description: 'Retrieves the collection of GlobalMacro resources.'
+                  $ref: '#/components/schemas/ListCommandResource'
+      summary: 'Retrieves the collection of Command resources.'
+      description: 'Retrieves the collection of Command resources.'
       parameters:
         -
-          name: 'name[lk]'
+          name: name
           in: query
-          description: 'Filter by name using "like" operator'
+          description: 'Filter commands by name (partial or exact match)'
           required: false
           deprecated: false
           schema:
@@ -4641,15 +4147,40 @@ paths:
           style: form
           explode: true
         -
-          name: 'name[eq]'
+          name: type
           in: query
-          description: 'Filter by name using "equals" operator'
+          description: 'Filter commands by type. Multiple values can be provided using type[]=Check&type[]=Notification'
           required: false
           deprecated: false
           schema:
             type: array
             items:
               type: string
+              enum:
+                - Check
+                - Notification
+                - Miscellaneous
+                - Discovery
+          style: form
+          explode: true
+        -
+          name: is_activated
+          in: query
+          description: 'Filter commands by activation status'
+          required: false
+          deprecated: false
+          schema:
+            type: boolean
+          style: form
+          explode: true
+        -
+          name: is_from_monitoring_connector
+          in: query
+          description: 'Filter commands by whether they are from a monitoring connector'
+          required: false
+          deprecated: false
+          schema:
+            type: boolean
           style: form
           explode: true
         -
@@ -4676,29 +4207,27 @@ paths:
             maximum: 30
           style: form
           explode: true
-  /configuration/host_groups:
-    get:
-      operationId: api_configurationhost_groups_get_collection
+    post:
+      operationId: api_configurationcommands_post
       tags:
-        - HostGroup
+        - Command
       responses:
-        '200':
-          description: 'HostGroup collection'
+        '409':
+          description: 'Command resource already exists'
+        '403':
+          description: 'You are not allowed to create commands'
+        '201':
+          description: 'Command resource created'
           content:
             application/ld+json:
               schema:
-                type: object
-                description: 'HostGroup.HostGroupCollectionOutput.jsonld collection.'
-                allOf:
-                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
-                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/HostGroup.HostGroupCollectionOutput.jsonld' } } } }
+                $ref: '#/components/schemas/CreateCommandResource.jsonld'
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/HostGroup.HostGroupCollectionOutput'
+                $ref: '#/components/schemas/CreateCommandResource'
+          links: {}
         '400':
-          description: 'Invalid query parameter (itemsPerPage must be a positive integer, name must use the "name[lk]=value" format)'
+          description: 'Invalid input'
           content:
             application/ld+json:
               schema:
@@ -4709,184 +4238,98 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
+        '422':
+          description: 'An error occurred'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+          links: {}
+      summary: 'Creates a Command resource.'
+      description: 'Creates a Command resource.'
+      parameters: []
+      requestBody:
+        description: 'The new Command resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/CreateCommandResource'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCommandResource'
+        required: true
+  /api/configuration/commands/_duplicate:
+    post:
+      operationId: api_configurationcommands_duplicate_post
+      tags:
+        - Command
+      responses:
+        '200':
+          description: 'A collection holding the duplication outcome for each requested command'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                properties:
+                  '@context': { type: string }
+                  '@id': { type: string }
+                  '@type': { type: string, example: Collection }
+                  totalItems: { type: integer }
+                  member: { type: array, items: { type: object, properties: { '@id': { type: string }, '@type': { type: string, example: DuplicateCommandResource }, command: { type: string, description: 'IRI of the duplicated command (absent when the duplication failed)' }, status: { type: integer }, message: { type: string } }, required: ['@id', '@type', status, message] } }
+              example:
+                '@context': /centreon/api/latest/contexts/Command
+                '@id': /centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8
+                '@type': Collection
+                totalItems: 2
+                member:
+                  - { '@id': /centreon/api/latest/.well-known/genid/c2afa2366f6f99491863, '@type': DuplicateCommandResource, command: /centreon/api/latest/configuration/commands/98, status: 204, message: 'Command duplicated successfully' }
+                  - { '@id': /centreon/api/latest/.well-known/genid/3fa305a034165257c384, '@type': DuplicateCommandResource, status: 404, message: 'Command with ID 99999 not found' }
+          links: {}
+        '400':
+          description: 'Invalid input — the request body failed validation'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code: { type: integer, example: 400 }
+                  message: { type: string, description: 'One line per violation, formatted as "[propertyPath] message"', example: "[ids] IDs array cannot be empty\n" }
+                required:
+                  - code
+                  - message
         '403':
-          description: Forbidden
+          description: 'You are not allowed to duplicate commands'
           content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Error.jsonld'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
             application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          links: {  }
-      summary: 'Retrieves the collection of HostGroup resources.'
-      description: 'Retrieves the collection of HostGroup resources.'
-      parameters:
-        -
-          name: 'name[lk]'
-          in: query
-          description: 'Filter by host group name using "like" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: string
-          style: form
-          explode: true
-        -
-          name: page
-          in: query
-          description: 'The collection page number'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 1
-          style: form
-          explode: true
-        -
-          name: itemsPerPage
-          in: query
-          description: 'The number of items per page'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 30
-            minimum: 1
-            maximum: 30
-          style: form
-          explode: true
-  /configuration/plugins:
-    summary: plugins
-    description: 'plugins configuration'
-    get:
-      operationId: api_configurationplugins_get_collection
-      tags:
-        - Plugins
-      responses:
-        '200':
-          description: 'Plugins collection'
-          content:
-            application/ld+json:
               schema:
                 type: object
-                description: 'Plugins.jsonld collection.'
-                allOf:
-                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
-                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/Plugins.jsonld' } } } }
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Plugins'
-      summary: 'Retrieves the collection of Plugins resources.'
-      description: 'Retrieves the collection of Plugins resources.'
-      parameters:
-        -
-          name: page
-          in: query
-          description: 'The collection page number'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 1
-          style: form
-          explode: true
-        -
-          name: itemsPerPage
-          in: query
-          description: 'The number of items per page'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 30
-            minimum: 0
-            maximum: 30
-          style: form
-          explode: true
-  /configuration/standard-macros:
-    summary: 'standard macros'
-    description: 'standard macros configuration'
-    get:
-      operationId: api_configurationstandard-macros_get_collection
-      tags:
-        - 'Standard Macro'
-      responses:
-        '200':
-          description: 'StandardMacro collection'
-          content:
-            application/ld+json:
-              schema:
-                type: object
-                description: 'StandardMacro.jsonld collection.'
-                allOf:
-                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
-                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/StandardMacro.jsonld' } } } }
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/StandardMacro'
-      summary: 'Retrieves the collection of StandardMacro resources.'
-      description: 'Retrieves the collection of StandardMacro resources.'
-      parameters:
-        -
-          name: 'name[lk]'
-          in: query
-          description: 'Filter by name using "like" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-        -
-          name: 'name[eq]'
-          in: query
-          description: 'Filter by name using "equals" operator'
-          required: false
-          deprecated: false
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-        -
-          name: page
-          in: query
-          description: 'The collection page number'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 1
-          style: form
-          explode: true
-        -
-          name: itemsPerPage
-          in: query
-          description: 'The number of items per page'
-          required: false
-          deprecated: false
-          schema:
-            type: integer
-            default: 30
-            minimum: 0
-            maximum: 30
-          style: form
-          explode: true
-  '/configuration/commands/{id}':
-    summary: 'operations on a specific command resource'
-    description: 'operations on a specific command resource'
+                properties:
+                  code: { type: integer, example: 0 }
+                  message: { type: string, example: 'You are not allowed to duplicate commands' }
+                required:
+                  - code
+                  - message
+      summary: 'Duplicate a Command resource'
+      description: 'Duplicate a Command resource'
+      parameters: []
+      requestBody:
+        description: 'The new Command resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
+        required: true
+  '/api/configuration/commands/{id}':
     get:
       operationId: api_configurationcommands_id_get
       tags:
@@ -4960,7 +4403,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Command'
-          links: {  }
+          links: {}
         '400':
           description: 'Invalid input'
           content:
@@ -4973,7 +4416,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
         '422':
           description: 'An error occurred'
           content:
@@ -4986,7 +4429,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
+          links: {}
       summary: 'Updates the Command resource.'
       description: 'Updates the Command resource.'
       parameters:
@@ -5007,75 +4450,116 @@ paths:
             schema:
               $ref: '#/components/schemas/Command.jsonMergePatch'
         required: true
-  /configuration/commands/_duplicate:
-    summary: 'duplicate a Command resource'
-    description: 'duplicate a Command resource'
-    post:
-      operationId: api_configurationcommands_duplicate_post
+  /api/configuration/connectors:
+    get:
+      operationId: api_configurationconnectors_get_collection
       tags:
-        - Command
+        - Connector
       responses:
         '200':
-          description: 'A collection holding the duplication outcome for each requested command'
+          description: 'Connector collection'
           content:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  '@context': { type: string }
-                  '@id': { type: string }
-                  '@type': { type: string, example: Collection }
-                  totalItems: { type: integer }
-                  member: { type: array, items: { type: object, properties: { '@id': { type: string }, '@type': { type: string, example: DuplicateCommandResource }, command: { type: string, description: 'IRI of the duplicated command (absent when the duplication failed)' }, status: { type: integer }, message: { type: string } }, required: ['@id', '@type', status, message] } }
-              example:
-                '@context': /centreon/api/latest/contexts/Command
-                '@id': /centreon/api/latest/.well-known/genid/b69ebebaa3bb3de34dd8
-                '@type': Collection
-                totalItems: 2
-                member:
-                  - { '@id': /centreon/api/latest/.well-known/genid/c2afa2366f6f99491863, '@type': DuplicateCommandResource, command: /centreon/api/latest/configuration/commands/98, status: 204, message: 'Command duplicated successfully' }
-                  - { '@id': /centreon/api/latest/.well-known/genid/3fa305a034165257c384, '@type': DuplicateCommandResource, status: 404, message: 'Command with ID 99999 not found' }
-          links: {  }
-        '400':
-          description: 'Invalid input — the request body failed validation'
-          content:
+                description: 'Connector.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/Connector.jsonld' } } } }
             application/json:
               schema:
-                type: object
-                properties:
-                  code: { type: integer, example: 400 }
-                  message: { type: string, description: 'One line per violation, formatted as "[propertyPath] message"', example: "[ids] IDs array cannot be empty\n" }
-                required:
-                  - code
-                  - message
+                type: array
+                items:
+                  $ref: '#/components/schemas/Connector'
         '403':
-          description: 'You are not allowed to duplicate commands'
+          description: Forbidden
           content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
             application/json:
               schema:
-                type: object
-                properties:
-                  code: { type: integer, example: 0 }
-                  message: { type: string, example: 'You are not allowed to duplicate commands' }
-                required:
-                  - code
-                  - message
-      summary: 'Duplicate a Command resource'
-      description: 'Duplicate a Command resource'
-      parameters: []
-      requestBody:
-        description: 'The new Command resource'
-        content:
-          application/ld+json:
-            schema:
-              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DuplicateCommandResource.DuplicateCommandInput'
-        required: true
-  '/configuration/connectors/{id}':
-    summary: 'operations on a specific connector resource'
-    description: 'operations on a specific Connector resource'
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Retrieves the collection of Connector resources.'
+      description: 'Retrieves the collection of Connector resources.'
+      parameters:
+        -
+          name: 'id[lk]'
+          in: query
+          description: 'Filter by id using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: integer
+          style: form
+          explode: true
+        -
+          name: 'id[eq]'
+          in: query
+          description: 'Filter by id using "equals" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: integer
+          style: form
+          explode: true
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        -
+          name: 'name[eq]'
+          in: query
+          description: 'Filter by name using "equals" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
+  '/api/configuration/connectors/{id}':
     get:
       operationId: api_configurationconnectors_id_get
       tags:
@@ -5102,7 +4586,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
         '404':
           description: 'Not found'
           content:
@@ -5115,7 +4599,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
       summary: 'Retrieves a Connector resource.'
       description: 'Retrieves a Connector resource.'
       parameters:
@@ -5129,9 +4613,92 @@ paths:
             type: string
           style: simple
           explode: false
-  '/configuration/plugins/{plugin_name}':
-    summary: 'operations on a specific plugin resource'
-    description: 'operations on a specific plugin resource'
+  /api/configuration/global-macros:
+    get:
+      operationId: api_configurationglobal-macros_get_collection
+      tags:
+        - 'Global Macro'
+      responses:
+        '200':
+          description: 'GlobalMacro collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'GlobalMacro.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/GlobalMacro.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GlobalMacro'
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Retrieves the collection of GlobalMacro resources.'
+      description: 'Retrieves the collection of GlobalMacro resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        -
+          name: 'name[eq]'
+          in: query
+          description: 'Filter by name using "equals" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
+  '/api/configuration/plugins/{plugin_name}':
     get:
       operationId: api_configurationplugins_plugin_name_get
       tags:
@@ -5158,7 +4725,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
       summary: 'Retrieves a Plugin resource.'
       description: 'Retrieves a Plugin resource.'
       parameters:
@@ -5172,58 +4739,62 @@ paths:
             type: string
           style: simple
           explode: false
-  '/configuration/agent-configurations/installation-command/{pollerId}':
+  /api/configuration/plugins:
     get:
-      operationId: api_configurationagent-configurationsinstallation-command_pollerId_get
+      operationId: api_configurationplugins_get_collection
       tags:
-        - 'Agent Configuration'
+        - Plugins
       responses:
-        '404':
-          description: 'Poller not found'
-        '403':
-          description: 'You are not allowed to access this resource'
         '200':
-          description: 'InstallationCommandResource resource'
+          description: 'Plugins collection'
           content:
             application/ld+json:
               schema:
-                $ref: '#/components/schemas/InstallationCommandResource.jsonld'
+                type: object
+                description: 'Plugins.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/Plugins.jsonld' } } } }
             application/json:
               schema:
-                $ref: '#/components/schemas/InstallationCommandResource'
-      summary: 'Retrieves a InstallationCommandResource resource.'
-      description: 'Retrieves a InstallationCommandResource resource.'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Plugins'
+      summary: 'Retrieves the collection of Plugins resources.'
+      description: 'Retrieves the collection of Plugins resources.'
       parameters:
         -
-          name: pollerId
-          in: path
-          description: 'InstallationCommandResource identifier'
-          required: true
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
           deprecated: false
           schema:
-            type: string
-          style: simple
-          explode: false
-  /configuration/pollers:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
+  /api/configuration/pollers:
     post:
       operationId: api_configurationpollers_post
       tags:
         - Poller
       responses:
-        '409':
-          description: 'Poller resource already exists'
-        '201':
-          description: 'Poller resource created'
-          content:
-            application/ld+json:
-              schema:
-                $ref: '#/components/schemas/Poller.jsonld'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Poller'
-          links: {  }
         '400':
-          description: 'Invalid input'
+          description: 'Invalid input (e.g. unknown poller token name)'
           content:
             application/ld+json:
               schema:
@@ -5234,7 +4805,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
+        '409':
+          description: 'Poller resource already exists'
+        '503':
+          description: 'Engine secrets are not available'
+        '201':
+          description: 'Poller resource created'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Poller.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Poller'
+          links: {}
         '422':
           description: 'An error occurred'
           content:
@@ -5247,7 +4832,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConstraintViolation'
-          links: {  }
+          links: {}
         '403':
           description: Forbidden
           content:
@@ -5260,7 +4845,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
       summary: 'Creates a Poller resource.'
       description: 'Creates a Poller resource.'
       parameters: []
@@ -5306,7 +4891,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          links: {  }
+          links: {}
       summary: 'Retrieves the collection of Poller resources.'
       description: 'Retrieves the collection of Poller resources.'
       parameters:
@@ -5344,16 +4929,18 @@ paths:
             maximum: 30
           style: form
           explode: true
-  '/configuration/pollers/installation-command/{id}':
+  '/api/configuration/pollers/installation-command/{id}':
     get:
       operationId: api_configurationpollersinstallation-command_id_get
       tags:
         - Poller
       responses:
         '404':
-          description: 'Poller not found'
+          description: 'Poller or poller token not found'
         '403':
           description: 'You are not allowed to access this resource'
+        '503':
+          description: 'Engine secrets are not available'
         '200':
           description: 'InstallationCommandResource resource'
           content:
@@ -5386,6 +4973,319 @@ paths:
             type: integer
           style: simple
           explode: false
+  /api/configuration/services/categories:
+    post:
+      operationId: api_configurationservicescategories_post
+      tags:
+        - 'Service Category'
+      responses:
+        '409':
+          description: 'ServiceCategory resource already exists'
+        '201':
+          description: 'ServiceCategory resource created'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ServiceCategory.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceCategory'
+          links: {}
+        '400':
+          description: 'Invalid input'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+        '422':
+          description: 'An error occurred'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+          links: {}
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Creates a ServiceCategory resource.'
+      description: 'Creates a ServiceCategory resource.'
+      parameters: []
+      requestBody:
+        description: 'The new ServiceCategory resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/ServiceCategory'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServiceCategory'
+        required: true
+  /api/configuration/standard-macros:
+    get:
+      operationId: api_configurationstandard-macros_get_collection
+      tags:
+        - 'Standard Macro'
+      responses:
+        '200':
+          description: 'StandardMacro collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'StandardMacro.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/StandardMacro.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StandardMacro'
+      summary: 'Retrieves the collection of StandardMacro resources.'
+      description: 'Retrieves the collection of StandardMacro resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        -
+          name: 'name[eq]'
+          in: query
+          description: 'Filter by name using "equals" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
+  /api/platform/updates:
+    post:
+      operationId: api_platformupdates_post
+      tags:
+        - Upgrade
+      responses:
+        '204':
+          description: 'Upgrade resource created'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Upgrade.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upgrade'
+          links: {}
+        '400':
+          description: 'Invalid input'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+        '422':
+          description: 'An error occurred'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConstraintViolation'
+          links: {}
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Creates a Upgrade resource.'
+      description: 'Creates a Upgrade resource.'
+      parameters: []
+      requestBody:
+        description: 'The new Upgrade resource'
+        content:
+          application/ld+json:
+            schema:
+              $ref: '#/components/schemas/Upgrade'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Upgrade'
+        required: true
+  '/api/configuration/agent-configurations/installation-command/{pollerId}':
+    get:
+      operationId: api_configurationagent-configurationsinstallation-command_pollerId_get
+      tags:
+        - 'Agent Configuration'
+      responses:
+        '404':
+          description: 'Poller not found'
+        '403':
+          description: 'You are not allowed to access this resource'
+        '200':
+          description: 'InstallationCommandResource resource'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/InstallationCommandResource.jsonld'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstallationCommandResource'
+      summary: 'Retrieves a InstallationCommandResource resource.'
+      description: 'Retrieves a InstallationCommandResource resource.'
+      parameters:
+        -
+          name: pollerId
+          in: path
+          description: 'InstallationCommandResource identifier'
+          required: true
+          deprecated: false
+          schema:
+            type: string
+          style: simple
+          explode: false
+  /api/configuration/host_groups:
+    get:
+      operationId: api_configurationhost_groups_get_collection
+      tags:
+        - HostGroup
+      responses:
+        '200':
+          description: 'HostGroup collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'HostGroup.HostGroupCollectionOutput.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/HostGroup.HostGroupCollectionOutput.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HostGroup.HostGroupCollectionOutput'
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Retrieves the collection of HostGroup resources.'
+      description: 'Retrieves the collection of HostGroup resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by host group name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
 components:
   securitySchemes:
     Token:
@@ -6029,15 +5929,17 @@ components:
               default: true
             attempts:
               description: 'login attempts before blocking'
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               minimum: 1
               maximum: 10
               default: 5
             blocking_duration:
               description: 'blocking duration in seconds before new login attempt'
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               maximum: 604800
               default: 900
             password_expiration:
@@ -6049,23 +5951,23 @@ components:
               properties:
                 expiration_delay:
                   description: 'password expiration delay in seconds'
-                  type: integer
-                  nullable: true
+                  type: [integer, 'null']
                   minimum: 604800
                   maximum: 31557600
                   default: 15552000
                 excluded_users:
                   description: 'list of users without password expiration rule'
                   type: array
-                  items: { type: string, description: 'user login', nullable: false, example: admin, minLength: 1, maxLength: 255 }
+                  items: { type: string, description: 'user login', example: admin, minLength: 1, maxLength: 255 }
             can_reuse_passwords:
               description: 'is allowed or not to reuse a password among 3 last'
               type: boolean
               default: false
             delay_before_new_password:
               description: 'delay in seconds before a new password can be set'
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               minimum: 3600
               maximum: 604800
               default: 3600
@@ -6123,17 +6025,19 @@ components:
           type: boolean
           description: Logout
         logout_from_url:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Indicates the logout URL'
           example: 'https://idp/saml'
-          nullable: true
         auto_import:
           type: boolean
           description: 'Auto import user from external provider'
           example: true
         contact_template:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             id:
               type: integer
@@ -6144,15 +6048,17 @@ components:
               description: 'Contact template name'
               example: Default
         email_bind_attribute:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Email bind attribute'
           example: email
-          nullable: true
         fullname_bind_attribute:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Fullname bind attribute'
           example: name
-          nullable: true
         authentication_conditions:
           type: object
           required:
@@ -6180,7 +6086,6 @@ components:
               type: boolean
             attribute_path:
               type: string
-              nullable: false
               example: info.items.groups
             relations:
               type: array
@@ -6280,18 +6185,21 @@ components:
             description: 'IP address'
             example: 127.0.0.1
         login_header_attribute:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Header used to retrieve user's login"
           example: HTTP_AUTH_USER
         pattern_matching_login:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Pattern to search for in the login header attribute name'
           example: '/@.*/'
         pattern_replace_login:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'String that will replace the string defined in the Pattern match login (regex) field'
           example: '/@.*/'
     Comment.Resources:
@@ -6319,14 +6227,16 @@ components:
                 description: 'Resource ID'
                 example: 10
               parent:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 properties:
                   id: { type: integer, description: 'Parent resource ID', example: 17 }
               date:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 format: date-time
-                nullable: true
                 description: 'Date of the comment (ISO8601)'
               comment:
                 type: string
@@ -6474,8 +6384,9 @@ components:
           description: 'is active or not (enable/disable)'
           example: true
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'some comment'
     Configuration.Service.Category:
       type: object
@@ -6512,8 +6423,9 @@ components:
           description: 'is active or not (enable/disable)'
           example: true
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'some comment'
     Configuration.Service.Category.Add:
       type: object
@@ -6554,9 +6466,10 @@ components:
           description: 'Define the image ID associated with this severity'
           example: 1
         comment:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Host severity comment'
-          nullable: true
         is_activated:
           type: boolean
           description: 'Indicates whether this host severity is enabled or not'
@@ -6580,9 +6493,10 @@ components:
           description: 'Define the image ID associated with this severity'
           example: 1
         comment:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Host severity comment'
-          nullable: true
         is_activated:
           type: boolean
           description: 'Indicates whether this host severity is enabled or not'
@@ -6611,60 +6525,71 @@ components:
           description: 'Host template alias'
           example: generic-active-host
         snmp_community:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Community of the SNMP agent'
         snmp_version:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           enum:
             - '1'
             - 2c
             - '3'
+            - null
           description: |
             Version of the SNMP agent.
 
             The value can be `1`, `2c` or `3`
           example: 2c
         timezone_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Timezone ID'
           example: 1
-          nullable: true
         severity_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Severity ID'
           example: 1
-          nullable: true
         check_command_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Check command ID'
           example: 1
-          nullable: true
         check_command_args:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Check command arguments'
           example: '!0!OK'
-          nullable: true
         check_timeperiod_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Check command timeperiod ID'
           example: 1
-          nullable: true
         max_check_attempts:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Define the number of times that monitoring engine will retry the host check command if it returns any non-OK state'
         check_interval:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of 'time units' between regularly scheduled checks of the host.
 
             With the default time unit of 60s, this number will mean multiples of 1 minute.
         retry_check_interval:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -6712,8 +6637,9 @@ components:
             example: A value equal to 5 corresponding to the selected options DOWN and RECOVERY
           example: 5
         notification_interval:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -6721,10 +6647,11 @@ components:
 
             A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
         notification_timeperiod_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Notification timeperiod ID'
           example: 1
-          nullable: true
         add_inherited_contact_group:
           type: boolean
           description: |
@@ -6738,22 +6665,25 @@ components:
 
             When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
         first_notification_delay:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
             With the default time unit of 60s, this number will mean multiples of 1 minute.
         recovery_notification_delay:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: |
             Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
             With the default time unit of 60s, this number will mean multiples of 1 minute.
         acknowledgement_timeout:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify a duration of acknowledgement for this host.'
         freshness_checked:
           type: integer
@@ -6764,8 +6694,9 @@ components:
             * `1` - STATUS_ENABLE
             * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of the Centreon Engine)
         freshness_threshold:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify the freshness threshold (in seconds) for this host.'
         flap_detection_enabled:
           type: integer
@@ -6776,12 +6707,14 @@ components:
             * `1` - STATUS_ENABLE
             * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of the Centreon Engine)
         low_flap_threshold:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify the low state change threshold used in flap detection for this host'
         high_flap_threshold:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Specify the high state change threshold used in flap detection for this host'
         event_handler_enabled:
           type: integer
@@ -6792,43 +6725,51 @@ components:
             * `1` - STATUS_ENABLE
             * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of the Centreon Engine)
         event_handler_command_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Event handler command ID'
           example: 1
-          nullable: true
         event_handler_command_args:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Event handler command arguments'
           example: '!0!OK'
-          nullable: true
         note_url:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Define an optional URL that can be used to provide more information about the host.'
         note:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Define an optional note.'
         action_url:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Define an optional URL that can be used to provide more actions to be performed on the host.'
         icon_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'Define the image ID that should be associated with this host template'
           example: 1
         icon_alternative:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 200
           description: 'Define an optional string that is used in the alternative description of the icon image'
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Host template comments'
         is_activated:
           type: boolean
@@ -6852,20 +6793,23 @@ components:
           description: 'Service group name'
           example: MySQL-Servers
         alias:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 200
           description: 'Service group alias'
           example: 'All MySQL Servers'
         geo_coords:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 32
           description: 'Geographical coordinates use by Centreon Map module to position element on map'
           example: '48.51,2.20'
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Comments on this service group'
         is_activated:
@@ -6927,8 +6871,9 @@ components:
           maxLength: 255
           description: 'Image path'
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           maxLength: 65535
           description: 'Image comments'
     User.Filter:
@@ -7154,23 +7099,26 @@ components:
           description: 'Name of the server'
           example: Central
         address:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'IP address of the server'
           example: 127.0.0.1
-          nullable: true
         isRunning:
           type: boolean
           description: 'Indicates if the server is running or not'
           example: true
         lastAlive:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: 'Timestamp of last time server was alive'
-          nullable: true
         version:
-          type: string
+          type:
+            - string
+            - 'null'
           description: 'Version of the server (centreon-engine)'
           example: 20.10.0
-          nullable: true
     Monitoring.Category:
       type: object
       properties:
@@ -7240,8 +7188,9 @@ components:
           items:
             $ref: '#/components/schemas/Monitoring.Resource.Action'
     Acknowledgement.Host:
-      type: object
-      nullable: true
+      type:
+        - object
+        - 'null'
       properties:
         id:
           type: integer
@@ -7262,9 +7211,10 @@ components:
           description: 'Short description of the acknowledgement'
           example: 'Acknowledged by admin'
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of the request for cancellation of the acknowledgement (ISO8601)'
         entry_time:
           type: string
@@ -7301,14 +7251,16 @@ components:
              * `3` - UNKNOWN
           example: 1
     Acknowledgement.Service:
-      type: object
-      nullable: true
+      type:
+        - object
+        - 'null'
       allOf:
         -
           $ref: '#/components/schemas/Acknowledgement.Host'
         -
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             service_id:
               type: integer
@@ -7451,9 +7403,10 @@ components:
           format: date-time
           description: 'Scheduled end date of the downtime (ISO8601)'
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of cancellation of downtime (ISO8601)'
           example: null
         actual_start_time:
@@ -7579,8 +7532,9 @@ components:
                 description: 'Resource ID'
                 example: 10
               parent:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 properties:
                   id: { type: integer, description: 'Parent resource ID', example: 17 }
     SubmitResult.Host:
@@ -7601,13 +7555,15 @@ components:
             * `2` - UNREACHABLE
           example: 1
         output:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Output result of the check sent'
           example: 'CRITICAL: Connection lost'
         performance_data:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Performance data result of the check sent'
           example: "'nbproc'=0;;1:1;0;"
     SubmitResult.Service:
@@ -7630,13 +7586,15 @@ components:
             * `3` - UNKNOWN
           example: 2
         output:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Output result of the check sent'
           example: 'CRITICAL: Memory exceeded '
         performance_data:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Performance data result of the check sent'
           example: "'used'=453849088B;;;0;1927262208"
     SubmitResult.Resources:
@@ -7665,8 +7623,9 @@ components:
                 description: 'Resource ID'
                 example: 10
               parent:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 properties:
                   id: { type: integer, description: 'Parent resource ID', example: 17 }
               status:
@@ -7684,13 +7643,15 @@ components:
                   * `3` - UNKNOWN
                 example: 2
               output:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: 'Output result of the check sent'
                 example: 'CRITICAL: Memory exceeded '
               performance_data:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: 'Performance data result of the check sent'
                 example: "'used'=453849088B;;;0;1927262208"
     Monitoring.Resource.Action:
@@ -7706,8 +7667,9 @@ components:
           description: 'ID of the resource'
           example: 12
         parent:
-          nullable: true
-          type: object
+          type:
+            - object
+            - 'null'
           properties:
             id:
               type: integer
@@ -7740,8 +7702,9 @@ components:
           description: 'ID of the host behind the resource'
           example: 12
         service_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           format: int32
           description: 'ID of the service behind the resource'
           example: 12
@@ -7750,13 +7713,15 @@ components:
           description: 'Resource name'
           example: Ping
         alias:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Resource alias'
           example: null
         fqdn:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Resource fqdn'
           example: null
         links:
@@ -7766,8 +7731,9 @@ components:
           description: 'Monitoring Server from which is monitored the Resource'
           example: Central
         icon:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             id:
               type: integer
@@ -7783,8 +7749,9 @@ components:
               description: 'Url of the icon'
               example: /media/memory.png
         parent:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             type:
               type: string
@@ -7804,8 +7771,9 @@ components:
               description: 'Parent resource name'
               example: Central
             alias:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Parent resource alias'
               example: Host
             fqdn:
@@ -7827,48 +7795,57 @@ components:
           description: 'Indicates whether resource is acknowledged'
           example: false
         duration:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Duration since last status change'
           example: '2h 3m'
         last_status_change:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of the last status change (ISO8601)'
         last_time_with_no_issue:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'Date of the last status change (ISO8601)'
         tries:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Number of check tries'
           example: '3/3 (H)'
         last_check:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Duration since last check'
           example: '1h 45m'
         information:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Output of the resource'
           example: 'OK - Ping is ok'
         has_active_checks_enabled:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: 'Indicates whether active checks are enabled'
           example: true
         has_passive_checks_enabled:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: 'Indicates whether passive checks are enabled'
           example: true
         performance_data:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Performance data result of the check sent'
           example: 'rta=0.025ms;200.000;400.000;0; rtmax=0.061ms;;;; rtmin=0.015ms;;;; pl=0%;20;50;0;100 '
         is_notification_enabled:
@@ -7876,8 +7853,9 @@ components:
           description: 'Indicates if notifications are enabled for the resource'
           example: false
         severity:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           properties:
             type:
               type: string
@@ -7917,95 +7895,112 @@ components:
           type: object
           properties:
             configuration:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'configuration uri'
               example: '/centreon/main.php?p=60101&o=c&host_id=11'
             logs:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'logs uri'
               example: '/centreon/main.php?p=20301&h=11'
             reporting:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'reporting uri'
               example: '/centreon/main.php?p=307&host=11'
         endpoints:
           type: object
           properties:
             details:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource details endpoint'
               example: /centreon/api/latest/monitoring/resources/hosts/11
             timeline:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource timeline endpoint'
               example: /centreon/api/latest/monitoring/hosts/11/timeline
             status_graph:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource status graph endpoint'
               example: null
             performance_graph:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'resource performance graph endpoint'
               example: null
             acknowledgement:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'current resource acknowledgement endpoint'
               example: '/centreon/api/latest/monitoring/hosts/11/acknowledgements?limit=1'
             downtime:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'current resource downtimes endpoint'
               example: '/centreon/api/latest/monitoring/hosts/11/downtimes?search=%7B%22%24and%22:%5B%7B%22start_time%22:%7B%22%24lt%22:1599655905%7D,%22end_time%22:%7B%22%24gt%22:1599655905%7D,%220%22:%7B%22%24or%22:%7B%22is_cancelled%22:%7B%22%24neq%22:1%7D,%22deletion_time%22:%7B%22%24gt%22:1599655905%7D%7D%7D%7D%5D%7D'
             notification_policy:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'current resource notification policy endpoint'
               example: /centreon/api/latest/configurations/hosts/11/notification-policy
             check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Endpoint dedicated for checks (forced_check payload entry set to false)'
               example: /centreon/api/latest/monitoring/hosts/17/services/23/check
             forced_check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Endpoint dedicated for checks (forced_check payload entry set to true)'
               example: /centreon/api/latest/monitoring/hosts/17/services/23/check
             metrics:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Endpoint dedicated for service metrics'
               example: /centreon/api/latest/monitoring/hosts/17/services/23/metrics
         externals:
           type: object
           properties:
             action_url:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'URL that can be used to provide more actions to be performed on the resource'
               example: 'http://mediawiki/resource/name'
             notes:
               $ref: '#/components/schemas/Monitoring.Notes'
     Monitoring.Notes:
-      type: object
-      nullable: true
+      type:
+        - object
+        - 'null'
       properties:
         url:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'URL that can be used to provide more information on the resource'
           example: 'http://mediawiki/resource/name'
         label:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Note that can be used to describe the note url'
           example: 'How to turn back on the server'
     Monitoring.ResourceStatus:
@@ -8123,13 +8118,15 @@ components:
                   * `1` - Passive
               example: 0
             last_hard_state:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Date of the last hard state (ISO8601)'
             last_notification:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Date of the last notification (ISO8601)'
             latency:
@@ -8138,8 +8135,9 @@ components:
               description: 'Time difference between scheduled check time and actual check time'
               example: 0.005
             next_check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Scheduled date for the next check (ISO8601)'
             next_host_notification:
@@ -8228,9 +8226,10 @@ components:
               description: 'Indicates whether the host is checked'
               example: true
             execution_time:
-              type: number
+              type:
+                - number
+                - 'null'
               format: float
-              nullable: true
               description: 'Time duration to check the host'
               example: 0.070906
             icon_image:
@@ -8242,39 +8241,46 @@ components:
               description: 'Alternative text of the icon representing the host'
               example: ''
             last_check:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of last check (ISO8601)'
             last_hard_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last hard state change (ISO8601)'
             last_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last state change (soft or hard) (ISO8601)'
             last_time_down:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the host was DOWN (ISO8601)'
             last_time_unreachable:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the host was UNREACHABLE (ISO8601)'
             last_time_up:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the host was UP (ISO8601)'
             last_update:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of last update (ISO8601)'
             max_check_attempts:
               type: integer
@@ -8306,8 +8312,9 @@ components:
               description: 'Is there scheduled downtime for host or not (1 or 0)'
               example: 0
             criticality:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               description: 'Host criticality level (for display purposes)'
               example: 10
     Monitoring.HostWithService:
@@ -8410,14 +8417,16 @@ components:
               description: 'Alternative text of the icon representing the service'
               example: ''
             last_check:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of last check (ISO8601)'
             last_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last state change (ISO8601)'
             max_check_attempts:
               type: integer
@@ -8436,15 +8445,17 @@ components:
                   * `1` - HARD
               example: 1
             criticality:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               description: 'Service criticality level (for display purposes)'
               example: 10
             status:
               $ref: '#/components/schemas/Monitoring.ResourceStatus'
             duration:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Duration since last status change'
               example: '2h 3m'
     Monitoring.ServiceFull:
@@ -8475,8 +8486,9 @@ components:
                   * `1` - Passive
               example: 0
             command_line:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               description: 'Command used for active checks'
               example: '/usr/lib64/nagios/plugins/check_icmp -H 127.0.0.1 -n 5 -w 200,20% -c 400,50%'
             execution_time:
@@ -8497,39 +8509,46 @@ components:
               description: 'Indicates whether the service has been checked'
               example: true
             last_hard_state_change:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last hard state change (ISO8601)'
             last_notification:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last notification (ISO8601)'
             last_time_critical:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was CRITICAL (ISO8601)'
             last_time_ok:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was OK (ISO8601)'
             last_time_unknown:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was UNKNOWN (ISO8601)'
             last_time_warning:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'The last time the service was WARNING (ISO8601)'
             last_update:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
               description: 'Date of the last update (ISO8601)'
             latency:
               type: number
@@ -8537,8 +8556,9 @@ components:
               description: 'Time difference between scheduled check time and actual check time'
               example: 0.031
             next_check:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               format: date-time
               description: 'Scheduled date for the next check (ISO8601)'
             performance_data:
@@ -8557,8 +8577,9 @@ components:
               allOf:
                 -
                   $ref: '#/components/schemas/Acknowledgement.Service'
-              type: object
-              nullable: true
+              type:
+                - object
+                - 'null'
             flapping:
               type: boolean
               description: 'Is the host flapping or not'
@@ -8581,9 +8602,10 @@ components:
           description: 'ID of the resource'
           example: 12
         parent_resource_id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           format: int64
-          nullable: true
           description: 'ID of the parent resource (eg: host id)'
           example: 5
     Configuration.Proxy:
@@ -8600,13 +8622,15 @@ components:
           maximum: 65535
           example: 3128
         user:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Login used to connect to proxy'
           example: proxy-user
         password:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: 'Password used to connect to proxy'
           example: proxy-pass
       required:
@@ -8636,26 +8660,30 @@ components:
           format: date-time
           description: 'The date the event happened (ISO8601)'
         start_date:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'The date the event started (ISO8601) (start date of downtime)'
         end_date:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: 'The date the event ended (ISO8601) (end date of downtime)'
         content:
           type: string
           description: 'The content of the event'
         contact:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: 'The contact of the event'
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               description: 'Id of the contact'
             name:
               type: string
@@ -8663,8 +8691,9 @@ components:
         status:
           $ref: '#/components/schemas/Monitoring.ResourceStatus'
         tries:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: 'The count of retry'
     Topology.Register:
       type: object
@@ -8753,23 +8782,27 @@ components:
           type: object
           properties:
             host:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               example: example.proxy.com
               description: 'Host of your proxy'
             port:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
               example: 80
               description: 'Proxy port'
             user:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               example: admin
               description: 'proxy username'
             password:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
               example: centreon
               description: 'proxy password'
     Gorgone.Response:
@@ -8842,12 +8875,14 @@ components:
           type: string
         title:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         instance:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     ConstraintViolation.jsonld-jsonld:
       type: object
       description: 'Unprocessable entity'
@@ -8902,37 +8937,43 @@ components:
           type: string
         title:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         instance:
           readOnly: true
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Error:
       type: object
       description: 'A representation of common errors.'
       properties:
         title:
-          type: string
           readOnly: true
           description: 'A short, human-readable summary of the problem.'
-          nullable: true
+          type:
+            - string
+            - 'null'
         detail:
-          type: string
           readOnly: true
           description: 'A human-readable explanation specific to this occurrence of the problem.'
-          nullable: true
+          type:
+            - string
+            - 'null'
         status:
-          type: number
-          default: 400
-          example:
+          type:
+            - integer
+            - 'null'
+          examples:
             - 404
-          nullable: true
+          default: 400
         instance:
-          type: string
           readOnly: true
           description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.'
-          nullable: true
+          type:
+            - string
+            - 'null'
         type:
           readOnly: true
           description: 'A URI reference that identifies the problem type'
@@ -8947,31 +8988,37 @@ components:
             title:
               readOnly: true
               description: 'A short, human-readable summary of the problem.'
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             detail:
               readOnly: true
               description: 'A human-readable explanation specific to this occurrence of the problem.'
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             status:
-              type: number
-              example: 404
+              type:
+                - integer
+                - 'null'
+              examples:
+                - 404
               default: 400
-              nullable: true
             instance:
               readOnly: true
               description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.'
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             type:
               readOnly: true
               description: 'A URI reference that identifies the problem type'
               type: string
             description:
               readOnly: true
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
       description: 'A representation of common errors.'
     GlobalMacroResource:
       type: object
@@ -8979,28 +9026,32 @@ components:
       deprecated: false
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: $USER1$
         expression:
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
         comment:
           maxLength: 255
           description: 'Additional information about the macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
         is_password:
           type: boolean
@@ -9021,28 +9072,32 @@ components:
           readOnly: true
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: $USER1$
         expression:
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
         comment:
           maxLength: 255
           description: 'Additional information about the macro'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
         is_password:
           type: boolean
@@ -9061,8 +9116,9 @@ components:
         name:
           maxLength: 255
           description: 'Name of plugin'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: negate
     ListPlugins.jsonld:
       type: object
@@ -9080,8 +9136,9 @@ components:
         name:
           maxLength: 255
           description: 'Name of plugin'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: negate
     ServiceCategory:
       type: object
@@ -9095,8 +9152,9 @@ components:
           maxLength: 255
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         is_activated:
           type: boolean
     ServiceCategory.jsonld:
@@ -9115,8 +9173,9 @@ components:
               maxLength: 255
               type: string
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             is_activated:
               type: boolean
     StandardMacroResource:
@@ -9125,11 +9184,13 @@ components:
       deprecated: false
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     StandardMacroResource.jsonld:
       type: object
       description: ''
@@ -9142,11 +9203,13 @@ components:
           readOnly: true
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Command:
       type: object
       properties:
@@ -9195,10 +9258,11 @@ components:
             id: 1
             name: 'SSH Connector'
         comment:
-          type: string
           description: 'Additional information about the command'
+          type:
+            - string
+            - 'null'
           example: 'This command is used to check the HTTP service'
-          nullable: true
     Command.DuplicateCommandInput:
       type: object
       description: ''
@@ -9274,9 +9338,10 @@ components:
                 name: 'SSH Connector'
             comment:
               description: 'Additional information about the command'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This command is used to check the HTTP service'
-              nullable: true
     Connector:
       type: object
       properties:
@@ -9291,10 +9356,11 @@ components:
           type: string
           example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
         description:
-          type: string
           description: 'The connector description'
+          type:
+            - string
+            - 'null'
           example: 'Connector using SSH to connect to remote hosts'
-          nullable: true
         is_activated:
           description: 'Indicates whether the connector is activated'
           type: boolean
@@ -9318,9 +9384,10 @@ components:
               example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
             description:
               description: 'The connector description'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'Connector using SSH to connect to remote hosts'
-              nullable: true
             is_activated:
               description: 'Indicates whether the connector is activated'
               type: boolean
@@ -9342,8 +9409,9 @@ components:
           example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
         description:
           description: 'The connector description'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'Connector using SSH to connect to remote hosts'
         is_activated:
           description: 'Indicates whether the connector is activated'
@@ -9372,8 +9440,9 @@ components:
           example: 'centreon_connector_ssh --log-file=/var/log/centreon-engine/connector-ssh.log'
         description:
           description: 'The connector description'
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           example: 'Connector using SSH to connect to remote hosts'
         is_activated:
           description: 'Indicates whether the connector is activated'
@@ -9391,10 +9460,11 @@ components:
           type: string
           example: /usr/lib64/nagios/plugins/negate
         description:
-          type: string
           description: 'description of plugin'
+          type:
+            - string
+            - 'null'
           example: 'This is the help description of the plugin.'
-          nullable: true
     Plugin.jsonld:
       allOf:
         -
@@ -9412,9 +9482,10 @@ components:
               example: /usr/lib64/nagios/plugins/negate
             description:
               description: 'description of plugin'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This is the help description of the plugin.'
-              nullable: true
     Command.jsonMergePatch:
       type: object
       properties:
@@ -9463,10 +9534,11 @@ components:
             id: 1
             name: 'SSH Connector'
         comment:
-          type: string
           description: 'Additional information about the command'
+          type:
+            - string
+            - 'null'
           example: 'This command is used to check the HTTP service'
-          nullable: true
     ConstraintViolation:
       type: object
       description: 'Unprocessable entity'
@@ -9505,13 +9577,15 @@ components:
           readOnly: true
           type: string
         title:
-          type: string
           readOnly: true
-          nullable: true
+          type:
+            - string
+            - 'null'
         instance:
-          type: string
           readOnly: true
-          nullable: true
+          type:
+            - string
+            - 'null'
     ConstraintViolation.jsonld:
       allOf:
         -
@@ -9546,12 +9620,14 @@ components:
               type: string
             title:
               readOnly: true
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             instance:
               readOnly: true
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
       description: 'Unprocessable entity'
     CreateCommandResource:
       type: object
@@ -9582,15 +9658,17 @@ components:
           description: 'Indicates whether the command can be executed through a shell'
           type: boolean
         connector:
-          type: string
+          type:
+            - string
+            - 'null'
           format: iri-reference
           example: 'https://example.com/'
-          nullable: true
         comment:
-          type: string
           description: 'Additional information about the command'
+          type:
+            - string
+            - 'null'
           example: 'This command is used to check the HTTP service'
-          nullable: true
     CreateCommandResource.jsonld:
       allOf:
         -
@@ -9624,23 +9702,26 @@ components:
               description: 'Indicates whether the command can be executed through a shell'
               type: boolean
             connector:
-              type: string
+              type:
+                - string
+                - 'null'
               format: iri-reference
               example: 'https://example.com/'
-              nullable: true
             comment:
               description: 'Additional information about the command'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This command is used to check the HTTP service'
-              nullable: true
     DuplicateCommandResource:
       type: object
       properties:
         command:
-          type: string
+          type:
+            - string
+            - 'null'
           format: iri-reference
           example: 'https://example.com/'
-          nullable: true
         status:
           description: 'The status of the duplication operation'
           type: integer
@@ -9666,10 +9747,11 @@ components:
           type: object
           properties:
             command:
-              type: string
+              type:
+                - string
+                - 'null'
               format: iri-reference
               example: 'https://example.com/'
-              nullable: true
             status:
               description: 'The status of the duplication operation'
               type: integer
@@ -9682,29 +9764,33 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
-          type: string
+          type:
+            - string
+            - 'null'
           example: $USER1$
-          nullable: true
         expression:
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
-          type: string
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
-          nullable: true
         comment:
           maxLength: 255
           description: 'Additional information about the macro'
-          type: string
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
-          nullable: true
         is_password:
           type: boolean
         is_activated:
@@ -9720,29 +9806,33 @@ components:
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
               minLength: 1
               maxLength: 255
               pattern: '^(\$.*\$)$'
               description: 'Name of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: $USER1$
-              nullable: true
             expression:
               minLength: 1
               maxLength: 255
               description: 'Expression (value) of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: /usr/lib64/nagios/plugins
-              nullable: true
             comment:
               maxLength: 255
               description: 'Additional information about the macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This macro is used to define the path of plugins'
-              nullable: true
             is_password:
               type: boolean
             is_activated:
@@ -9766,16 +9856,16 @@ components:
                 '@type':
                   type: string
                 first:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 last:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 previous:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
                 next:
-                  type: string
+                  type: [string, 'null']
                   format: iri-reference
               example:
                 '@id': string
@@ -9806,7 +9896,7 @@ components:
                 properties:
                   '@type': { type: string }
                   variable: { type: string }
-                  property: { type: string, nullable: true }
+                  property: { type: [string, 'null'] }
                   required: { type: boolean }
     HydraItemBaseSchema:
       type: object
@@ -9958,11 +10048,12 @@ components:
         - name
       properties:
         name:
-          type: string
           maxLength: 255
           description: 'Name of plugin'
+          type:
+            - string
+            - 'null'
           example: negate
-          nullable: true
     Plugins.jsonld:
       allOf:
         -
@@ -9975,9 +10066,10 @@ components:
             name:
               maxLength: 255
               description: 'Name of plugin'
-              type: string
+              type:
+                - string
+                - 'null'
               example: negate
-              nullable: true
     Service.Category:
       type: object
       properties:
@@ -9990,8 +10082,9 @@ components:
           maxLength: 255
           type: string
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         is_activated:
           type: boolean
     Service.Category.jsonld:
@@ -10010,19 +10103,22 @@ components:
               maxLength: 255
               type: string
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             is_activated:
               type: boolean
     Standard.Macro:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Standard.Macro.jsonld:
       allOf:
         -
@@ -10031,38 +10127,44 @@ components:
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
     GlobalMacro:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
           minLength: 1
           maxLength: 255
           pattern: '^(\$.*\$)$'
           description: 'Name of the global macro'
+          type:
+            - string
+            - 'null'
           example: $USER1$
-          nullable: true
         expression:
-          type: string
           minLength: 1
           maxLength: 255
           description: 'Expression (value) of the global macro'
+          type:
+            - string
+            - 'null'
           example: /usr/lib64/nagios/plugins
-          nullable: true
         comment:
-          type: string
           maxLength: 255
           description: 'Additional information about the macro'
+          type:
+            - string
+            - 'null'
           example: 'This macro is used to define the path of plugins'
-          nullable: true
         is_password:
           type: boolean
         is_activated:
@@ -10078,29 +10180,33 @@ components:
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
               minLength: 1
               maxLength: 255
               pattern: '^(\$.*\$)$'
               description: 'Name of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: $USER1$
-              nullable: true
             expression:
               minLength: 1
               maxLength: 255
               description: 'Expression (value) of the global macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: /usr/lib64/nagios/plugins
-              nullable: true
             comment:
               maxLength: 255
               description: 'Additional information about the macro'
-              type: string
+              type:
+                - string
+                - 'null'
               example: 'This macro is used to define the path of plugins'
-              nullable: true
             is_password:
               type: boolean
             is_activated:
@@ -10125,14 +10231,17 @@ components:
           maxLength: 255
           type: string
         central_address:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         uid:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     Poller-poller.write:
       type: object
       properties:
@@ -10174,23 +10283,28 @@ components:
               maxLength: 255
               type: string
             central_address:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             uid:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
     StandardMacro:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     StandardMacro.jsonld:
       allOf:
         -
@@ -10199,11 +10313,13 @@ components:
           type: object
           properties:
             id:
-              type: integer
-              nullable: true
+              type:
+                - integer
+                - 'null'
             name:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
     Upgrade:
       type: object
     Upgrade.jsonld:
@@ -10222,18 +10338,18 @@ components:
         address:
           type: string
         central_address:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         id:
           type: integer
-          nullable: true
         uid:
           type: string
-          nullable: true
+        gorgone_communication_type:
+          type: string
         installation_command:
           type: string
-          example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
-          nullable: true
+          example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.CreatePollerInput:
       type: object
       properties:
@@ -10249,6 +10365,7 @@ components:
         address:
           minLength: 1
           maxLength: 255
+          pattern: '^(((?!://).)*)$'
           type: string
         poller_token_name:
           minLength: 1
@@ -10257,8 +10374,10 @@ components:
         central_address:
           minLength: 1
           maxLength: 255
+          pattern: '^(((?!://).)*)$'
           type: string
       required:
+        - address
         - poller_token_name
         - central_address
     Poller.InstallationCommandResource:
@@ -10267,7 +10386,7 @@ components:
         installation_command:
           description: 'Poller Installation Command'
           type: string
-          example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+          example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.InstallationCommandResource.jsonld:
       allOf:
         -
@@ -10278,7 +10397,7 @@ components:
             installation_command:
               description: 'Poller Installation Command'
               type: string
-              example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+              example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
     Poller.jsonld:
       allOf:
         -
@@ -10293,26 +10412,26 @@ components:
             address:
               type: string
             central_address:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
             id:
               type: integer
-              nullable: true
             uid:
               type: string
-              nullable: true
+            gorgone_communication_type:
+              type: string
             installation_command:
               type: string
-              example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
-              nullable: true
-    Poller.PollerCollectionOutput:
+              example: 'curl -fsSL <central_url>/poller/install.sh | bash -s -- --poller_token <token_name>:<token_value> --uid <uid> --name <name> --type <vm|docker> --central_url <central_url> --appsecret <app_secret> --salt <salt>'
+    HostGroup.HostGroupCollectionOutput:
       type: object
       properties:
         id:
           type: integer
         name:
           type: string
-    Poller.PollerCollectionOutput.jsonld:
+    HostGroup.HostGroupCollectionOutput.jsonld:
       allOf:
         -
           $ref: '#/components/schemas/HydraItemBaseSchema'
@@ -10323,14 +10442,14 @@ components:
               type: integer
             name:
               type: string
-    HostGroup.HostGroupCollectionOutput:
+    Poller.PollerCollectionOutput:
       type: object
       properties:
         id:
           type: integer
         name:
           type: string
-    HostGroup.HostGroupCollectionOutput.jsonld:
+    Poller.PollerCollectionOutput.jsonld:
       allOf:
         -
           $ref: '#/components/schemas/HydraItemBaseSchema'

--- a/centreon/doc/API/centreon-cloud-api.yaml
+++ b/centreon/doc/API/centreon-cloud-api.yaml
@@ -1,6 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Centreon Web RestAPI for Cloud
+  version: '25.10'
   description: |
 
     <blockquote style="
@@ -37,7 +38,7 @@ externalDocs:
   description: You can contact us on our community platform The Watch
   url: 'https://thewatch.centreon.com/'
 servers:
-  - url: '{protocol}://{server}:{port}/centreon/api/{version}'
+  - url: '{protocol}://{server}:{port}/centreon'
     variables:
       protocol:
         enum:
@@ -51,9 +52,6 @@ servers:
       port:
         default: '80'
         description: "Port used by HTTP server"
-      version:
-        default: latest
-        description: "Version of the API"
 tags:
   - name: Host
   - name: Host group
@@ -62,44 +60,68 @@ tags:
   - name: Resource Access Management
   - name: Service
   - name: Service template
+security:
+  -
+    Token: []
+  -
+    Cookie: []
 paths:
-  /administration/resource-access/rules:
+  /api/latest/administration/resource-access/rules:
     $ref: "./latest/Cloud/Administration/ResourceAccessManagement/AddAndFindRules.yaml"
-  /administration/resource-access/rules/{rule_id}:
+  /api/latest/administration/resource-access/rules/{rule_id}:
     $ref: "./latest/Cloud/Administration/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml"
-  /administration/resource-access/rules/_delete:
+  /api/latest/administration/resource-access/rules/_delete:
     $ref: "./latest/Cloud/Administration/ResourceAccessManagement/DeleteRules.yaml"
-  /configuration/hosts:
+  /api/latest/configuration/hosts:
     $ref: './latest/Cloud/Configuration/Host/AddAndFindHosts.yaml'
-  /configuration/hosts/{host_id}:
+  /api/latest/configuration/hosts/{host_id}:
     $ref: './latest/Cloud/Configuration/Host/GetAndPartialUpdateHost.yaml'
-  /configuration/hosts/groups:
+  /api/latest/configuration/hosts/groups:
     $ref: './latest/Cloud/Configuration/HostGroup/AddAndFindHostGroups.yaml'
-  /configuration/hosts/groups/{hostgroup_id}:
+  /api/latest/configuration/hosts/groups/{hostgroup_id}:
     $ref: './latest/Cloud/Configuration/HostGroup/GetAndUpdateHostGroup.yaml'
-  /configuration/hosts/templates:
+  /api/latest/configuration/hosts/templates:
     $ref: './latest/Cloud/Configuration/HostTemplate/AddAndFindHostTemplates.yaml'
-  /configuration/hosts/templates/{host_template_id}:
+  /api/latest/configuration/hosts/templates/{host_template_id}:
     $ref: './latest/Cloud/Configuration/HostTemplate/GetAndPartialUpdateHostTemplate.yaml'
-  /configuration/hosts/{host_id}/services/deploy:
+  /api/latest/configuration/hosts/{host_id}/services/deploy:
     $ref: './latest/Cloud/Configuration/Service/DeployServices.yaml'
-  /configuration/services:
+  /api/latest/configuration/services:
     $ref: "./latest/Cloud/Configuration/Service/AddAndFindServices.yaml"
-  /configuration/services/{service_id}:
+  /api/latest/configuration/services/{service_id}:
     $ref: "./latest/Cloud/Configuration/Service/GetAndPartialUpdateService.yaml"
-  /configuration/services/templates:
+  /api/latest/configuration/services/templates:
     $ref: "./latest/Cloud/Configuration/ServiceTemplate/AddAndFindServiceTemplates.yaml"
-  /configuration/services/templates/{service_template_id}:
+  /api/latest/configuration/services/templates/{service_template_id}:
     $ref: "./latest/Cloud/Configuration/ServiceTemplate/PartialUpdateServiceTemplate.yaml"
-  /configuration/notifications:
+  /api/latest/configuration/notifications:
     $ref: "./latest/Cloud/Configuration/Notification/Notifications.yaml"
-  /configuration/notifications/_delete:
+  /api/latest/configuration/notifications/_delete:
     $ref: "./latest/Cloud/Configuration/Notification/DeleteNotifications.yaml"
-  /configuration/notifications/{notification_id}:
+  /api/latest/configuration/notifications/{notification_id}:
     $ref: "./latest/Cloud/Configuration/Notification/Notification.yaml"
-  /configuration/notifications/resources:
+  /api/latest/configuration/notifications/resources:
     $ref: "./latest/Cloud/Configuration/Notification/FindNotifiableResources.yaml"
-  /configuration/notifications/{notification_id}/rules:
+  /api/latest/configuration/notifications/{notification_id}/rules:
     $ref: "./latest/Cloud/Configuration/Notification/FindNotifiableRule.yaml"
-  /configuration/notifications/contact_groups:
+  /api/latest/configuration/notifications/contact_groups:
     $ref: "./latest/Cloud/Configuration/Notification/FindNotifiableContactGroups.yaml"
+components:
+  securitySchemes:
+    Token:
+      description: |
+        The use of the API requires a security token.
+
+        To retrieve it, you will need to authenticate yourself with your login credentials.
+
+        The token will be deleted if it has not been used for more than one hour.
+      type: apiKey
+      name: X-AUTH-TOKEN
+      in: header
+    Cookie:
+      description: |
+        If you have already connected on the Centreon web application, you can reused the PHPSESSID cookie.
+        The cookie will be valid as long as the connection to Centreon is maintained.
+      type: apiKey
+      name: PHPSESSID
+      in: cookie

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddOrUpdateRuleRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddOrUpdateRuleRequest.yaml
@@ -32,8 +32,9 @@ properties:
           description: "Indicates that the rule should be applied to all current / future contact groups"
           example: true
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Short description of the rule"
     example: "Rule dedicated for users with limited rights"
   is_enabled:

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddRuleResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/AddRuleResponse.yaml
@@ -32,8 +32,9 @@ properties:
           description: "Indicates that the rule should be applied to all current / future contact groups"
           example: true
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Short description of the rule"
     example: "Rule dedicated for users with limited rights"
   is_enabled:

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilter.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilter.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - object
+  - 'null'
 properties:
   type:
     type: string

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilterWithNames.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/DatasetFilterWithNames.yaml
@@ -1,5 +1,6 @@
-type: object
-nullable: true
+type:
+  - object
+  - 'null'
 properties:
   type:
     type: string

--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
@@ -5,8 +5,9 @@ properties:
     description: "Resource access rule name"
     example: "Rule for viewers"
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Short description of the rule"
     example: "Rule dedicated for users with limited rights"
   is_enabled:

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostRequest.yaml
@@ -18,38 +18,44 @@ properties:
     description: "Host alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -57,24 +63,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -83,28 +93,33 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether the host is activated or not"
   categories:
     type: array
@@ -137,17 +152,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -159,7 +176,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostResponse.yaml
@@ -17,43 +17,50 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host alias"
     example: "generic-active-host"
-    nullable: true
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -61,24 +68,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -87,23 +98,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
@@ -165,8 +180,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -177,7 +193,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/FindHostsResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/FindHostsResponse.yaml
@@ -4,25 +4,20 @@ properties:
     type: integer
     description: "Host ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Host name"
     example: "Centreon-Server"
-    nullable: false
   alias:
     type: string
     description: "Host alias"
     example: ""
-    nullable: false
   address:
     type: string
     description: "IP or domain of the host"
     example: "127.0.0.1"
-    nullable: false
   monitoring_server:
     type: object
-    nullable: false
     properties:
       id:
         type: integer
@@ -47,15 +42,18 @@ properties:
           description: "Host template name"
           example: 'generic-host'
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
     default: 5
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -64,10 +62,10 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
     default: 1
-    nullable: true
   check_timeperiod:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -78,8 +76,9 @@ properties:
         description: "Check timeperiod name"
         example: "24x7"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -119,4 +118,3 @@ properties:
   is_activated:
     type: boolean
     description: "Indicates whether the host is activated or not"
-    nullable: false

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/GetHostResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/GetHostResponse.yaml
@@ -17,43 +17,50 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host alias"
     example: "generic-active-host"
-    nullable: true
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -61,24 +68,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -100,23 +111,27 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
@@ -178,8 +193,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -190,7 +206,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
@@ -17,38 +17,44 @@ properties:
     description: "Host alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -56,24 +62,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -90,33 +100,39 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   is_activated:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether the host is activated or not"
   categories:
     type: array
@@ -149,17 +165,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -171,7 +189,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
@@ -6,31 +6,36 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "ID of the hostgroup Icon"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host group comment"
     example: "This is a comment"
   hosts:
-    type: array
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
-    nullable: true
     example: [1, 2, 3]
     items:
       type: integer

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
@@ -10,19 +10,22 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host group"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
@@ -10,14 +10,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -34,8 +36,9 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
@@ -6,14 +6,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -30,8 +32,9 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
@@ -6,29 +6,34 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "ID of the host group icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host group comment"
     example: "This is a comment"
   hosts:
-    type: array
-    nullable: true
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
     example: [1, 2, 3]
     items:

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
@@ -10,33 +10,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -44,24 +49,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   nornal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -70,23 +79,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   categories:
@@ -114,17 +127,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -136,7 +151,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -13,33 +13,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -47,24 +52,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -73,23 +82,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   is_locked:
@@ -138,8 +151,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -150,7 +164,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
@@ -13,33 +13,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -47,24 +52,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -80,28 +89,33 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   is_locked:
@@ -150,8 +164,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -162,7 +177,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/HostTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/HostTemplate.yaml
@@ -13,47 +13,55 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -62,23 +70,27 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   is_locked:

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -12,17 +12,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -34,8 +36,9 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"
   categories:
@@ -64,33 +67,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ['1', '2c', '3']
+    type:
+      - string
+      - 'null'
+    enum: ['1', '2c', '3', null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -98,24 +106,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -132,27 +144,32 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableResources.Listing.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableResources.Listing.yaml
@@ -15,9 +15,10 @@ properties:
           type: string
           example: "Host 1"
         alias:
-          type: string
+          type:
+            - string
+            - 'null'
           example: "Host 1"
-          nullable: true
         event:
           type: integer
           description: "Bitmask representing host's status triggering a notification"
@@ -34,9 +35,10 @@ properties:
                 type: string
                 example: "Ping"
               alias:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 example: "Ping"
-                nullable: true
               event:
                 type: integer
                 description: "Bitmask representing service's status triggering a notification"

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableRule.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/Schema/NotifiableRule.yaml
@@ -7,8 +7,9 @@ properties:
     type: object
     properties:
       email:
-        type: object
-        nullable: true
+        type:
+          - object
+          - 'null'
         properties:
           contacts:
             type: array
@@ -28,8 +29,9 @@ properties:
             type: string
             example: "This is a formatted message"
       slack:
-        type: object
-        nullable: true
+        type:
+          - object
+          - 'null'
         properties:
           slack_channel:
             type: string
@@ -38,8 +40,9 @@ properties:
             type: string
             example: "This is a Slack message"
       sms:
-        type: object
-        nullable: true
+        type:
+          - object
+          - 'null'
         properties:
           phone_number:
             type: string

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceRequest.yaml
@@ -9,8 +9,9 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   service_template_id:
@@ -19,16 +20,18 @@ properties:
     minimum: 1
     example: null
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -37,18 +40,22 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -56,33 +63,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   service_categories:
     type: array
     description: "IDs of service categories linked to this service."

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceResponse.yaml
@@ -18,22 +18,25 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -42,18 +45,22 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,33 +68,37 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       categories:
         type: array
         description: "Service categories associated with this service"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/DeployServiceResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/DeployServiceResponse.yaml
@@ -18,30 +18,36 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -49,30 +55,34 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/FindServicesResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/FindServicesResponse.yaml
@@ -15,28 +15,24 @@ allOf:
           - $ref: 'simpleEntity.yaml'
       service_template:
         description: "Service template linked to this service."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       check_timeperiod:
         description: "Time period of the check command."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       notification_timeperiod:
         description: "Time period of the notification command."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       severity:
         description: "Severity linked to this service."
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       categories:
         type: array
         description: "Service categories associated with this service."
@@ -61,14 +57,17 @@ allOf:
               type: string
               example: 'host-name'
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -76,7 +75,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/GetServiceResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/GetServiceResponse.yaml
@@ -17,12 +17,14 @@ allOf:
         description: 'Geographic coordinates of the service'
         example: '48.10,12.5'
       service_template_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Template ID of the service template.'
       check_command_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Check command ID.'
       check_command_args:
         type: array
@@ -31,29 +33,35 @@ allOf:
           description: 'Arguments of the check command.'
         example: ['80', '90']
       check_timeperiod_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Time period ID of the check command.'
       event_handler_enabled:
         type: integer
         description: 'Enable/disable event handler command (0/1/2).'
       event_handler_command_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Event handler command ID.'
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: 'Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state.'
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,35 +69,38 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       notification_timeperiod:
         description: 'Time period of the notification command.'
-        type: object
-        nullable: true
-        allOf:
+        anyOf:
           - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: 'Define an optional note.'
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: 'Define an optional URL that can be used to provide more information about the service.'
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: 'Define an optional URL that can be used to specify actions to be performed on the service.'
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Icon ID associated with this service.'
       severity_id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: 'Severity ID.'
       is_activated:
         type: boolean

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
@@ -9,27 +9,31 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -38,18 +42,22 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -57,33 +65,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   is_activated:
     type: boolean
     description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/macro.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
@@ -18,22 +18,25 @@ allOf:
         description: "Service template alias."
         example: "generic-service"
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -42,18 +45,22 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,33 +68,37 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service template."
         minimum: 1
-        nullable: true
         example: null
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
@@ -13,16 +13,18 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -31,24 +33,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -56,33 +63,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
@@ -12,16 +12,18 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -39,30 +41,36 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -70,33 +78,37 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -9,16 +9,18 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -50,31 +52,36 @@ properties:
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/macro.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/Common/Response/MultiStatus.yaml
+++ b/centreon/doc/API/latest/Common/Response/MultiStatus.yaml
@@ -11,14 +11,16 @@ content:
             type: object
             properties:
               href:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 example: "/path/to/entity/1"
               status:
                 type: integer
                 format: int64
                 example: 404
               message:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 example: "Not found"

--- a/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/PartialUpdateAuthenticationOpenIdProvider.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/PartialUpdateAuthenticationOpenIdProvider.yaml
@@ -9,35 +9,41 @@ properties:
     description: "Indicates whether the provider is forced or not"
     example: false
   base_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Base URL of the provider"
     example: "https://localhost:8080"
-    nullable: true
   authorization_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authorization endpoint of the provider"
     example: "/authorize"
-    nullable: true
   token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Token endpoint of the provider"
     example: "/token"
-    nullable: true
   introspection_token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Introspection token endpoint of the provider"
     example: "/introspect"
-    nullable: true
   userinfo_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Userinfo endpoint of the provider"
     example: "/userinfo"
-    nullable: true
   endsession_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Endsession endpoint of the provider"
     example: "/logout"
-    nullable: true
   connection_scopes:
     type: array
     description: "List of scopes to request"
@@ -46,28 +52,33 @@ properties:
       description: "Scope"
       example: "openid"
   login_claim:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Claim used to login"
     example: "sub"
-    nullable: true
   client_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client ID"
     example: "client_id"
-    nullable: true
   client_secret:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client secret"
     example: "client_secret"
-    nullable: true
   authentication_type:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authentication type"
     example: "client_secret_post"
-    nullable: true
     enum:
       - client_secret_post
       - client_secret_basic
+      - null
   verify_peer:
     type: boolean
     description: "Verify peer"
@@ -77,8 +88,9 @@ properties:
     description: "Auto import user from external provider"
     example: true
   contact_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -89,20 +101,23 @@ properties:
         description: "Contact template name"
         example: "Default"
   email_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Email bind attribute"
     example: "email"
-    nullable: true
   fullname_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Fullname bind attribute"
     example: "name"
-    nullable: true
   redirect_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "custom redirect url"
     example: "https://my_custom_domain.com"
-    nullable: true
   authentication_conditions:
     type: object
     properties:
@@ -133,8 +148,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       authorized_values:
         type: array
         items:
@@ -146,7 +162,6 @@ properties:
         type: boolean
       attribute_path:
         type: string
-        nullable: false
         example: info.items.groups
       endpoint:
         type: object
@@ -156,8 +171,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:
@@ -190,8 +206,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:

--- a/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/ReadAuthenticationOpenIdProvider.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/ReadAuthenticationOpenIdProvider.yaml
@@ -29,35 +29,41 @@ properties:
     description: "Indicates whether the provider is forced or not"
     example: false
   base_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Base URL of the provider"
     example: "https://localhost:8080"
-    nullable: true
   authorization_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authorization endpoint of the provider"
     example: "/authorize"
-    nullable: true
   token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Token endpoint of the provider"
     example: "/token"
-    nullable: true
   introspection_token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Introspection token endpoint of the provider"
     example: "/introspect"
-    nullable: true
   userinfo_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Userinfo endpoint of the provider"
     example: "/userinfo"
-    nullable: true
   endsession_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Endsession endpoint of the provider"
     example: "/logout"
-    nullable: true
   connection_scopes:
     type: array
     description: "List of scopes to request"
@@ -66,28 +72,33 @@ properties:
       description: "Scope"
       example: "openid"
   login_claim:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Claim used to login"
     example: "sub"
-    nullable: true
   client_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client ID"
     example: "client_id"
-    nullable: true
   client_secret:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client secret"
     example: "client_secret"
-    nullable: true
   authentication_type:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authentication type"
     example: "client_secret_post"
-    nullable: true
     enum:
       - client_secret_post
       - client_secret_basic
+      - null
   verify_peer:
     type: boolean
     description: "Verify peer"
@@ -97,8 +108,9 @@ properties:
     description: "Auto import user from external provider"
     example: true
   contact_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -109,20 +121,23 @@ properties:
         description: "Contact template name"
         example: "Default"
   email_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Email bind attribute"
     example: "email"
-    nullable: true
   fullname_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Fullname bind attribute"
     example: "name"
-    nullable: true
   redirect_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "custom redirect url"
     example: "https://my_custom_domain.com"
-    nullable: true
   authentication_conditions:
     type: object
     required:
@@ -159,8 +174,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       authorized_values:
         type: array
         items:
@@ -177,7 +193,6 @@ properties:
         type: boolean
       attribute_path:
         type: string
-        nullable: false
         example: info.items.groups
       endpoint:
         type: object
@@ -186,8 +201,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:
@@ -232,8 +248,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:

--- a/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/UpdateAuthenticationOpenIdProvider.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Authentication/OpenIdProvider/Schema/UpdateAuthenticationOpenIdProvider.yaml
@@ -29,35 +29,41 @@ properties:
     description: "Indicates whether the provider is forced or not"
     example: false
   base_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Base URL of the provider"
     example: "https://localhost:8080"
-    nullable: true
   authorization_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authorization endpoint of the provider"
     example: "/authorize"
-    nullable: true
   token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Token endpoint of the provider"
     example: "/token"
-    nullable: true
   introspection_token_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Introspection token endpoint of the provider"
     example: "/introspect"
-    nullable: true
   userinfo_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Userinfo endpoint of the provider"
     example: "/userinfo"
-    nullable: true
   endsession_endpoint:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Endsession endpoint of the provider"
     example: "/logout"
-    nullable: true
   connection_scopes:
     type: array
     description: "List of scopes to request"
@@ -66,28 +72,33 @@ properties:
       description: "Scope"
       example: "openid"
   login_claim:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Claim used to login"
     example: "sub"
-    nullable: true
   client_id:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client ID"
     example: "client_id"
-    nullable: true
   client_secret:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Client secret"
     example: "client_secret"
-    nullable: true
   authentication_type:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Authentication type"
     example: "client_secret_post"
-    nullable: true
     enum:
       - client_secret_post
       - client_secret_basic
+      - null
   verify_peer:
     type: boolean
     description: "Verify peer"
@@ -97,8 +108,9 @@ properties:
     description: "Auto import user from external provider"
     example: true
   contact_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -109,20 +121,23 @@ properties:
         description: "Contact template name"
         example: "Default"
   email_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Email bind attribute"
     example: "email"
-    nullable: true
   fullname_bind_attribute:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Fullname bind attribute"
     example: "name"
-    nullable: true
   redirect_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "custom redirect url"
     example: "https://my_custom_domain.com"
-    nullable: true
   authentication_conditions:
     type: object
     required:
@@ -159,8 +174,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       authorized_values:
         type: array
         items:
@@ -177,7 +193,6 @@ properties:
         type: boolean
       attribute_path:
         type: string
-        nullable: false
         example: info.items.groups
       endpoint:
         type: object
@@ -186,8 +201,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:
@@ -224,8 +240,9 @@ properties:
             type: string
             enum: [introspection_endpoint, user_information_endpoint, custom_endpoint]
           custom_endpoint:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       relations:
         type: array
         items:

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewToken.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewToken.yaml
@@ -9,11 +9,12 @@ properties:
     description: "User ID linked to the authentication token (mandatory for type API)"
     example: 23
   expiration_date:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Expiration date of the authentication token"
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
-    nullable: true
   type:
     type: string
     enum: ["cma", "api", "poller"]

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/NewTokenResponse.yaml
@@ -9,8 +9,9 @@ properties:
     description: "Authentication token"
     example: "xxxxxxx"
   user:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -24,10 +25,11 @@ properties:
     type: object
     properties:
       id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Token creator ID"
         example: 23
-        nullable: true
       name:
         type: string
         description: "Token creator name"
@@ -38,11 +40,12 @@ properties:
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
   expiration_date:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
-    nullable: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"

--- a/centreon/doc/API/latest/onPremise/Administration/Token/Schema/Token.yaml
+++ b/centreon/doc/API/latest/onPremise/Administration/Token/Schema/Token.yaml
@@ -5,8 +5,9 @@ properties:
     description: "Token name."
     example: "my-api-token"
   user:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -20,10 +21,11 @@ properties:
     type: object
     properties:
       id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Token creator ID"
         example: 23
-        nullable: true
       name:
         type: string
         description: "Token creator name"
@@ -34,11 +36,12 @@ properties:
     format: date-time
     example: '2023-08-31T15:46:00+02:00'
   expiration_date:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Expiration date of the API authentication token"
     format: date-time
     example: '2024-08-31T00:00:00+00:00'
-    nullable: true
   is_revoked:
     type: boolean
     description: "Indicate if the token has been revoked"

--- a/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/AddAccResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/AddAccResponse.yaml
@@ -50,13 +50,15 @@ properties:
         }
       ]
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID", example: 1 }
       name: { type: string,  description: "Creation contact name", example: "admin" }
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"

--- a/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccResponse.yaml
@@ -50,24 +50,28 @@ properties:
         }
       ]
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID", example: 1 }
       name: { type: string,  description: "Creation contact name", example: "admin" }
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Update contact ID", example: 1 }
       name: { type: string,  description: "Update contact name", example: "admin" }
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Update date (ISO8601)"

--- a/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AdditionalConnectorConfiguration/Schema/FindAccsResponse.yaml
@@ -20,24 +20,28 @@ properties:
         * vmware_v6
     example: vmware_v6
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID", example: 1 }
       name: { type: string,  description: "Creation contact name", example: "admin" }
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Update contact ID", example: 1 }
       name: { type: string,  description: "Update contact name", example: "admin" }
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Update date (ISO8601)"

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcRequest.yaml
@@ -49,9 +49,10 @@ properties:
             example: true
 
           port:
-            type: integer
+            type:
+              - integer
+              - 'null'
             description: Port used for connection (mandatory for agent initiated connection).
-            nullable: true
 
           create_host_auto:
             type: boolean
@@ -64,8 +65,9 @@ properties:
             example: true
 
           otel_public_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the public certificate.
               - Must end with `.crt`,`.cert` or `.cer`
@@ -74,8 +76,9 @@ properties:
             example: otel-cert.crt
 
           otel_ca_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the CA certificate used by the agent.
               - Must end with `.crt` or `.cer`
@@ -84,8 +87,9 @@ properties:
             example: ca-cert.cer
 
           otel_private_key:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the private key.
               - Must end with `.key`
@@ -134,18 +138,21 @@ properties:
                   description: Port used to connect to the host.
                   example: 1234
                 poller_ca_certificate:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: CA certificate expected by the host.
                   example: poller-ca-cert.crt
                 poller_ca_name:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: CA name for the host.
                   example: CentreonCA
                 token:
-                  type: object
-                  nullable: true
+                  type:
+                    - object
+                    - 'null'
                   description: Token used for the host.
                   properties:
                     name:
@@ -197,8 +204,9 @@ properties:
           - conf_private_key
         properties:
           otel_public_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the public certificate.
               - Must end with `.crt`,`.cert` or `.cer`
@@ -207,8 +215,9 @@ properties:
             example: otel-cert.crt
 
           otel_ca_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of CA certificate.
               - Must end with `.crt`,`.cert` or `.cer`
@@ -217,8 +226,9 @@ properties:
             example: telegraf-ca.crt
 
           otel_private_key:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path of the private key.
               - Must end with `.key`
@@ -232,8 +242,9 @@ properties:
             example: 1443
 
           conf_certificate:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Path to certificate for the configuration server.
               - Must end with `.crt` or `.cer`
@@ -242,8 +253,9 @@ properties:
             example: conf-cert.crt
 
           conf_private_key:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: |
               Private key for the configuration server.
               - Must end with `.key`

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/UpdateAcRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/UpdateAcRequest.yaml
@@ -52,16 +52,18 @@ properties:
             description: Connection initiated by poller.
             example: true
         port:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: Port used for connection (mandatory for agent initiated connection).
-          nullable: true
         create_host_auto:
           type: boolean
           description: Whether to automatically create host (in agent initiated mode).
           example: false
         otel_public_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the public certificate.
 
@@ -71,8 +73,9 @@ properties:
           example: otel-cert.crt
 
         otel_ca_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the CA certificate.
 
@@ -82,8 +85,9 @@ properties:
           example: ca-cert.cer
 
         otel_private_key:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the private key.
 
@@ -133,18 +137,21 @@ properties:
                 description: Port number for host connection.
                 example: 1443
               poller_ca_certificate:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: Path to poller's CA certificate.
                 example: poller-ca.crt
               poller_ca_name:
-                type: string
-                nullable: true
+                type:
+                  - string
+                  - 'null'
                 description: CA name expected by the host.
                 example: CentreonCA
               token:
-                type: object
-                nullable: true
+                type:
+                  - object
+                  - 'null'
                 description: Token used for this host.
                 properties:
                   name:
@@ -195,8 +202,9 @@ properties:
         - conf_private_key
       properties:
         otel_public_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the public certificate.
 
@@ -206,8 +214,9 @@ properties:
           example: otel-cert.crt
 
         otel_ca_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the CA certificate.
 
@@ -217,8 +226,9 @@ properties:
           example: telegraf-ca.crt
 
         otel_private_key:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Path to the private key.
 
@@ -233,8 +243,9 @@ properties:
           example: 1443
 
         conf_certificate:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Server certificate path.
 
@@ -244,8 +255,9 @@ properties:
           example: conf-cert.crt
 
         conf_private_key:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Server private key path.
 

--- a/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandRequest.yaml
@@ -28,8 +28,9 @@ properties:
       Note that commands that require shell features are slowing down the poller server.
     example: true
   argument_example:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Example of command argument values"
     example: "!80!90"
   arguments:
@@ -43,8 +44,9 @@ properties:
           description: "Name of the argument"
           example: "argument-name"
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the argument"
           example: "argument-description"
   macros:
@@ -66,16 +68,19 @@ properties:
             * `2` - SERVICE
           example: 1
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the macro"
           example: "macro-description"
   connector_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       A connector is run in the background and executes specific commands without the need to execute a binary.
   graph_template_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Graph template for the command"

--- a/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Command/Schema/AddCommandResponse.yaml
@@ -39,8 +39,9 @@ properties:
     description: "Indicates whether the command is activated or not"
     example: true
   argument_example:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Example of command argument values"
     example: "!80!90"
   arguments:
@@ -54,8 +55,9 @@ properties:
           description: "Name of the argument"
           example: "argument-name"
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the argument"
           example: "argument-description"
   macros:
@@ -77,13 +79,15 @@ properties:
             * `2` - SERVICE
           example: 1
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Description of the macro"
           example: "macro-description"
   connector:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: |
       A connector is run in background and executes specific commands without the need to execute a binary.
     properties:
@@ -96,8 +100,9 @@ properties:
         description: "Connector name"
         example: "SSH Connector"
   graph_template:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Graph template for the command"
     properties:
       id:

--- a/centreon/doc/API/latest/onPremise/Configuration/Connector/Schema/FindConnectorsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Connector/Schema/FindConnectorsResponse.yaml
@@ -12,8 +12,9 @@ properties:
     type: string
     description: "Command line to be executed by the poller"
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "A short description of the connector"
     example: "some description"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/ContactGroup/Schema/FindContactGroupsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ContactGroup/Schema/FindContactGroupsResponse.yaml
@@ -4,28 +4,23 @@ properties:
     type: integer
     description: "Contact group ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Contact group name"
     example: "Contact group"
-    nullable: false
   alias:
     type: string
     description: "Contact group alias"
     example: "Contact group alias"
-    nullable: false
   comments:
     type: string
     description: "Contact group comments"
     example: "Contact group comments"
-    nullable: false
   type:
     type: string
     description: "Contact group types"
     enum: [ local, ldap ]
     example: "local"
-    nullable: false
   is_activated:
     type: boolean
     description: "Contact group activation status"

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Add.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Add.yaml
@@ -11,8 +11,9 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
@@ -31,6 +32,7 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.One.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.One.yaml
@@ -14,36 +14,41 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
 
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID" }
       name: { type: string,  description: "Creation contact name" }
 
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Last update contact ID" }
       name: { type: string,  description: "Last update contact name" }
 
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
 
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Last update date (ISO8601)"
 
   own_role:
@@ -59,8 +64,9 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10
 
   is_favorite:

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.yaml
@@ -14,36 +14,41 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
 
   created_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Creation contact ID" }
       name: { type: string,  description: "Creation contact name" }
 
   updated_by:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id: { type: integer, description: "Last update contact ID" }
       name: { type: string,  description: "Last update contact name" }
 
   created_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Creation date (ISO8601)"
 
   updated_at:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Last update date (ISO8601)"
 
   own_role:
@@ -65,13 +70,15 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10
 
   thumbnail:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
@@ -30,27 +30,32 @@ properties:
           description: name of the metric
           example: rta
         unit:
-          type: string
+          type:
+            - string
+            - 'null'
           description: unit of the metric
           example: '%'
-          nullable: true
         warning_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: warning high threshold
           example: 200
-          nullable: true
         critical_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: critical high threshold
           example: 400
-          nullable: true
         warning_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: warning low threshold
           example: 200
-          nullable: true
         critical_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: critical low threshold
           example: 400
-          nullable: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformancesData.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsPerformancesData.yaml
@@ -26,13 +26,15 @@ properties:
           description: metric unit
           example: "%"
         min:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: min value
           example: "0"
         max:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: max value
           example: "100"
         ds_data:
@@ -44,10 +46,11 @@ properties:
               description: color of the line
               example: "#666600"
             ds_color_area:
-              type: string
+              type:
+                - string
+                - 'null'
               description: color of the area
               example: "#666600"
-              nullable: true
             ds_filled:
               type: boolean
               description: enables area filling
@@ -57,29 +60,33 @@ properties:
               description: indicates if the curve should be inverted
               example: true
             ds_legend:
-              type: string
+              type:
+                - string
+                - 'null'
               description: legend associated to the curve
               example: "#666600"
-              nullable: true
             ds_stack:
               type: boolean
               description: enable graph stacking
               example: false
             ds_order:
-              type: integer
+              type:
+                - integer
+                - 'null'
               description: display order
               example: 2
-              nullable: true
             ds_transparency:
-              type: number
+              type:
+                - number
+                - 'null'
               description: Curve transparency. Used to export the chart
               example: 30
-              nullable: true
             ds_color_line_mode:
-              type: integer
+              type:
+                - integer
+                - 'null'
               description: curve line color mode. Random or manual
               example: 1
-              nullable: true
         legend:
           type: string
           description: metric name in legend
@@ -89,23 +96,27 @@ properties:
           description: if the metric is stacked with other metrics
           example: 0
         warning_high_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: warning high threshold
           example: null
         critical_high_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: critical high threshold
           example: null
         warning_low_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: warning low threshold
           example: null
         critical_low_threshold:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: critical low threshold
           example: null
         ds_order:
@@ -115,34 +126,39 @@ properties:
         data:
           type: array
           items:
-            type: number
+            type:
+              - number
+              - 'null'
             format: float
-            nullable: true
             description: value of the metric
           example:
             - 1.0
             - null
             - 1.0
         last_value:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: last value
           example: 5.0
         average_value:
-          type: number
-          nullable: true
+          type:
+            - number
+            - 'null'
           description: average value
           example: 5.64
         minimum_value:
-          type: number
+          type:
+            - number
+            - 'null'
           format: float
-          nullable: true
           description: minimum value
           example: 1.0
         maximum_value:
-          type: number
+          type:
+            - number
+            - 'null'
           format: float
-          nullable: true
           description: maximum value
           example: 1.0
   times:

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsTop.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.MetricsTop.yaml
@@ -42,32 +42,38 @@ properties:
           description: "Current value of the metrics, use to sort the resources"
           example: 1.30
         warning_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured warning threshold
           example: 100
-          nullable: true
         critical_high_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured critical threshold
           example: 300
-          nullable: true
         warning_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured warning low threshold
           example: 100
-          nullable: true
         critical_low_threshold:
-          type: number
+          type:
+            - number
+            - 'null'
           description: configured critical low threshold
           example: 300
-          nullable: true
         max:
-          type: number
+          type:
+            - number
+            - 'null'
           description: max value of the metric
           example: 100,
-          nullable: true
         min:
-          type: number
+          type:
+            - number
+            - 'null'
           description: min value of the metric
           example: 0,
-          nullable: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.PartialUpdate.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.PartialUpdate.yaml
@@ -8,8 +8,9 @@ properties:
     example: "my dashboard"
 
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Description about this dashboard"
     example: "my description"
@@ -29,16 +30,18 @@ properties:
         enum: [ global, manual ]
         example: 'manual'
       interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 10
 
   thumbnail:
     type: object
     properties:
       id:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         example: 1
       name:
         type: string

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Panel/DashboardPanel.IdOptional.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Panel/DashboardPanel.IdOptional.yaml
@@ -2,7 +2,8 @@ type: object
 
 properties:
   id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Dashboard panel ID"
     example: 1

--- a/centreon/doc/API/latest/onPremise/Configuration/GraphTemplate/Schema/FindGraphTemplatesResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/GraphTemplate/Schema/FindGraphTemplatesResponse.yaml
@@ -28,13 +28,15 @@ properties:
     type: object
     properties:
       lower_limit:
-        type: number
-        nullable: true
+        type:
+          - number
+          - 'null'
         description: "Lower limit of the grid"
         example: 115
       upper_limit:
-        type: number
-        nullable: true
+        type:
+          - number
+          - 'null'
         description: "Upper limit of the grid"
         example: 115
       is_upper_limit_sized_to_max:

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostRequest.yaml
@@ -18,38 +18,44 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -57,24 +63,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -107,7 +117,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -123,10 +135,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -134,10 +146,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about alerts for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -151,22 +164,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -177,8 +193,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -189,12 +206,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -205,10 +224,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -216,33 +236,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_activated:
     type: boolean
@@ -278,17 +304,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -300,7 +328,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/AddHostResponse.yaml
@@ -17,39 +17,45 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host template alias"
     example: "generic-active-host"
-    nullable: true
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -57,24 +63,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -107,7 +117,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -123,10 +135,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -134,10 +146,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -151,22 +164,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -177,8 +193,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -189,12 +206,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -205,10 +224,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -216,33 +236,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as the alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_activated:
     type: boolean
@@ -303,8 +329,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -315,7 +342,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/FindHostsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/FindHostsResponse.yaml
@@ -4,25 +4,20 @@ properties:
     type: integer
     description: "Host ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Host name"
     example: "Centreon-Server"
-    nullable: false
   alias:
     type: string
     description: "Host alias"
     example: ""
-    nullable: false
   address:
     type: string
     description: "IP or domain of the host"
     example: "127.0.0.1"
-    nullable: false
   monitoring_server:
     type: object
-    nullable: false
     properties:
       id:
         type: integer
@@ -47,15 +42,18 @@ properties:
           description: "Host template name"
           example: 'generic-host'
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
     default: 5
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -64,10 +62,10 @@ properties:
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
     default: 1
-    nullable: true
   notification_timeperiod:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -78,8 +76,9 @@ properties:
         description: "Notification timeperiod name"
         example: "24x7"
   check_timeperiod:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -90,8 +89,9 @@ properties:
         description: "Check timeperiod name"
         example: "24x7"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -131,4 +131,3 @@ properties:
   is_activated:
     type: boolean
     description: "Indicates whether the host is activated or not"
-    nullable: false

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/GetHostResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/GetHostResponse.yaml
@@ -17,44 +17,51 @@ properties:
     description: "IP or domain of the host"
     example: "127.0.0.1"
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Host alias"
     example: "generic-active-host"
-    nullable: true
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
       The value can be `1`, `2c` or `3`
     example: "2c"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 255
     description: "SNMP community string of the host"
     example: "public"
   geo_coords:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
-    nullable: true
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -62,23 +69,27 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
@@ -106,7 +117,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
       The value is the sum of all the values of the selected options.
@@ -119,19 +132,20 @@ properties:
       * NULL - (inheritance of its parent's value. If there is no parent, the values used will be: DOWN, UNREACHABLE, RECOVERY, FLAPPING and DOWNTIME_SCHEDULED)
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
       A value of 0 disables re-notifications of contacts about problems for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -143,20 +157,23 @@ properties:
       Only used when notification inheritance for hosts and services is set to vertical inheritance only.
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -166,8 +183,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -177,12 +195,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -192,10 +212,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -203,33 +224,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as the alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host comments"
   is_activated:
     type: boolean
@@ -290,8 +317,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
             If the macro.is_password property is set to true, macro.value will be set to null.
@@ -301,7 +329,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
@@ -17,38 +17,44 @@ properties:
     description: "Host alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the host"
     example: "48.10,12.5"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -56,24 +62,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -106,7 +116,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -122,10 +134,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -133,10 +145,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about alerts for this host - only one alert notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -150,22 +163,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first alert notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -176,8 +192,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -188,12 +205,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -204,10 +223,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -215,33 +235,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the ID of the image that should be associated with this host"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host comments"
   is_activated:
     type: boolean
@@ -277,17 +303,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -299,7 +327,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DeleteHostGroups.yaml
@@ -37,8 +37,9 @@ post:
                   type: integer
                   description: "HTTP Status Code of the operation"
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
@@ -43,8 +43,9 @@ post:
                   description: "HTTP Status Code of the operation"
                   example: 204
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
                   example: null
     '404':
@@ -65,8 +66,9 @@ post:
                   description: "HTTP Status Code of the operation"
                   example: 404
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Host Group not found"
                   example: "Host Group not found"
     '401':

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/EnableDisableHostGroups.yaml
@@ -39,8 +39,9 @@ post:
                   type: integer
                   description: "HTTP Status Code of the operation"
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupRequest.yaml
@@ -6,30 +6,35 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host group"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   hosts:
-    type: array
-    nullable: true
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
     example: [1, 2, 3]
     items:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
@@ -6,14 +6,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -30,14 +32,16 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   hosts:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/FindHostGroupsResponse.yaml
@@ -10,14 +10,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -34,14 +36,16 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/GetHostGroupResponse.yaml
@@ -6,14 +6,16 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     description: "Host group icon"
     properties:
       id:
@@ -30,13 +32,15 @@ properties:
         description: "Icon URL"
         example: "/centreon/img/media/folder/image.png"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/Schema/UpdateHostGroupRequest.yaml
@@ -6,31 +6,36 @@ properties:
     description: "Host group name"
     example: "MySQL-Servers"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Host group alias"
     example: "All MySQL Servers"
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host group"
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 32
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Comments on this host group"
   hosts:
-    type: array
+    type:
+      - array
+      - 'null'
     description: "Hosts linked to this host group"
-    nullable: true
     example: [1, 2, 3]
     items:
       type: integer

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
@@ -10,33 +10,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -44,24 +49,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -94,7 +103,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -110,10 +121,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -121,10 +132,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -138,22 +150,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -164,8 +179,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -176,12 +192,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -192,10 +210,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -203,33 +222,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   categories:
     type: array
@@ -256,17 +281,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -278,7 +305,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -13,29 +13,33 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -43,24 +47,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -93,7 +101,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -109,10 +119,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -120,10 +130,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -137,22 +148,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -163,8 +177,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -175,12 +190,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -191,10 +208,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -202,33 +220,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used in the alternative description of the icon image"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_locked:
     type: boolean
@@ -276,8 +300,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -288,7 +313,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/FindHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/FindHostTemplateResponse.yaml
@@ -13,29 +13,33 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -43,24 +47,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -93,7 +101,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -109,10 +119,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -120,10 +130,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -137,22 +148,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -163,8 +177,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -175,12 +190,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of his parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -191,10 +208,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -202,33 +220,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used in the alternative description of the icon image"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_locked:
     type: boolean

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/GetHostTemplateResponse.yaml
@@ -13,28 +13,32 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID"
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -42,23 +46,27 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-UP state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
@@ -86,7 +94,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
       The value is the sum of all the values of the selected options.
@@ -99,19 +109,20 @@ properties:
       * NULL - (inheritance of its parent's value. If there is no parent, the values used will be: DOWN, UNREACHABLE, RECOVERY, FLAPPING and DOWNTIME_SCHEDULED)
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -123,20 +134,23 @@ properties:
       Only used when notification inheritance for hosts and services is set to vertical inheritance only.
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -146,8 +160,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -157,12 +172,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -172,10 +189,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -183,33 +201,39 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used in the alternative description of the icon image"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"
   is_locked:
     type: boolean
@@ -249,8 +273,9 @@ properties:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "Macro ID"
           example: 1
         name:
@@ -258,8 +283,9 @@ properties:
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
             If macro.is_password property is set to true and macro.value will be set to null.
@@ -269,7 +295,8 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -12,17 +12,19 @@ properties:
       required: ['name', 'value', 'is_password', 'description']
       properties:
         id:
-          type: integer
+          type:
+            - integer
+            - 'null'
           description: "Macro ID (only for existing macros)"
           example: 1
-          nullable: true
         name:
           type: string
           description: "Name of the macro"
           example: "MacroName"
         value:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: |
             Value of the macro.
 
@@ -34,8 +36,9 @@ properties:
           description: "Indicates whether the macro value is a password or not"
           example: false
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Macro description"
           example: "Some text to describe the macro"
   categories:
@@ -64,33 +67,38 @@ properties:
     description: "Host template alias"
     example: "generic-active-host"
   snmp_community:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Community of the SNMP agent"
   snmp_version:
-    type: string
-    nullable: true
-    enum: ["1", "2c", "3"]
+    type:
+      - string
+      - 'null'
+    enum: ["1", "2c", "3", null]
     description: |
       Version of the SNMP agent.
 
       The value can be `1`, `2c` or `3`
     example: "2c"
   timezone_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Timezone ID"
     example: 1
-    nullable: true
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID"
     example: 1
-    nullable: true
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID. Must be of type 'Check'."
     example: 1
-    nullable: true
   check_command_args:
     type: array
     description: "Check command arguments"
@@ -98,24 +106,28 @@ properties:
       type: string
     example: ["0", "OK"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command timeperiod ID"
     example: 1
-    nullable: true
   max_check_attempts:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the host check command if it returns any non-OK state"
   normal_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the host.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   retry_check_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this host after a non-UP state was detected.
 
@@ -148,7 +160,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   notification_options:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the states of the host for which notifications should be sent out.
 
@@ -164,10 +178,10 @@ properties:
 
       example: A value equal to 5 corresponds to the selected options DOWN and RECOVERY
     example: 5
-    nullable: true
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this host is still down or unreachable.
 
@@ -175,10 +189,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this host - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID"
     example: 1
-    nullable: true
   add_inherited_contact_group:
     type: boolean
     description: |
@@ -192,22 +207,25 @@ properties:
 
       When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this host enters a non-UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this host enters an UP state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this host."
   freshness_checked:
     type: integer
@@ -218,8 +236,9 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   freshness_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this host."
   flap_detection_enabled:
     type: integer
@@ -230,12 +249,14 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   low_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this host"
   high_flap_threshold:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this host"
   event_handler_enabled:
     type: integer
@@ -246,10 +267,11 @@ properties:
       * `1` - STATUS_ENABLED
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID"
     example: 1
-    nullable: true
   event_handler_command_args:
     type: array
     description: "Event handler command arguments"
@@ -257,31 +279,37 @@ properties:
       type: string
     example: ["0", "OK"]
   note_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more information about the host."
   note:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional note."
   action_url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 65535
     description: "Define an optional URL that can be used to provide more actions to be performed on the host."
   icon_id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this host template"
     example: 1
   icon_alternative:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     maxLength: 200
     description: "Define an optional string that is used as alternative description for the icon"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Host template comments"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaRequest.yaml
@@ -3,10 +3,8 @@ required: ['directory', 'data']
 properties:
   directory:
     type: string
-    nullable: false
     description: "Directory where the file will be created"
   data:
     type: string
     format: binary
-    nullable: false
     description: "File content"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/AddMediaResponse.yaml
@@ -6,20 +6,18 @@ properties:
       type: object
       properties:
         id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           example: 1
         filename:
           type: string
-          nullable: false
           example: "centreon_logo.jpg"
         directory:
           type: string
-          nullable: false
           example: "logos"
         md5:
           type: string
-          nullable: false
           example: "f7d5fc06a33946703054046c7174bbf4"
   errors:
     type: array
@@ -30,14 +28,11 @@ properties:
           type: string
           description: "file name of the media"
           example: "old_logo.jpg"
-          nullable: false
         directory:
           type: string
           description: "Destination directory"
           example: "logos"
-          nullable: false
         reason:
           type: string
           description: "Reason for error"
           example: "Media already exists"
-          nullable: false

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindImageFoldersResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindImageFoldersResponse.yaml
@@ -4,19 +4,19 @@ properties:
     type: integer
     description: "ID of the image folder"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Name of the image folder"
     example: "my-logos"
-    nullable: false
   alias:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "image folder alias"
     example: "logos"
-    nullable: true
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "image folder comment"
     example: "Those are my beautiful logos"
-    nullable: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindMediasResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/FindMediasResponse.yaml
@@ -4,19 +4,15 @@ properties:
     type: integer
     description: "Media ID"
     example: 1
-    nullable: false
   name:
     type: string
     description: "Media filename"
     example: "logo.png"
-    nullable: false
   directory:
     type: string
     description: "Media directory"
     example: "logos"
-    nullable: false
   url:
     type: string
     description: "Media URL"
     example: "/centreon/img/media/logo.png"
-    nullable: false

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/GetMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/GetMediaResponse.yaml
@@ -3,21 +3,16 @@ type: object
 properties:
   id:
     type: integer
-    nullable: false
     example: 1
   filename:
     type: string
-    nullable: false
     example: "centreon_logo.jpg"
   directory:
     type: string
-    nullable: false
     example: "logos"
   md5:
     type: string
-    nullable: false
     example: "f7d5fc06a33946703054046c7174bbf4"
   comment:
     type: string
-    nullable: false
     example: "Company logo"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaRequest.yaml
@@ -4,5 +4,4 @@ properties:
   data:
     type: string
     format: binary
-    nullable: false
     description: "File content"

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/Schema/UpdateMediaResponse.yaml
@@ -1,18 +1,16 @@
 type: object
 properties:
   id:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     example: 1
   filename:
     type: string
-    nullable: false
     example: "centreon_logo.jpg"
   directory:
     type: string
-    nullable: false
     example: "logos"
   md5:
     type: string
-    nullable: false
     example: "f7d5fc06a33946703054046c7174bbf4"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/DeleteServices.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/DeleteServices.yaml
@@ -37,8 +37,9 @@ post:
                   type: integer
                   description: "HTTP Status Code of the operation"
                 message:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: "Error message for non 204 status"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceRequest.yaml
@@ -9,25 +9,29 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -36,24 +40,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,7 +70,6 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   active_check_enabled:
     type: integer
     description: |
@@ -111,8 +119,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -120,10 +129,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this service - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID."
     minimum: 1
-    nullable: true
     example: 1
   notification_type:
     type: integer
@@ -145,23 +155,26 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this service."
-    nullable: true
   freshness_checked:
     type: integer
     description: |
@@ -172,9 +185,10 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   freshness_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this service."
-    nullable: true
   flap_detection_enabled:
     type: integer
     description: |
@@ -185,13 +199,15 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   low_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this service."
-    nullable: true
   high_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this service."
-    nullable: true
   event_handler_enabled:
     type: integer
     description: |
@@ -202,10 +218,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   event_handler_command_args:
     type: array
@@ -214,42 +231,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   is_activated:
     type: boolean
     description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/AddServiceResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/DeployServiceResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/DeployServiceResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/FindServicesResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/FindServicesResponse.yaml
@@ -16,20 +16,24 @@ allOf:
           $ref: 'simpleEntity.yaml'
       service_template:
         description: "Service template linked to this service."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       check_timeperiod:
         description: "Time period of the check command."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       notification_timeperiod:
         description: "Time period of the notification command."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       severity:
         description: "Severity linked to this service."
-        nullable: true
-        $ref: 'simpleEntity.yaml'
+        anyOf:
+          - $ref: 'simpleEntity.yaml'
+          - type: 'null'
       categories:
         type: array
         description: "Service categories associated with this service."
@@ -54,14 +58,17 @@ allOf:
               type: string
               example: 'host-name'
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -69,7 +76,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/GetServiceResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/GetServiceResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Geographic coordinates of the service"
         example: "48.10,12.5"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       is_activated:
         type: boolean
         description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
@@ -9,25 +9,29 @@ properties:
     description: "ID of the host linked to this service."
     example: 1
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographic coordinates of the service"
     example: "48.10,12.5"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -36,24 +40,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -61,7 +70,6 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   active_check_enabled:
     type: integer
     description: |
@@ -111,8 +119,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -120,10 +129,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this service - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID."
     minimum: 1
-    nullable: true
     example: 1
   notification_type:
     type: integer
@@ -145,23 +155,26 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this service."
-    nullable: true
   freshness_checked:
     type: integer
     description: |
@@ -172,9 +185,10 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   freshness_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this service."
-    nullable: true
   flap_detection_enabled:
     type: integer
     description: |
@@ -185,13 +199,15 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   low_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this service."
-    nullable: true
   high_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this service."
-    nullable: true
   event_handler_enabled:
     type: integer
     description: |
@@ -202,10 +218,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   event_handler_command_args:
     type: array
@@ -214,42 +231,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   is_activated:
     type: boolean
     description: "Indicates whether the service is activated or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/macro.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Service/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupRequest.yaml
@@ -10,13 +10,15 @@ properties:
     description: "Service group alias"
     example: "service-group"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographical coordinates used by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Service group description"
     example: "Example description"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceGroup/Schema/ServiceGroupResponse.yaml
@@ -13,13 +13,15 @@ properties:
     description: "Service group alias"
     example: "service-group"
   geo_coords:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Geographical coordinates use by Centreon Map module to position element on map"
     example: "48.51,2.20"
   comment:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Service group description"
     example: "example comment"
   is_activated:

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Service template alias."
         example: "generic-service"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service template comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,10 +132,11 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
         type: integer
@@ -149,23 +158,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service template."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -176,9 +188,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -189,13 +202,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -206,10 +221,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -218,42 +234,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service template."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/GetServiceTemplateResponse.yaml
@@ -18,20 +18,23 @@ allOf:
         description: "Service template alias."
         example: "generic-service"
       comment:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Service template comment."
-        nullable: true
       service_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Template ID of the service template."
         minimum: 1
-        nullable: true
         example: null
       check_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Check command ID."
         minimum: 1
-        nullable: true
         example: null
       check_command_args:
         type: array
@@ -40,24 +43,29 @@ allOf:
           description: "Arguments of the check command."
         example: ["80", "90"]
       check_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Time period ID of the check command."
         minimum: 1
-        nullable: true
         example: null
       max_check_attempts:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-        nullable: true
       normal_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of 'time units' between regularly scheduled checks of the service.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
-        nullable: true
       retry_check_interval:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -65,7 +73,6 @@ allOf:
 
           Once the service has been retried max_check_attempts times without a change in its status,
           it will revert to being scheduled at its "normal" check interval rate.
-        nullable: true
       active_check_enabled:
         type: integer
         description: |
@@ -115,8 +122,9 @@ allOf:
 
           When enabled, the contactgroup definition will not override the definitions on template levels, it will be appended instead.
       notification_interval:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -124,14 +132,16 @@ allOf:
 
           A value of 0 disables re-notifications of contacts about alerts for this service - only one alert notification will be sent out.
       notification_timeperiod_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Notification timeperiod ID."
         minimum: 1
-        nullable: true
         example: 1
       notification_type:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the states of the service for which notifications should be sent out.
 
@@ -150,23 +160,26 @@ allOf:
           example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
         example: 5
       first_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       recovery_notification_delay:
-        type: integer
-        nullable: true
+        type:
+          - integer
+          - 'null'
         description: |
           Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
           With the default time unit of 60s, this number will mean multiples of 1 minute.
       acknowledgement_timeout:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify a duration of acknowledgement for this service template."
-        nullable: true
       freshness_checked:
         type: integer
         description: |
@@ -177,9 +190,10 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       freshness_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the freshness threshold (in seconds) for this service."
-        nullable: true
       flap_detection_enabled:
         type: integer
         description: |
@@ -190,13 +204,15 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       low_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the low state change threshold used in flap detection for this service."
-        nullable: true
       high_flap_threshold:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Specify the high state change threshold used in flap detection for this service."
-        nullable: true
       event_handler_enabled:
         type: integer
         description: |
@@ -207,10 +223,11 @@ allOf:
           * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
         example: 2
       event_handler_command_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Event handler command ID."
         minimum: 1
-        nullable: true
         example: 1
       event_handler_command_args:
         type: array
@@ -219,42 +236,49 @@ allOf:
           description: "Command arguments of the event handler."
         example: [ "80", "90" ]
       graph_template_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "ID of the default graph template that will be used for this service."
         minimum: 1
-        nullable: true
         example: null
       note:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional note."
-        nullable: true
         maxLength: 65535
       note_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to provide more information about the service."
         maxLength: 65535
-        nullable: true
       action_url:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional URL that can be used to specify actions to be performed on the service."
-        nullable: true
         maxLength: 65535
       icon_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Define the image ID that should be associated with this service template."
         minimum: 1
-        nullable: true
         example: null
       icon_alternative:
-        type: string
+        type:
+          - string
+          - 'null'
         description: "Define an optional string that is used as an alternative description for the icon."
-        nullable: true
         maxLength: 200
       severity_id:
-        type: integer
+        type:
+          - integer
+          - 'null'
         description: "Severity ID."
         minimum: 1
-        nullable: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
@@ -9,20 +9,23 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service template comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -31,24 +34,29 @@ properties:
       description: "Arguments of the check command."
     example: ["80", "90"]
   check_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Time period ID of the check command."
     minimum: 1
-    nullable: true
     example: null
   max_check_attempts:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the number of times that the monitoring engine will retry the service check command if it returns any non-OK state."
-    nullable: true
   normal_normal_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of 'time units' between regularly scheduled checks of the service.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
-    nullable: true
   retry_check_interval:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before scheduling a re-check for this service after a non-OK state was detected.
 
@@ -56,7 +64,6 @@ properties:
 
       Once the service has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
-    nullable: true
   active_check_enabled:
     type: integer
     description: |
@@ -106,8 +113,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -115,10 +123,11 @@ properties:
 
       A value of 0 disables re-notifications of contacts about problems for this service - only one problem notification will be sent out.
   notification_timeperiod_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Notification timeperiod ID."
     minimum: 1
-    nullable: true
     example: 1
   notification_type:
     type: integer
@@ -140,23 +149,26 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   acknowledgement_timeout:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify a duration of acknowledgement for this service template."
-    nullable: true
   freshness_checked:
     type: integer
     description: |
@@ -167,9 +179,10 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   freshness_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the freshness threshold (in seconds) for this service."
-    nullable: true
   flap_detection_enabled:
     type: integer
     description: |
@@ -180,13 +193,15 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   low_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the low state change threshold used in flap detection for this service."
-    nullable: true
   high_flap_threshold:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Specify the high state change threshold used in flap detection for this service."
-    nullable: true
   event_handler_enabled:
     type: integer
     description: |
@@ -197,10 +212,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: 1
   event_handler_command_args:
     type: array
@@ -209,42 +225,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -9,20 +9,23 @@ properties:
     description: "Service template alias."
     example: "generic-service"
   comment:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Service template comment."
-    nullable: true
   service_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Template ID of the service template."
     minimum: 1
-    nullable: true
     example: null
   check_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Check command ID."
     minimum: 1
-    nullable: true
     example: null
   check_command_args:
     type: array
@@ -102,8 +105,9 @@ properties:
 
       When enabled, the contact definition will not override the definitions on template levels, it will be appended instead.
   notification_interval:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before re-notifying a contact that this service is still down or unreachable.
 
@@ -135,15 +139,17 @@ properties:
       example: A value equal to 5 corresponds to the selected options WARNING and CRITICAL
     example: 5
   first_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the first problem notification when this service enters a non-OK state.
 
       With the default time unit of 60s, this number will mean multiples of 1 minute.
   recovery_notification_delay:
-    type: integer
-    nullable: true
+    type:
+      - integer
+      - 'null'
     description: |
       Define the number of "time units" to wait before sending out the recovery notification when this service enters an OK state.
 
@@ -188,10 +194,11 @@ properties:
       * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
     example: 2
   event_handler_command_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Event handler command ID."
     minimum: 1
-    nullable: true
     example: null
   event_handler_command_args:
     type: array
@@ -200,42 +207,49 @@ properties:
       description: "Command arguments of the event handler."
     example: [ "80", "90" ]
   graph_template_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "ID of the default graph template that will be used for this service."
     minimum: 1
-    nullable: true
     example: null
   note:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional note."
-    nullable: true
     maxLength: 65535
   note_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to provide more information about the service."
     maxLength: 65535
-    nullable: true
   action_url:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional URL that can be used to specify actions to be performed on the service."
-    nullable: true
     maxLength: 65535
   icon_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Define the image ID that should be associated with this service template."
     minimum: 1
-    nullable: true
     example: null
   icon_alternative:
-    type: string
+    type:
+      - string
+      - 'null'
     description: "Define an optional string that is used as an alternative description for the icon."
-    nullable: true
     maxLength: 200
   severity_id:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: "Severity ID."
     minimum: 1
-    nullable: true
   host_templates:
     type: array
     description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/macro.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceTemplate/Schema/macro.yaml
@@ -6,8 +6,9 @@ properties:
     description: "Name of the macro"
     example: "MacroName"
   value:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: |
       Value of the macro.
 
@@ -18,7 +19,8 @@ properties:
     description: "Indicates whether the macro value is a password or not"
     example: false
   description:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Macro description"
     example: "Some text to describe the macro"

--- a/centreon/doc/API/latest/onPremise/Configuration/Users/Schema/CurrentParameters.Get.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Users/Schema/CurrentParameters.Get.yaml
@@ -26,8 +26,9 @@ properties:
     example: Europe/Paris
 
   locale:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: Locale of the current user
     example: en_US
 
@@ -63,14 +64,16 @@ properties:
     default: compact
 
   default_page:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: Default page for the current user
     example: '/main.php?p=60901'
 
   dashboard:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       global_user_role:
         type: string

--- a/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/Metric.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/Metric.yaml
@@ -7,30 +7,37 @@ properties:
   unit:
     type: string
   current_value:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   warning_high_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   warning_low_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   critical_high_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   critical_low_threshold:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   min:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true
   max:
-    type: number
+    type:
+      - number
+      - 'null'
     format: float
-    nullable: true

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Links.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Links.yaml
@@ -4,74 +4,87 @@ properties:
     type: object
     properties:
       configuration:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "configuration uri"
         example: "/centreon/main.php?p=60101&o=c&host_id=11"
       logs:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "logs uri"
         example: "/centreon/main.php?p=20301&h=11"
       reporting:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "reporting uri"
         example: "/centreon/main.php?p=307&host=11"
   endpoints:
     type: object
     properties:
       details:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource details endpoint"
         example: "/centreon/api/latest/monitoring/resources/hosts/11"
       timeline:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource timeline endpoint"
         example: "/centreon/api/latest/monitoring/hosts/11/timeline"
       status_graph:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource status graph endpoint"
         example: null
       performance_graph:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "resource performance graph endpoint"
         example: null
       acknowledgement:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "current resource acknowledgement endpoint"
         example: "/centreon/api/latest/monitoring/hosts/11/acknowledgements?limit=1"
       downtime:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "current resource downtimes endpoint"
         example: "/centreon/api/latest/monitoring/hosts/11/downtimes?search=%7B%22%24and%22:%5B%7B%22start_time%22:%7B%22%24lt%22:1599655905%7D,%22end_time%22:%7B%22%24gt%22:1599655905%7D,%220%22:%7B%22%24or%22:%7B%22is_cancelled%22:%7B%22%24neq%22:1%7D,%22deletion_time%22:%7B%22%24gt%22:1599655905%7D%7D%7D%7D%5D%7D"
       notification_policy:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "current resource notification policy endpoint"
         example: "/centreon/api/latest/configurations/hosts/11/notification-policy"
       check:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Endpoint dedicated for checks (forced_check payload entry set to false)"
         example: "/centreon/api/latest/monitoring/hosts/17/services/23/check"
       forced_check:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Endpoint dedicated for checks (forced_check payload entry set to true)"
         example: "/centreon/api/latest/monitoring/hosts/17/services/23/check"
   externals:
     type: object
     properties:
       action_url:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "URL that can be used to provide more actions to be performed on the resource"
         example: "http://mediawiki/resource/name"
       notes:

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Notes.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/Notes.yaml
@@ -1,13 +1,16 @@
-type: object
-nullable: true
+type:
+  - object
+  - 'null'
 properties:
   url:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "URL that can be used to provide more information on the resource"
     example: "http://mediawiki/resource/name"
   label:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Note that can be used to describe the note url"
     example: "How to turn back on the server"

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceHostDetail.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceHostDetail.yaml
@@ -30,8 +30,9 @@ properties:
     description: "FQDN of the Host Resource"
     example: "localhost|127.0.0.1"
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Alias given to the Host Resource"
     example: "central"
   status:
@@ -121,16 +122,18 @@ properties:
     description: "Indicates whether the check script is active or not"
     example: true
   parent:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
         description: "ID of the parent"
         example: 12
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       name:
         type: string
@@ -165,12 +168,14 @@ properties:
         description: "Name of the host category"
         example: "All-Cpu-Services"
       configuration_uri:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Internal URI to reach category configuration"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -208,8 +213,9 @@ properties:
             description: "URL of the icon"
             example: "baseUri/ppm/dog.png"
   acknowledgement:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -245,9 +251,10 @@ properties:
         description: "Short description of the acknowledgement"
         example: "Acknowledged by admin"
       deletion_time:
-        type: string
+        type:
+          - string
+          - 'null'
         format: date-time
-        nullable: true
         description: "Date of the request for cancellation of the acknowledgement (ISO8601)"
       entry_time:
         type: string
@@ -286,18 +293,21 @@ properties:
       type: object
       properties:
         start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled start date of the downtime (ISO8601)"
         end_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled end date of the downtime (ISO8601)"
         actual_start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Actual start date of the downtime (ISO8601)"
         id:
@@ -309,13 +319,15 @@ properties:
           format: date-time
           description: "Date of the request to create the downtime (ISO8601)"
         author_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "ID of the contact who requested the downtime"
           example: 3
         author_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Name of the contact who requested the downtime"
           example: "admin"
         host_id:
@@ -331,19 +343,22 @@ properties:
           description: "Indicates whether the downtime has been cancelled or not"
           example: false
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Comment of set on the downtime"
           example: "Downtime set by admin"
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: "Date of cancellation of downtime (ISO8601)"
           example: null
         duration:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "Downtime duration in seconds"
           example: 7200
         internal_id:
@@ -359,38 +374,45 @@ properties:
           description: "Indicates whether the downtime has started"
           example: true
   timezone:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Timezone configured on the Host resource"
     example: 'Europe/Paris'
   duration:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last status change"
     example: "2h 3m"
   next_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Scheduled date for the next check (ISO8601)"
   last_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last check (ISO8601)"
   last_time_with_no_issue:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last time Host Resource was UP (ISO8601)"
   last_status_change:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last status change (ISO8601)"
   last_notification:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last notification sent (ISO8601)"
   tries:
@@ -404,30 +426,35 @@ properties:
         type: object
         properties:
           configuration:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "configuration uri"
             example: "/centreon/main.php?p=60101&o=c&host_id=11"
           logs:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "logs uri"
             example: "/centreon/main.php?p=20301&h=11"
           reporting:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "reporting uri"
             example: "/centreon/main.php?p=307&host=11"
       endpoints:
         type: object
         properties:
           notification_policy:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Host resource notification policy endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/202/notification-policy"
           timeline:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "resource timeline endpoint"
             example: "/centreon/api/latest/monitoring/hosts/11/timeline"

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceLightened.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceLightened.yaml
@@ -18,13 +18,15 @@ properties:
     description: "ID of the resource"
     example: 12
   alias:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Resource alias"
     example: null
   fqdn:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Resource fqdn"
     example: null
   links:
@@ -34,8 +36,9 @@ properties:
     description: "Monitoring Server from which is monitored the Resource"
     example: "Central"
   icon:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -65,53 +68,63 @@ properties:
     description: "Indicates whether resource is in flapping"
     example: false
   percent_state_change:
-    type: number
-    nullable: true
+    type:
+      - number
+      - 'null'
     description: "Percentage of state change"
     example: "10.4"
   duration:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last status change"
     example: "2h 3m"
   last_status_change:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Date of the last status change (ISO8601)"
   last_time_with_no_issue:
-    type: string
+    type:
+      - string
+      - 'null'
     format: date-time
-    nullable: true
     description: "Date of the last status change (ISO8601)"
   tries:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Number of check tries"
     example: "3/3 (H)"
   last_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last check"
     example: "1h 45m"
   information:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Output of the resource"
     example: "OK - Ping is ok"
   has_active_checks_enabled:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether active checks are enabled"
     example: true
   has_passive_checks_enabled:
-    type: boolean
-    nullable: true
+    type:
+      - boolean
+      - 'null'
     description: "Indicates whether passive checks are enabled"
     example: true
   performance_data:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Performance data result of the check sent"
     example: "rta=0.025ms;200.000;400.000;0; rtmax=0.061ms;;;; rtmin=0.015ms;;;; pl=0%;20;50;0;100 "
   is_notification_enabled:
@@ -119,8 +132,9 @@ properties:
     description: "Indicates if notifications are enabled for the resource"
     example: false
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       type:
         type: string

--- a/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceServiceDetail.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Resources/Schema/ResourceServiceDetail.yaml
@@ -148,8 +148,9 @@ properties:
         description: "Name of the service group"
         example: "All-Cpu-Services"
       configuration_uri:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Internal URI to reach group configuration"
   categories:
     type: object
@@ -164,12 +165,14 @@ properties:
         description: "Name of the service category"
         example: "All-Cpu-Services"
       configuration_uri:
-        type: string
-        nullable: true
+        type:
+          - string
+          - 'null'
         description: "Internal URI to reach category configuration"
   severity:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -207,8 +210,9 @@ properties:
             description: "URL of the icon"
             example: "baseUri/ppm/dog.png"
   acknowledgement:
-    type: object
-    nullable: true
+    type:
+      - object
+      - 'null'
     properties:
       id:
         type: integer
@@ -244,9 +248,10 @@ properties:
         description: "Short description of the acknowledgement"
         example: "Acknowledged by admin"
       deletion_time:
-        type: string
+        type:
+          - string
+          - 'null'
         format: date-time
-        nullable: true
         description: "Date of the request for cancellation of the acknowledgement (ISO8601)"
       entry_time:
         type: string
@@ -289,18 +294,21 @@ properties:
         - service_id
       properties:
         start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled start date of the downtime (ISO8601)"
         end_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Scheduled end date of the downtime (ISO8601)"
         actual_start_time:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           format: date-time
           description: "Actual start date of the downtime (ISO8601)"
         id:
@@ -312,13 +320,15 @@ properties:
           format: date-time
           description: "Date of the request to create the downtime (ISO8601)"
         author_id:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "ID of the contact who requested the downtime"
           example: 3
         author_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Name of the contact who requested the downtime"
           example: "admin"
         host_id:
@@ -334,19 +344,22 @@ properties:
           description: "Indicates whether the downtime has been cancelled or not"
           example: false
         comment:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: "Comment of set on the downtime"
           example: "Downtime set by admin"
         deletion_time:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
           description: "Date of cancellation of downtime (ISO8601)"
           example: null
         duration:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: "Downtime duration in seconds"
           example: 7200
         internal_id:
@@ -362,33 +375,39 @@ properties:
           description: "Indicates whether the downtime has started"
           example: true
   duration:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     description: "Duration since last status change"
     example: "2h 3m"
   next_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Scheduled date for the next check (ISO8601)"
   last_check:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last check (ISO8601)"
   last_time_with_no_issue:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last time Host Resource was UP (ISO8601)"
   last_status_change:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last status change (ISO8601)"
   last_notification:
-    type: string
-    nullable: true
+    type:
+      - string
+      - 'null'
     format: date-time
     description: "Date of the last notification sent (ISO8601)"
   tries:
@@ -402,40 +421,47 @@ properties:
         type: object
         properties:
           configuration:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Redirection link to Service resource configuration page"
             example: "/centreon/main.php?p=60201&o=c&service_id=1533"
           logs:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Redirection link to Service resource logs pre-filtered page"
             example: "centreon/main.php?p=20301&svc=202_1533"
           reporting:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Redirection link to Service resource reporting pre-filtered page"
             example: "/centreon/main.php?p=30702&period=yesterday&start=&end=&host_id=202&item=1533"
       endpoints:
         type: object
         properties:
           notification_policy:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource notification policy endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/202/services/1533/notification-policy"
           timeline:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource timeline endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/202/services/1533/timeline"
           status_graph:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource status graph endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/14/services/26/metrics/status"
           performance_graph:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
             description: "Service resource performance graph endpoint"
             example: "/centreon/api/v22.04/monitoring/hosts/14/services/26/metrics/performance"

--- a/centreon/doc/API/redocly.yaml
+++ b/centreon/doc/API/redocly.yaml
@@ -1,0 +1,4 @@
+# Ruleset for `redocly lint`, pinned so the backend-lint CI gate is stable across CLI versions.
+# The committed specs (centreon-api.yaml, centreon-cloud-api.yaml) pass this ruleset with 0 errors.
+extends:
+  - recommended

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/MergeDocumentationCommand.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/MergeDocumentationCommand.php
@@ -79,14 +79,15 @@ final readonly class MergeDocumentationCommand
          *   },
          * }
          */
-        $newDoc = $this->normalizer->normalize(($this->openApiFactory)(), 'json', ['spec_version' => '3.0.0']);
+        $newDoc = $this->normalizer->normalize(($this->openApiFactory)(), 'json', ['spec_version' => '3.1.0']);
         /** @var array{paths: array<string, array<string, mixed>>, tags: array<array{name: string, ...}>, components: array{parameters: array<string, mixed>, responses: array<string, mixed>, schemas: array<string, mixed>}} $newDoc */
-        $newDoc = $this->toOpenApi30($newDoc);
-
+        $newDoc = $this->removeEmptyLinks($newDoc);
+        /** @var array{paths: array<string, array<string, mixed>>, tags: array<array{name: string, ...}>, components: array{parameters: array<string, mixed>, responses: array<string, mixed>, schemas: array<string, mixed>}} $newDoc */
         $io->section('Paths...');
         foreach ($newDoc['paths'] as $url => $path) {
-            /** @var string $url */
-            $url = preg_replace('#/api/latest#', '', (string) $url) ?? '';
+            // Keep the canonical bare `/api` prefix emitted by API Platform (see #11078); the doc's
+            // server base is `/centreon`, so `/api/...` paths resolve to `/centreon/api/...`.
+            $url = (string) $url;
             $io->text($url);
 
             if (! isset($doc['paths'][$url])) {
@@ -95,7 +96,7 @@ final readonly class MergeDocumentationCommand
             }
 
             foreach ($path as $method => $operation) {
-                $label = mb_strtoupper($method) . ' ' . $url;
+                $label = mb_strtoupper((string) $method) . ' ' . $url;
                 $io->text('  ' . $label);
 
                 if (! $override && isset($doc['paths'][$url][$method]) && ! $this->askOverride($io, $label)) {
@@ -178,67 +179,29 @@ final readonly class MergeDocumentationCommand
     }
 
     /**
-     * Recursively convert OpenAPI 3.1 null patterns to OpenAPI 3.0 nullable: true.
+     * Remove empty `links` entries from the generated spec.
      *
-     * ApiPlatform generates 3.1-style schemas (type arrays, anyOf with null) regardless
-     * of spec_version context — LegacyOpenApiNormalizer only partially converts them.
-     * This method handles the two patterns that must become nullable: true in 3.0:
-     *   - type: ['string', 'null']           → type: string,  nullable: true
-     *   - anyOf: [{...}, {type: 'null'}]     → merged schema, nullable: true
+     * ApiPlatform emits `links: []` on operation responses that declare no links. The OpenAPI
+     * Response Object requires `links` to be a map, so an empty array is invalid — drop it.
      *
-     * @param array<mixed> $schema
+     * @param array<mixed> $node
      *
      * @return array<mixed>
      */
-    private function toOpenApi30(array $schema): array
+    private function removeEmptyLinks(array $node): array
     {
-        // type: ['string', 'null'] → type: string, nullable: true
-        if (isset($schema['type']) && \is_array($schema['type'])) {
-            $types = array_values(array_filter($schema['type'], static fn ($type): bool => $type !== 'null'));
-            if (\count($types) < \count($schema['type'])) {
-                $schema['nullable'] = true;
-                $schema['type'] = \count($types) === 1 ? $types[0] : $types;
-                if ($schema['type'] === []) {
-                    unset($schema['type']);
-                }
-            }
-        }
+        foreach ($node as $key => $value) {
+            if ($key === 'links' && $value === []) {
+                unset($node[$key]);
 
-        // anyOf: [{...}, {type: 'null'}] → merge inner schema + nullable: true
-        if (isset($schema['anyOf']) && \is_array($schema['anyOf'])) {
-            $nullKey = null;
-            foreach ($schema['anyOf'] as $nullIdx => $sub) {
-                if (\is_array($sub) && $sub === ['type' => 'null']) {
-                    $nullKey = $nullIdx;
-                    break;
-                }
+                continue;
             }
-            if ($nullKey !== null) {
-                unset($schema['anyOf'][$nullKey]);
-                $remaining = array_values($schema['anyOf']);
-                $schema['nullable'] = true;
-                if (\count($remaining) === 1) {
-                    unset($schema['anyOf']);
-                    /** @var array<mixed> $firstSchema */
-                    $firstSchema = $remaining[0];
-                    if (isset($firstSchema['$ref'])) {
-                        // $ref cannot have sibling keys in OAS 3.0; wrap in allOf
-                        $schema = ['allOf' => [$firstSchema, $schema]];
-                    } else {
-                        $schema = array_merge($firstSchema, $schema);
-                    }
-                } else {
-                    $schema['anyOf'] = $remaining;
-                }
-            }
-        }
 
-        foreach ($schema as $key => $value) {
             if (\is_array($value)) {
-                $schema[$key] = $this->toOpenApi30($value);
+                $node[$key] = $this->removeEmptyLinks($value);
             }
         }
 
-        return $schema;
+        return $node;
     }
 }


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the OpenAPI 3.1 migration: updates the documentation tooling to emit OpenAPI 3.1 and ships the regenerated `centreon-api.yaml`. On this stacked base the regenerated spec matches the branch's real API surface exactly.

**Fixes** MON-208973

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.10.x

## How this pull request can be tested ?

- `centreon-api.yaml` declares `openapi: 3.1.0` and passes `redocly lint` against the committed ruleset.
- Regenerating via `bin/console.new app:open-api:merge --override` produces no diff.
- Backend: PHPStan + App unit suite green.

## Stacked PR

Based on #11594 — merge that first.