### PR TITLE
feat(security): store adminship on the Credential aggregate

### DIFF
--- a/centreon/config.new/packages/security.yaml
+++ b/centreon/config.new/packages/security.yaml
@@ -3,7 +3,9 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 
     role_hierarchy:
-        ROLE_ADMIN: ROLE_USER
+        ROLE_SUPER_ADMIN: ROLE_USER
+        ROLE_CLOUD_ADMIN: ROLE_USER
+
     firewalls:
         dev:
             pattern: '^/api(/latest)?/_(profiler|wdt)'

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/ListHostGroupsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostGroup/ListHostGroupsProvider.php
@@ -63,7 +63,6 @@ final readonly class ListHostGroupsProvider implements ProviderInterface
     {
         $credentialUser = $this->security->getUser();
         Assert::isInstanceOf($credentialUser, CredentialUser::class);
-        $isAdmin = $credentialUser->credential->isAdmin();
 
         $criteria = new HostGroupCriteria();
         if ($this->pagination->isEnabled($operation, $context)) {
@@ -77,7 +76,9 @@ final readonly class ListHostGroupsProvider implements ProviderInterface
         /** @var array{name?: mixed} $filters */
         $filters = $context['filters'] ?? [];
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
-        $criteria = $isAdmin ? $criteria : $criteria->withViewerId($credentialUser->credential->userId);
+        $criteria = $credentialUser->credential->hasUnrestrictedResourceAccess()
+            ? $criteria
+            : $criteria->withViewerId($credentialUser->credential->userId);
 
         $hostGroups = $this->repository->findAll($criteria);
         $resources = [];

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ListPollersProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Poller/ListPollersProvider.php
@@ -65,7 +65,7 @@ final readonly class ListPollersProvider implements ProviderInterface
     {
         $credentialUser = $this->security->getUser();
         Assert::isInstanceOf($credentialUser, CredentialUser::class);
-        $isAdmin = $credentialUser->credential->isAdmin();
+        $hasUnrestrictedResourceAccess = $credentialUser->credential->hasUnrestrictedResourceAccess();
 
         $criteria = new PollerCriteria();
         if ($this->pagination->isEnabled($operation, $context)) {
@@ -79,8 +79,10 @@ final readonly class ListPollersProvider implements ProviderInterface
         /** @var array{name?: mixed} $filters */
         $filters = $context['filters'] ?? [];
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
-        $criteria = $criteria->withExcludeUnknownCentral($this->isCloudPlatform && ! $isAdmin);
-        $criteria = $isAdmin ? $criteria : $criteria->withViewerId($credentialUser->credential->userId);
+        $criteria = $criteria->withExcludeUnknownCentral($this->isCloudPlatform && ! $hasUnrestrictedResourceAccess);
+        $criteria = $hasUnrestrictedResourceAccess
+            ? $criteria
+            : $criteria->withViewerId($credentialUser->credential->userId);
 
         $pollers = $this->repository->findAll($criteria);
         $resources = [];

--- a/centreon/src/App/Security/Domain/Aggregate/Credential.php
+++ b/centreon/src/App/Security/Domain/Aggregate/Credential.php
@@ -68,11 +68,38 @@ final readonly class Credential
 
     public function isPermissionGranted(Permission $permission): bool
     {
+        if ($this->isSuperAdmin()) {
+            return true;
+        }
+
         return $this->permissions->contains($permission);
     }
 
-    public function isAdmin(): bool
+    /**
+     * Centreon-staff-level administrator
+     */
+    public function isSuperAdmin(): bool
     {
-        return $this->roles->contains(new Role('ROLE_ADMIN'));
+        return $this->roles->contains(new Role('ROLE_SUPER_ADMIN'));
+    }
+
+    /**
+     * Top-level administrator of a Cloud tenant
+     */
+    public function isCloudAdmin(): bool
+    {
+        return $this->roles->contains(new Role('ROLE_CLOUD_ADMIN'));
+    }
+
+    /**
+     * Whether the user escapes ACL resource scoping, i.e. sees every resource on the platform.
+     */
+    public function hasUnrestrictedResourceAccess(): bool
+    {
+        if ($this->isSuperAdmin()) {
+            return true;
+        }
+
+        return $this->isCloudAdmin();
     }
 }

--- a/centreon/src/App/Security/Domain/Repository/AccessGroupRepository.php
+++ b/centreon/src/App/Security/Domain/Repository/AccessGroupRepository.php
@@ -21,20 +21,15 @@
 
 declare(strict_types=1);
 
-namespace App\Upgrade\Infrastructure\ApiPlatform\Resource;
+namespace App\Security\Domain\Repository;
 
-use ApiPlatform\Metadata\Post;
-use App\Upgrade\Infrastructure\ApiPlatform\State\UpdateProcessor;
+use App\Security\Domain\Aggregate\UserId;
 
-#[Post(
-    shortName: 'Upgrade',
-    uriTemplate: '/platform/updates',
-    processor: UpdateProcessor::class,
-    status: 204,
-    deserialize: false,
-    security: "is_granted('ROLE_SUPER_ADMIN')",
-    securityMessage: 'Only admin users can perform upgrades',
-)]
-final class UpdateResource
+interface AccessGroupRepository
 {
+    /**
+     * Whether the user belongs — directly, or through a contact group — to an
+     * active Access Group with this exact name.
+     */
+    public function userHasGroup(UserId $userId, string $groupName): bool;
 }

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalAccessGroupRepository.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalAccessGroupRepository.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Security\Infrastructure\Dbal;
+
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Domain\Repository\AccessGroupRepository;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class DbalAccessGroupRepository implements AccessGroupRepository
+{
+    public function __construct(
+        #[Autowire(service: 'doctrine.dbal.default_connection')]
+        private Connection $connection,
+    ) {
+    }
+
+    public function userHasGroup(UserId $userId, string $groupName): bool
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('1')
+            ->from('acl_groups', 'ag')
+            ->where("ag.acl_group_activate = '1'")
+            ->andWhere('ag.acl_group_name = :groupName')
+            ->andWhere(
+                $qb->expr()->or(
+                    'ag.acl_group_id IN (
+                        SELECT acl_group_id
+                        FROM acl_group_contacts_relations
+                        WHERE contact_contact_id = :contactId
+                    )',
+                    'ag.acl_group_id IN (
+                        SELECT agcr.acl_group_id
+                        FROM acl_group_contactgroups_relations agcr
+                        INNER JOIN contactgroup_contact_relation cgcr
+                            ON cgcr.contactgroup_cg_id = agcr.cg_cg_id
+                        WHERE cgcr.contact_contact_id = :contactId
+                    )'
+                )
+            )
+            ->setMaxResults(1)
+            ->setParameter('groupName', $groupName)
+            ->setParameter('contactId', $userId->value);
+
+        return (bool) $qb->executeQuery()->fetchOne();
+    }
+}

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialRepository.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialRepository.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace App\Security\Infrastructure\Dbal;
 
 use App\Security\Domain\Aggregate\Credential;
+use App\Security\Domain\Aggregate\UserId;
 use App\Security\Domain\Exception\CredentialNotFoundException;
+use App\Security\Domain\Repository\AccessGroupRepository;
 use App\Security\Domain\Repository\CredentialRepository;
 use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\TransformerInterface;
@@ -38,6 +40,7 @@ use Webmozart\Assert\Assert;
  *   c_alias: non-empty-string,
  *   c_admin: string,
  *   c_active: string,
+ *   is_cloud_admin: bool,
  *   topology_permissions: array<string>,
  *   action_rules: array<string>
  * }
@@ -45,6 +48,7 @@ use Webmozart\Assert\Assert;
 final readonly class DbalCredentialRepository extends DbalRepository implements CredentialRepository
 {
     public const TABLE_NAME = 'contact';
+    private const CUSTOMER_ADMIN_ACCESS_GROUP_NAME = 'customer_admin_acl';
     private const MENU_ACCESS_NO_ACCESS = 0;
     private const MENU_ACCESS_READ_WRITE = 1;
     private const MENU_ACCESS_READ_ONLY = 2;
@@ -58,6 +62,11 @@ final readonly class DbalCredentialRepository extends DbalRepository implements 
 
         #[Autowire(service: DbalCredentialTransformer::class)]
         private TransformerInterface $transformer,
+
+        private AccessGroupRepository $accessGroupRepository,
+
+        #[Autowire(env: 'bool:default::IS_CLOUD_PLATFORM')]
+        private bool $isCloudPlatform,
     ) {
     }
 
@@ -133,61 +142,25 @@ final readonly class DbalCredentialRepository extends DbalRepository implements 
     {
         Assert::notEmpty($row['c_alias']);
 
-        $topologies = $this->fetchTopologyRules($row['c_id'], $row['c_admin'] === '1');
-        $topologyPermissions = $this->buildTopologyPermissions($topologies);
-        $actionRules = $this->fetchActionRules($row['c_id']);
+        $isCloudAdmin = $this->isCloudPlatform && $this->accessGroupRepository->userHasGroup(
+            new UserId($row['c_id']),
+            self::CUSTOMER_ADMIN_ACCESS_GROUP_NAME,
+        );
+
+        // A super admin is granted every permission by Credential::isPermissionGranted()
+        $topologyPermissions = $row['c_admin'] === '1'
+            ? []
+            : $this->buildTopologyPermissions($this->fetchTopologyRulesForNonAdmin($row['c_id']));
 
         /** @var RowTypeAlias $rowWithPermissions */
         $rowWithPermissions = [
             ...$row,
+            'is_cloud_admin' => $isCloudAdmin,
             'topology_permissions' => $topologyPermissions,
-            'action_rules' => $actionRules,
+            'action_rules' => $this->fetchActionRules($row['c_id']),
         ];
 
         return $this->transformer->transform($rowWithPermissions);
-    }
-
-    /**
-     * @return array<int, array{name: string, page: int, parent: int|null, access_right: int|null}>
-     */
-    private function fetchTopologyRules(int $contactId, bool $isAdmin): array
-    {
-        if ($isAdmin) {
-            return $this->fetchTopologyRulesForAdmin();
-        }
-
-        return $this->fetchTopologyRulesForNonAdmin($contactId);
-    }
-
-    /**
-     * @return array<int, array{name: string, page: int, parent: int|null, access_right: int|null}>
-     */
-    private function fetchTopologyRulesForAdmin(): array
-    {
-        $qb = $this->connection->createQueryBuilder();
-
-        $qb->select('t.topology_name', 't.topology_page', 't.topology_parent')
-            ->from('topology', 't')
-            ->where($qb->expr()->isNotNull('t.topology_page'))
-            ->orderBy('t.topology_page');
-
-        $result = $qb->executeQuery();
-        $topologies = [];
-
-        /** @var array<array{topology_page: int, topology_name: string, topology_parent: ?string}> $rows */
-        $rows = $result->fetchAllAssociative();
-
-        foreach ($rows as $row) {
-            $topologyPage = (int) $row['topology_page'];
-            $topologies[$topologyPage] = [
-                'name' => $row['topology_name'],
-                'page' => $topologyPage,
-                'parent' => $row['topology_parent'] !== null ? (int) $row['topology_parent'] : null,
-                'access_right' => 1,
-            ];
-        }
-
-        return $topologies;
     }
 
     /**

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
@@ -82,7 +82,6 @@ final readonly class DbalCredentialTransformer implements TransformerInterface
      */
     public function transform(mixed $from): Credential
     {
-        $isAdmin = $from['c_admin'] === '1';
         $credential = new Credential(
             identifier: new CredentialIdentifier($from['c_alias']),
             userId: new UserId($from['c_id']),
@@ -94,11 +93,12 @@ final readonly class DbalCredentialTransformer implements TransformerInterface
             }
         }
 
-        if ($isAdmin) {
-            $credential->assignRole(new Role('ROLE_ADMIN'));
-            foreach (array_keys(self::LEGACY_ROLE_MAP) as $roleString) {
-                $credential->grantPermission(new Permission(self::LEGACY_ROLE_MAP[$roleString]));
-            }
+        if ($from['c_admin'] === '1') {
+            $credential->assignRole(new Role('ROLE_SUPER_ADMIN'));
+        }
+
+        if ($from['is_cloud_admin']) {
+            $credential->assignRole(new Role('ROLE_CLOUD_ADMIN'));
         }
 
         foreach ($from['action_rules'] as $actionRule) {

--- a/centreon/tests/php/App/Security/Domain/Aggregate/CredentialTest.php
+++ b/centreon/tests/php/App/Security/Domain/Aggregate/CredentialTest.php
@@ -25,32 +25,142 @@ namespace Tests\App\Security\Domain\Aggregate;
 
 use App\Security\Domain\Aggregate\Credential;
 use App\Security\Domain\Aggregate\CredentialIdentifier;
+use App\Security\Domain\Aggregate\Permission;
 use App\Security\Domain\Aggregate\Role;
 use App\Security\Domain\Aggregate\UserId;
 use PHPUnit\Framework\TestCase;
 
 final class CredentialTest extends TestCase
 {
-    public function testIsAdminReturnsFalseByDefault(): void
+    public function testNoAdminRoleByDefault(): void
     {
-        $credential = new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
+        $credential = $this->createCredential();
 
-        self::assertFalse($credential->isAdmin());
+        self::assertFalse($credential->isSuperAdmin());
+        self::assertFalse($credential->isCloudAdmin());
+        self::assertFalse($credential->hasUnrestrictedResourceAccess());
     }
 
-    public function testIsAdminReturnsTrueAfterRoleAdminIsAssigned(): void
+    public function testSuperAdminIsAdminButNotCloudAdmin(): void
     {
-        $credential = new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
-        $credential->assignRole(new Role('ROLE_ADMIN'));
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_SUPER_ADMIN'));
 
-        self::assertTrue($credential->isAdmin());
+        self::assertTrue($credential->isSuperAdmin());
+        self::assertFalse($credential->isCloudAdmin());
+        self::assertTrue($credential->hasUnrestrictedResourceAccess());
     }
 
-    public function testIsAdminReturnsFalseForAnyOtherRole(): void
+    public function testCloudAdminIsAdminButNotSuperAdmin(): void
     {
-        $credential = new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_CLOUD_ADMIN'));
+
+        self::assertFalse($credential->isSuperAdmin());
+        self::assertTrue($credential->isCloudAdmin());
+        self::assertTrue($credential->hasUnrestrictedResourceAccess());
+    }
+
+    public function testSuperAdminAndCloudAdminCanBeHeldTogether(): void
+    {
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_SUPER_ADMIN'));
+        $credential->assignRole(new Role('ROLE_CLOUD_ADMIN'));
+
+        self::assertTrue($credential->isSuperAdmin());
+        self::assertTrue($credential->isCloudAdmin());
+        self::assertTrue($credential->hasUnrestrictedResourceAccess());
+    }
+
+    public function testAnyOtherRoleGrantsNoAdminship(): void
+    {
+        $credential = $this->createCredential();
         $credential->assignRole(new Role('ROLE_USER'));
 
-        self::assertFalse($credential->isAdmin());
+        self::assertFalse($credential->isSuperAdmin());
+        self::assertFalse($credential->isCloudAdmin());
+        self::assertFalse($credential->hasUnrestrictedResourceAccess());
+    }
+
+    public function testRevokingAnAdminRoleTakesAdminshipAway(): void
+    {
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_CLOUD_ADMIN'));
+        $credential->revokeRole(new Role('ROLE_CLOUD_ADMIN'));
+
+        self::assertFalse($credential->isCloudAdmin());
+        self::assertFalse($credential->hasUnrestrictedResourceAccess());
+    }
+
+    public function testOnlyExplicitlyGrantedPermissionsAreGrantedToARestrictedUser(): void
+    {
+        $credential = $this->createCredential();
+        $credential->grantPermission(new Permission('can_read_host_groups'));
+
+        self::assertTrue($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+        self::assertFalse($credential->isPermissionGranted(new Permission('can_write_host_groups')));
+    }
+
+    public function testARestrictedUserLosesARemovedPermission(): void
+    {
+        $credential = $this->createCredential();
+        $credential->grantPermission(new Permission('can_read_host_groups'));
+        $credential->removePermission(new Permission('can_read_host_groups'));
+
+        self::assertFalse($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+    }
+
+    /**
+     * A super admin bypasses every voter, so this must hold for permissions never granted.
+     */
+    public function testASuperAdminIsGrantedEveryPermission(): void
+    {
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_SUPER_ADMIN'));
+
+        self::assertTrue($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+        self::assertTrue($credential->isPermissionGranted(new Permission('any_permission_never_granted')));
+    }
+
+    /**
+     * Removing a permission cannot restrict a super admin: adminship wins.
+     */
+    public function testRemovingAPermissionDoesNotRestrictASuperAdmin(): void
+    {
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_SUPER_ADMIN'));
+        $credential->grantPermission(new Permission('can_read_host_groups'));
+        $credential->removePermission(new Permission('can_read_host_groups'));
+
+        self::assertTrue($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+    }
+
+    /**
+     * A Cloud admin escapes resource scoping but keeps ACL-governed menu access — it is
+     * granted exactly what it was granted, like any other user.
+     */
+    public function testACloudAdminIsGrantedOnlyItsOwnPermissions(): void
+    {
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_CLOUD_ADMIN'));
+        $credential->grantPermission(new Permission('can_read_host_groups'));
+
+        self::assertTrue($credential->hasUnrestrictedResourceAccess());
+        self::assertTrue($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+        self::assertFalse($credential->isPermissionGranted(new Permission('can_write_host_groups')));
+    }
+
+    public function testLosingAdminshipRestoresPermissionScoping(): void
+    {
+        $credential = $this->createCredential();
+        $credential->assignRole(new Role('ROLE_SUPER_ADMIN'));
+        $credential->revokeRole(new Role('ROLE_SUPER_ADMIN'));
+
+        self::assertFalse($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+    }
+
+    private function createCredential(): Credential
+    {
+        return new Credential(new CredentialIdentifier('user'), new UserId(1), active: true);
     }
 }

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalAccessGroupRepositoryTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalAccessGroupRepositoryTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Security\Infrastructure\Dbal;
+
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Infrastructure\Dbal\DbalAccessGroupRepository;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class DbalAccessGroupRepositoryTest extends KernelTestCase
+{
+    private Connection $connection;
+
+    private DbalAccessGroupRepository $repository;
+
+    protected function setUp(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->repository = new DbalAccessGroupRepository($this->connection);
+    }
+
+    public function testContactWithNoAclGroupDoesNotBelongToTheNamedGroup(): void
+    {
+        $userId = new UserId($this->createContact('user-no-acl'));
+
+        self::assertFalse($this->repository->userHasGroup($userId, 'customer_admin_acl'));
+    }
+
+    public function testContactDirectlyInTheNamedGroupBelongsToIt(): void
+    {
+        $contactId = $this->createContact('user-direct-member');
+        $this->createAclGroup('customer_admin_acl', active: true, memberContactId: $contactId);
+
+        $userId = new UserId($contactId);
+
+        self::assertTrue($this->repository->userHasGroup($userId, 'customer_admin_acl'));
+    }
+
+    public function testContactInADifferentlyNamedGroupDoesNotBelongToTheNamedGroup(): void
+    {
+        $contactId = $this->createContact('user-other-group');
+        $this->createAclGroup('some-other-group', active: true, memberContactId: $contactId);
+
+        $userId = new UserId($contactId);
+
+        self::assertFalse($this->repository->userHasGroup($userId, 'customer_admin_acl'));
+    }
+
+    public function testContactBelongingToTheNamedGroupOnlyThroughAnInactiveGroupDoesNotBelongToIt(): void
+    {
+        $contactId = $this->createContact('user-inactive-group');
+        $this->createAclGroup('customer_admin_acl', active: false, memberContactId: $contactId);
+
+        $userId = new UserId($contactId);
+
+        self::assertFalse($this->repository->userHasGroup($userId, 'customer_admin_acl'));
+    }
+
+    public function testContactInTheNamedGroupThroughAContactGroupBelongsToIt(): void
+    {
+        $contactId = $this->createContact('user-via-contactgroup');
+        $contactGroupId = $this->createContactGroup('cg-1', $contactId);
+        $this->createAclGroup('customer_admin_acl', active: true, memberContactGroupId: $contactGroupId);
+
+        $userId = new UserId($contactId);
+
+        self::assertTrue($this->repository->userHasGroup($userId, 'customer_admin_acl'));
+    }
+
+    private function createContact(string $alias): int
+    {
+        $this->connection->insert('contact', [
+            'contact_name' => $alias,
+            'contact_alias' => $alias,
+            'contact_admin' => '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => $alias . '@email.com',
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function createContactGroup(string $name, int $memberContactId): int
+    {
+        $this->connection->insert('contactgroup', [
+            'cg_name' => $name,
+            'cg_alias' => $name,
+            'cg_activate' => '1',
+        ]);
+        $contactGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('contactgroup_contact_relation', [
+            'contact_contact_id' => $memberContactId,
+            'contactgroup_cg_id' => $contactGroupId,
+        ]);
+
+        return $contactGroupId;
+    }
+
+    private function createAclGroup(
+        string $name,
+        bool $active,
+        ?int $memberContactId = null,
+        ?int $memberContactGroupId = null,
+    ): void {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => $name,
+            'acl_group_alias' => $name,
+            'acl_group_activate' => $active ? '1' : '0',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        if ($memberContactId !== null) {
+            $this->connection->insert('acl_group_contacts_relations', [
+                'acl_group_id' => $aclGroupId,
+                'contact_contact_id' => $memberContactId,
+            ]);
+        }
+
+        if ($memberContactGroupId !== null) {
+            $this->connection->insert('acl_group_contactgroups_relations', [
+                'acl_group_id' => $aclGroupId,
+                'cg_cg_id' => $memberContactGroupId,
+            ]);
+        }
+    }
+}

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalCredentialRepositoryTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalCredentialRepositoryTest.php
@@ -23,12 +23,25 @@ declare(strict_types=1);
 
 namespace Tests\App\Security\Infrastructure\Dbal;
 
+use App\Security\Domain\Aggregate\Credential;
+use App\Security\Domain\Aggregate\Permission;
 use App\Security\Domain\Exception\CredentialNotFoundException;
+use App\Security\Infrastructure\Dbal\DbalAccessGroupRepository;
 use App\Security\Infrastructure\Dbal\DbalCredentialRepository;
+use App\Security\Infrastructure\Dbal\DbalCredentialTransformer;
+use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\Connection;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
+/**
+ * @phpstan-import-type RowTypeAlias from DbalCredentialRepository
+ */
 final class DbalCredentialRepositoryTest extends KernelTestCase
 {
+    private const CUSTOMER_ADMIN_ACCESS_GROUP_NAME = 'customer_admin_acl';
+
+    private Connection $connection;
+
     private DbalCredentialRepository $repository;
 
     protected function setUp(): void
@@ -36,6 +49,10 @@ final class DbalCredentialRepositoryTest extends KernelTestCase
         /** @var DbalCredentialRepository $repository */
         $repository = self::getContainer()->get(DbalCredentialRepository::class);
         $this->repository = $repository;
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
     }
 
     public function testGetByUsernameReturnsCredential(): void
@@ -50,5 +67,103 @@ final class DbalCredentialRepositoryTest extends KernelTestCase
     {
         $this->expectException(CredentialNotFoundException::class);
         $this->repository->getByUsername('invalid-user');
+    }
+
+    public function testContactAdminIsSuperAdmin(): void
+    {
+        [, $username] = $this->createContact(admin: true);
+
+        $credential = $this->repository->getByUsername($username);
+
+        self::assertTrue($credential->isSuperAdmin());
+        self::assertFalse($credential->isCloudAdmin());
+        self::assertTrue($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+    }
+
+    public function testCustomerAdminAclMemberIsCloudAdminOnCloud(): void
+    {
+        [$contactId, $username] = $this->createContact(admin: false);
+        $this->addToCustomerAdminAccessGroup($contactId);
+
+        $credential = $this->repositoryFor(isCloudPlatform: true)->getByUsername($username);
+
+        self::assertFalse($credential->isSuperAdmin());
+        self::assertTrue($credential->isCloudAdmin());
+        self::assertTrue($credential->hasUnrestrictedResourceAccess());
+
+        // Escaping resource scoping does not hand out menu access: with no ACL topology
+        // rule of its own, the contact is granted nothing.
+        self::assertFalse($credential->isPermissionGranted(new Permission('can_read_host_groups')));
+    }
+
+    public function testCustomerAdminAclMemberIsNotCloudAdminOnPrem(): void
+    {
+        [$contactId, $username] = $this->createContact(admin: false);
+        $this->addToCustomerAdminAccessGroup($contactId);
+
+        $credential = $this->repositoryFor(isCloudPlatform: false)->getByUsername($username);
+
+        self::assertFalse($credential->isCloudAdmin());
+        self::assertFalse($credential->hasUnrestrictedResourceAccess());
+    }
+
+    public function testPlainContactIsNoAdminOnCloud(): void
+    {
+        [, $username] = $this->createContact(admin: false);
+
+        $credential = $this->repositoryFor(isCloudPlatform: true)->getByUsername($username);
+
+        self::assertFalse($credential->isSuperAdmin());
+        self::assertFalse($credential->isCloudAdmin());
+    }
+
+    /**
+     * The container-built repository reads IS_CLOUD_PLATFORM, which is unset under test;
+     * building it by hand is the only way to exercise both platform kinds.
+     */
+    private function repositoryFor(bool $isCloudPlatform): DbalCredentialRepository
+    {
+        /** @var TransformerInterface<RowTypeAlias, Credential> $transformer */
+        $transformer = self::getContainer()->get(DbalCredentialTransformer::class);
+
+        return new DbalCredentialRepository(
+            $this->connection,
+            $transformer,
+            new DbalAccessGroupRepository($this->connection),
+            $isCloudPlatform,
+        );
+    }
+
+    /**
+     * @return array{int, non-empty-string} contact id and alias
+     */
+    private function createContact(bool $admin): array
+    {
+        $alias = 'credential-' . bin2hex(random_bytes(8));
+
+        $this->connection->insert('contact', [
+            'contact_name' => $alias,
+            'contact_alias' => $alias,
+            'contact_admin' => $admin ? '1' : '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => $alias . '@email.com',
+        ]);
+
+        return [(int) $this->connection->lastInsertId(), $alias];
+    }
+
+    private function addToCustomerAdminAccessGroup(int $contactId): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => self::CUSTOMER_ADMIN_ACCESS_GROUP_NAME,
+            'acl_group_alias' => self::CUSTOMER_ADMIN_ACCESS_GROUP_NAME,
+            'acl_group_activate' => '1',
+        ]);
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => (int) $this->connection->lastInsertId(),
+            'contact_contact_id' => $contactId,
+        ]);
     }
 }

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalCredentialTransformerTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalCredentialTransformerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Security\Infrastructure\Dbal;
+
+use App\Security\Domain\Aggregate\Credential;
+use App\Security\Infrastructure\Dbal\DbalCredentialRepository;
+use App\Security\Infrastructure\Dbal\DbalCredentialTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Whether the contact actually is a Cloud admin is resolved by {@see DbalCredentialRepository}
+ * and reaches the transformer as the "is_cloud_admin" row key — the on-premise / Cloud
+ * branching itself is covered by DbalCredentialRepositoryTest.
+ *
+ * @phpstan-import-type RowTypeAlias from DbalCredentialRepository
+ */
+final class DbalCredentialTransformerTest extends TestCase
+{
+    #[DataProvider('adminshipProvider')]
+    public function testAdminshipIsMappedToRoles(
+        bool $contactAdmin,
+        bool $isCloudAdmin,
+        bool $expectedSuperAdmin,
+        bool $expectedCloudAdmin,
+    ): void {
+        $credential = $this->transform($contactAdmin, $isCloudAdmin);
+
+        self::assertSame($expectedSuperAdmin, $credential->isSuperAdmin());
+        self::assertSame($expectedCloudAdmin, $credential->isCloudAdmin());
+        self::assertSame($expectedSuperAdmin || $expectedCloudAdmin, $credential->hasUnrestrictedResourceAccess());
+    }
+
+    /**
+     * @return iterable<string, array{bool, bool, bool, bool}>
+     */
+    public static function adminshipProvider(): iterable
+    {
+        yield 'plain contact' => [false, false, false, false];
+
+        yield 'super admin' => [true, false, true, false];
+
+        yield 'cloud admin' => [false, true, false, true];
+
+        yield 'both' => [true, true, true, true];
+    }
+
+    public function testIdentityIsMapped(): void
+    {
+        $credential = $this->transform(contactAdmin: false, isCloudAdmin: false);
+
+        self::assertSame('jdoe', $credential->identifier->value);
+        self::assertSame(42, $credential->userId->value);
+        self::assertTrue($credential->active);
+    }
+
+    private function transform(bool $contactAdmin, bool $isCloudAdmin): Credential
+    {
+        /** @var RowTypeAlias $row */
+        $row = [
+            'c_id' => 42,
+            'c_alias' => 'jdoe',
+            'c_admin' => $contactAdmin ? '1' : '0',
+            'c_active' => '1',
+            'is_cloud_admin' => $isCloudAdmin,
+            'topology_permissions' => [],
+            'action_rules' => [],
+        ];
+
+        return (new DbalCredentialTransformer())->transform($row);
+    }
+}


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x`: stores adminship on the `Credential` aggregate. Adds `isSuperAdmin()`, `isCloudAdmin()` and `hasUnrestrictedResourceAccess()`, short-circuits permission checks for super admins, and introduces the access-group repository backing it.

**Fixes** MON-208941

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.10.x

## How this pull request can be tested ?

- Backend: PHPStan + App unit suite green (Credential aggregate, transformer and access-group repository covered).

## Stacked PR

Based on #11595 — merge that first.

## Cross-repo dependent

centreon/centreon-modules#9263 (BAM credential fixture) depends on this PR — merge it only after this one lands on `dev-26.10.x`.
