### PR TITLE
feat(host-template): expose GET /configuration/host_templates selector

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -99,8 +99,7 @@ tags:
     description: "Resource 'Upgrade' operations."
   - name: HostGroup
     description: "Resource 'HostGroup' operations."
-  -
-    name: HostTemplate
+  - name: HostTemplate
     description: "Resource 'HostTemplate' operations."
 security:
   -
@@ -10217,8 +10216,7 @@ components:
           type: string
     HostTemplate.HostTemplateCollectionOutput.jsonld:
       allOf:
-        -
-          $ref: '#/components/schemas/HydraItemBaseSchema'
+        - $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:

--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -99,6 +99,9 @@ tags:
     description: "Resource 'Upgrade' operations."
   - name: HostGroup
     description: "Resource 'HostGroup' operations."
+  -
+    name: HostTemplate
+    description: "Resource 'HostTemplate' operations."
 security:
   -
     Token: []
@@ -4986,6 +4989,77 @@ paths:
           name: 'name[lk]'
           in: query
           description: 'Filter by host group name using "like" operator'
+          required: false
+          deprecated: false
+          schema:
+            type: string
+          style: form
+          explode: true
+        -
+          name: page
+          in: query
+          description: 'The collection page number'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 1
+          style: form
+          explode: true
+        -
+          name: itemsPerPage
+          in: query
+          description: 'The number of items per page'
+          required: false
+          deprecated: false
+          schema:
+            type: integer
+            default: 30
+            minimum: 0
+            maximum: 30
+          style: form
+          explode: true
+  /api/configuration/host_templates:
+    get:
+      operationId: api_configurationhost_templates_get_collection
+      tags:
+        - HostTemplate
+      responses:
+        '200':
+          description: 'HostTemplate collection'
+          content:
+            application/ld+json:
+              schema:
+                type: object
+                description: 'HostTemplate.HostTemplateCollectionOutput.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: [member], properties: { member: { type: array, items: { $ref: '#/components/schemas/HostTemplate.HostTemplateCollectionOutput.jsonld' } } } }
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HostTemplate.HostTemplateCollectionOutput'
+        '403':
+          description: Forbidden
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Error.jsonld'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          links: {}
+      summary: 'Retrieves the collection of HostTemplate resources.'
+      description: 'Retrieves the collection of HostTemplate resources.'
+      parameters:
+        -
+          name: 'name[lk]'
+          in: query
+          description: 'Filter by host template name using "like" operator'
           required: false
           deprecated: false
           schema:
@@ -10127,6 +10201,24 @@ components:
     Poller.PollerCollectionOutput.jsonld:
       allOf:
         - $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+    HostTemplate.HostTemplateCollectionOutput:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    HostTemplate.HostTemplateCollectionOutput.jsonld:
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
         -
           type: object
           properties:

--- a/centreon/phpstan.new.baseline.neon
+++ b/centreon/phpstan.new.baseline.neon
@@ -11,9 +11,3 @@ parameters:
 			identifier: trait.unused
 			count: 1
 			path: src/App/Shared/Domain/Repository/SearchableCriteriaTrait.php
-
-		-
-			message: '#^Trait App\\Shared\\Infrastructure\\Dbal\\DbalCriteriaApplierTrait is used zero times and is not analysed\.$#'
-			identifier: trait.unused
-			count: 1
-			path: src/App/Shared/Infrastructure/Dbal/DbalCriteriaApplierTrait.php

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostSeverity/HostSeverityId.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostSeverity/HostSeverityId.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostSeverity;
+
+use App\Shared\Domain\Aggregate\AggregateRootId;
+
+final readonly class HostSeverityId extends AggregateRootId
+{
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostTemplate/HostTemplate.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostTemplate/HostTemplate.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostTemplate;
+
+use App\Shared\Domain\Aggregate\AggregateRoot;
+
+/**
+ * @extends AggregateRoot<HostTemplateId>
+ */
+final class HostTemplate extends AggregateRoot
+{
+    public function __construct(
+        ?HostTemplateId $id,
+        public readonly HostTemplateName $name,
+    ) {
+        parent::__construct($id);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostTemplate/HostTemplateId.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostTemplate/HostTemplateId.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostTemplate;
+
+use App\Shared\Domain\Aggregate\AggregateRootId;
+
+final readonly class HostTemplateId extends AggregateRootId
+{
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostTemplate/HostTemplateName.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/HostTemplate/HostTemplateName.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Aggregate\HostTemplate;
+
+use Webmozart\Assert\Assert;
+
+final readonly class HostTemplateName
+{
+    public const MIN_LENGTH = 1;
+    public const MAX_LENGTH = 200;
+
+    public function __construct(
+        public string $value,
+    ) {
+        Assert::lengthBetween($value, self::MIN_LENGTH, self::MAX_LENGTH);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/HostTemplateCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/HostTemplateCriteria.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Repository\Criteria;
+
+use App\Security\Domain\Aggregate\UserId;
+use Webmozart\Assert\Assert;
+
+final class HostTemplateCriteria
+{
+    private ?int $page = null;
+
+    private ?int $itemsPerPage = null;
+
+    private ?string $name = null;
+
+    private ?UserId $viewerId = null;
+
+    public function withPagination(int $page, int $itemsPerPage): self
+    {
+        Assert::positiveInteger($page);
+        Assert::positiveInteger($itemsPerPage);
+
+        $new = clone $this;
+        $new->page = $page;
+        $new->itemsPerPage = $itemsPerPage;
+
+        return $new;
+    }
+
+    public function withName(string $name): self
+    {
+        // notEmpty() relies on empty(), which would wrongly reject a legitimate name of "0"
+        Assert::stringNotEmpty($name);
+
+        $new = clone $this;
+        $new->name = $name;
+
+        return $new;
+    }
+
+    /**
+     * @param UserId|null $viewerId the user to scope results for, or null when no ACL restriction applies (e.g. an admin)
+     */
+    public function withViewerId(?UserId $viewerId): self
+    {
+        $new = clone $this;
+        $new->viewerId = $viewerId;
+
+        return $new;
+    }
+
+    public function getPage(): ?int
+    {
+        return $this->page;
+    }
+
+    public function getItemsPerPage(): ?int
+    {
+        return $this->itemsPerPage;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getViewerId(): ?UserId
+    {
+        return $this->viewerId;
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/HostTemplateRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/HostTemplateRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Repository;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplate;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostTemplateCriteria;
+
+interface HostTemplateRepository
+{
+    /**
+     * @return \IteratorAggregate<int, HostTemplate>&\Countable
+     */
+    public function findAll(?HostTemplateCriteria $criteria = null): \IteratorAggregate&\Countable;
+}

--- a/centreon/src/App/MonitoringConfiguration/Domain/Security/HostTemplatePermissionEnum.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Security/HostTemplatePermissionEnum.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Domain\Security;
+
+enum HostTemplatePermissionEnum: string
+{
+    case CanRead = 'can_read_host_template';
+    case CanReadAndWrite = 'can_read_and_write_host_template';
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostTemplate/HostTemplateCollectionOutput.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostTemplate/HostTemplateCollectionOutput.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostTemplate;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+final class HostTemplateCollectionOutput
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostTemplate/HostTemplateResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/HostTemplate/HostTemplateResource.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostTemplate;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\OpenApi\Model;
+use App\MonitoringConfiguration\Domain\Security\HostTemplatePermissionEnum;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostTemplate\ListHostTemplatesProvider;
+
+#[ApiResource(
+    shortName: 'HostTemplate',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/configuration/host_templates',
+            provider: ListHostTemplatesProvider::class,
+            output: HostTemplateCollectionOutput::class,
+            openapi: new Model\Operation(
+                parameters: [
+                    new Model\Parameter(
+                        name: 'name[lk]',
+                        in: 'query',
+                        description: 'Filter by host template name using "like" operator',
+                        required: false,
+                        schema: ['type' => 'string'],
+                    ),
+                ],
+            ),
+            security: '
+                is_granted("' . HostTemplatePermissionEnum::CanRead->value . '") or
+                is_granted("' . HostTemplatePermissionEnum::CanReadAndWrite->value . '")',
+            securityMessage: 'You are not allowed to list host templates',
+        ),
+    ],
+)]
+final class HostTemplateResource
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        public int $id,
+
+        public string $name,
+    ) {
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostTemplate/HostTemplateCollectionOutputTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostTemplate/HostTemplateCollectionOutputTransformer.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostTemplate;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplate;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostTemplate\HostTemplateCollectionOutput;
+use App\Shared\Infrastructure\TransformerInterface;
+
+/**
+ * @implements TransformerInterface<HostTemplate, HostTemplateCollectionOutput>
+ */
+final readonly class HostTemplateCollectionOutputTransformer implements TransformerInterface
+{
+    public function transform(mixed $from): HostTemplateCollectionOutput
+    {
+        return new HostTemplateCollectionOutput(
+            id: $from->id()->value,
+            name: $from->name->value,
+        );
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostTemplate/ListHostTemplatesProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostTemplate/ListHostTemplatesProvider.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostTemplate;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplate;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostTemplateCriteria;
+use App\MonitoringConfiguration\Domain\Repository\HostTemplateRepository;
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostTemplate\HostTemplateCollectionOutput;
+use App\Security\Infrastructure\Security\CredentialUser;
+use App\Shared\Domain\Repository\Paginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Webmozart\Assert\Assert;
+
+/**
+ * @implements ProviderInterface<HostTemplateCollectionOutput>
+ */
+final readonly class ListHostTemplatesProvider implements ProviderInterface
+{
+    /**
+     * @param TransformerInterface<HostTemplate, HostTemplateCollectionOutput> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: HostTemplateCollectionOutputTransformer::class)]
+        private TransformerInterface $transformer,
+        private HostTemplateRepository $repository,
+        private Pagination $pagination,
+        private Security $security,
+    ) {
+    }
+
+    /**
+     * @return iterable<HostTemplateCollectionOutput>
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): iterable
+    {
+        $credentialUser = $this->security->getUser();
+        Assert::isInstanceOf($credentialUser, CredentialUser::class);
+        $hasUnrestrictedResourceAccess = $credentialUser->credential->hasUnrestrictedResourceAccess();
+
+        $criteria = new HostTemplateCriteria();
+        if ($this->pagination->isEnabled($operation, $context)) {
+            $itemsPerPage = $this->pagination->getLimit($operation, $context);
+            if ($itemsPerPage <= 0) {
+                throw new BadRequestHttpException('itemsPerPage must be a positive integer.');
+            }
+            $criteria = $criteria->withPagination($this->pagination->getPage($context), $itemsPerPage);
+        }
+
+        /** @var array{name?: mixed} $filters */
+        $filters = $context['filters'] ?? [];
+        $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
+
+        // Users with unrestricted resource access see every host template; others are scoped to their
+        // accessible host severities.
+        $criteria = $hasUnrestrictedResourceAccess
+            ? $criteria
+            : $criteria->withViewerId($credentialUser->credential->userId);
+
+        $hostTemplates = $this->repository->findAll($criteria);
+        $resources = [];
+        foreach ($hostTemplates as $hostTemplate) {
+            $resources[] = $this->transformer->transform($hostTemplate);
+        }
+
+        if (! $hostTemplates instanceof Paginator) {
+            return $resources;
+        }
+
+        return new TraversablePaginator(
+            new \ArrayIterator($resources),
+            $hostTemplates->getCurrentPage(),
+            $hostTemplates->getItemsPerPage(),
+            $hostTemplates->getTotalItems()
+        );
+    }
+
+    private function handleNameFilter(mixed $nameFilter, HostTemplateCriteria $criteria): HostTemplateCriteria
+    {
+        if ($nameFilter === null) {
+            return $criteria;
+        }
+
+        // a client sending "?name=foo" instead of "?name[lk]=foo" lands here as a plain string
+        if (! is_array($nameFilter)) {
+            throw new BadRequestHttpException('The "name" filter must use the "name[lk]=value" format.');
+        }
+
+        $likeValue = $nameFilter['lk'] ?? null;
+        if (is_array($likeValue)) {
+            $likeValue = reset($likeValue);
+        }
+
+        if (! is_string($likeValue) || $likeValue === '') {
+            return $criteria;
+        }
+
+        return $criteria->withName($likeValue);
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostTemplateRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostTemplateRepository.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplate;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostTemplateCriteria;
+use App\MonitoringConfiguration\Domain\Repository\HostTemplateRepository;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Domain\Repository\ResourceAccessRepository;
+use App\Shared\Domain\Collection;
+use App\Shared\Infrastructure\Dbal\DbalCriteriaApplierTrait;
+use App\Shared\Infrastructure\Dbal\DbalRepository;
+use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
+use App\Shared\Infrastructure\TransformerInterface;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * @phpstan-type RowTypeAlias = array{
+ *   host_id: int,
+ *   host_name: string,
+ * }
+ */
+final readonly class DbalHostTemplateRepository extends DbalRepository implements HostTemplateRepository
+{
+    use DbalCriteriaApplierTrait;
+    public const TABLE_NAME = 'host';
+
+    // host templates are host rows discriminated by host_register = '0'
+    private const HOST_TEMPLATE_REGISTER = '0';
+
+    /**
+     * @param TransformerInterface<RowTypeAlias, HostTemplate> $transformer
+     */
+    public function __construct(
+        #[Autowire(service: 'doctrine.dbal.default_connection')]
+        private Connection $connection,
+
+        #[Autowire(service: HostTemplateTransformer::class)]
+        private TransformerInterface $transformer,
+
+        private ResourceAccessRepository $resourceAccessRepository,
+    ) {
+    }
+
+    public function findAll(?HostTemplateCriteria $criteria = null): \IteratorAggregate&\Countable
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('h.host_id', 'h.host_name')
+            ->from(self::TABLE_NAME, 'h')
+            ->where('h.host_register = ' . $qb->createNamedParameter(self::HOST_TEMPLATE_REGISTER))
+            ->orderBy('h.host_id'); // required for deterministic pagination
+
+        if ($criteria instanceof HostTemplateCriteria) {
+            $this->filterByCriteria($qb, $criteria);
+        }
+
+        if ($criteria?->getPage() === null || $criteria->getItemsPerPage() === null) {
+            /** @var array<RowTypeAlias> $rows */
+            $rows = $qb->executeQuery()->fetchAllAssociative();
+
+            return $this->createHostTemplates($rows);
+        }
+
+        $this->paginate($qb, $criteria);
+
+        // total across all pages: countMatching clones $qb and strips its sort/pagination,
+        // so the count is unaffected by the pagination applied above.
+        $count = $this->countMatching($qb, 'COUNT(DISTINCT h.host_id)');
+
+        /** @var array<RowTypeAlias> $rows */
+        $rows = $qb->executeQuery()->fetchAllAssociative();
+
+        return new InMemoryPaginator(
+            items: $this->createHostTemplates($rows),
+            totalItems: $count,
+            currentPage: $criteria->getPage() ?? throw new \LogicException('Unexpected null page'),
+            itemsPerPage: $criteria->getItemsPerPage() ?? throw new \LogicException('Unexpected null items per page'),
+        );
+    }
+
+    private function filterByCriteria(QueryBuilder $qb, HostTemplateCriteria $criteria): void
+    {
+        if (($name = $criteria->getName()) !== null) {
+            $qb->andWhere($qb->expr()->like('h.host_name', $qb->createNamedParameter('%' . $name . '%')));
+        }
+
+        $this->filterByViewer($qb, $criteria);
+    }
+
+    private function filterByViewer(QueryBuilder $qb, HostTemplateCriteria $criteria): void
+    {
+        $viewerId = $criteria->getViewerId();
+        if (! $viewerId instanceof UserId) {
+            return;
+        }
+
+        $accessibleHostSeverities = $this->resourceAccessRepository->findAccessibleHostSeverityIds($viewerId);
+        // null means no host-severity restriction applies — the viewer sees every host template.
+        if (! $accessibleHostSeverities instanceof Collection) {
+            return;
+        }
+
+        $accessibleHostSeverityIds = array_map(
+            static fn (HostSeverityId $hostSeverityId): int => $hostSeverityId->value,
+            $accessibleHostSeverities->toArray()
+        );
+
+        // An empty set means the viewer is restricted but grants no accessible severity: they must see
+        // nothing (fail-closed), matching legacy, which returns [] for a user with no access group and
+        // filters out every severity-less template once a category restriction applies. Forcing an
+        // always-false predicate avoids emitting an `IN ()` the driver would reject.
+        if ($accessibleHostSeverityIds === []) {
+            $qb->andWhere('1 = 0');
+
+            return;
+        }
+
+        // Restricted viewer: keep only templates linked to an accessible host severity. This mirrors
+        // legacy findByRequestParametersAndAccessGroups, whose "AND hc.hc_id IN (...)" is applied on a
+        // join filtered by "hc.level IS NOT NULL", so a template linked only to a regular (levelless)
+        // category — or to none — is excluded. The accessible set is already severity-scoped (see
+        // ResourceAccessRepository::findAccessibleHostSeverityIds), so matching the relation id
+        // directly is enough. EXISTS rather than a JOIN keeps LIMIT/OFFSET pagination correct, as
+        // hostcategories_relation carries no per-host uniqueness.
+        $qb->andWhere(
+            'EXISTS (
+                SELECT 1 FROM hostcategories_relation hcr
+                WHERE hcr.host_host_id = h.host_id
+                    AND hcr.hostcategories_hc_id IN (' . $qb->createNamedParameter(
+                $accessibleHostSeverityIds,
+                ArrayParameterType::INTEGER
+            ) . ')
+            )'
+        );
+    }
+
+    /**
+     * @param array<RowTypeAlias> $rows
+     *
+     * @return Collection<HostTemplate>
+     */
+    private function createHostTemplates(array $rows): Collection
+    {
+        return new Collection(
+            array_map(
+                fn (array $row): HostTemplate => $this->transformer->transform($row),
+                $rows
+            ),
+            HostTemplate::class
+        );
+    }
+
+    private function paginate(QueryBuilder $qb, HostTemplateCriteria $criteria): void
+    {
+        if ($criteria->getPage() === null || $criteria->getItemsPerPage() === null) {
+            return;
+        }
+
+        $qb->setFirstResult(($criteria->getPage() - 1) * $criteria->getItemsPerPage())
+            ->setMaxResults($criteria->getItemsPerPage());
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/HostTemplateTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/HostTemplateTransformer.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplate;
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplateId;
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplateName;
+use App\Shared\Infrastructure\TransformerInterface;
+
+/**
+ * @phpstan-import-type RowTypeAlias from DbalHostTemplateRepository
+ *
+ * @implements TransformerInterface<RowTypeAlias,HostTemplate>
+ */
+final readonly class HostTemplateTransformer implements TransformerInterface
+{
+    /**
+     * @param RowTypeAlias $from
+     */
+    public function transform(mixed $from): HostTemplate
+    {
+        return new HostTemplate(
+            id: new HostTemplateId($from['host_id']),
+            name: new HostTemplateName($from['host_name']),
+        );
+    }
+}

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Security/HostTemplatePermissionVoter.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Security/HostTemplatePermissionVoter.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\MonitoringConfiguration\Infrastructure\Security;
+
+use App\MonitoringConfiguration\Domain\Security\HostTemplatePermissionEnum;
+use App\Security\Domain\Aggregate\Permission;
+use App\Security\Infrastructure\Security\CredentialUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<value-of<HostTemplatePermissionEnum>, mixed>
+ */
+final class HostTemplatePermissionVoter extends Voter
+{
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return HostTemplatePermissionEnum::tryFrom($attribute) !== null;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
+    {
+        $user = $token->getUser();
+
+        if (! $user instanceof CredentialUser) {
+            $vote?->addReason('The user is not logged in.');
+
+            return false;
+        }
+
+        if (! $user->credential->isPermissionGranted(new Permission($attribute))) {
+            $vote?->addReason('The user has not the required permission.');
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/centreon/src/App/Security/Domain/Repository/ResourceAccessRepository.php
+++ b/centreon/src/App/Security/Domain/Repository/ResourceAccessRepository.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App\Security\Domain\Repository;
 
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
+use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\Security\Domain\Aggregate\UserId;
 use App\Shared\Domain\Collection;
@@ -33,6 +34,19 @@ interface ResourceAccessRepository
     public function hasAccessToAllPollers(UserId $userId): bool;
 
     public function hasAccessToPoller(PollerId $pollerId, UserId $userId): bool;
+
+    /**
+     * Returns the host severities (host categories carrying a level) the user is restricted to.
+     *
+     * Three states, mirroring the legacy host-template ACL (DbReadHostTemplateRepository::
+     * findByRequestParametersAndAccessGroups):
+     *  - null                   → no restriction applies; the user sees host templates of any severity
+     *  - an empty Collection    → the user is restricted but grants no accessible severity: sees nothing
+     *  - a non-empty Collection → the user is restricted to exactly these severities
+     *
+     * @return Collection<HostSeverityId>|null
+     */
+    public function findAccessibleHostSeverityIds(UserId $userId): ?Collection;
 
     /**
      * @return Collection<PollerId>|null null means no restriction applies (the user can access

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalCredentialTransformer.php
@@ -28,6 +28,7 @@ use App\MonitoringConfiguration\Domain\Security\CommandPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\ConnectorPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\GlobalMacroPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\HostGroupPermissionEnum;
+use App\MonitoringConfiguration\Domain\Security\HostTemplatePermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\PollerPermissionEnum;
 use App\MonitoringConfiguration\Domain\Security\ServiceCategoryPermissionEnum;
 use App\Security\Domain\Aggregate\Credential;
@@ -58,6 +59,8 @@ final readonly class DbalCredentialTransformer implements TransformerInterface
         'ROLE_CONFIGURATION_POLLERS_POLLERS_RW' => PollerPermissionEnum::CanReadAndWrite->value,
         'ROLE_CONFIGURATION_HOSTS_HOST_GROUPS_R' => HostGroupPermissionEnum::CanRead->value,
         'ROLE_CONFIGURATION_HOSTS_HOST_GROUPS_RW' => HostGroupPermissionEnum::CanReadAndWrite->value,
+        'ROLE_CONFIGURATION_HOSTS_TEMPLATES_R' => HostTemplatePermissionEnum::CanRead->value,
+        'ROLE_CONFIGURATION_HOSTS_TEMPLATES_RW' => HostTemplatePermissionEnum::CanReadAndWrite->value,
     ];
 
     /**

--- a/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
+++ b/centreon/src/App/Security/Infrastructure/Dbal/DbalResourceAccessRepository.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App\Security\Infrastructure\Dbal;
 
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
+use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\Security\Domain\Aggregate\UserId;
 use App\Security\Domain\Repository\ResourceAccessRepository;
@@ -87,6 +88,62 @@ final readonly class DbalResourceAccessRepository implements ResourceAccessRepos
             'contactId' => $userId->value,
             'pollerId' => $pollerId->value,
         ]);
+    }
+
+    public function findAccessibleHostSeverityIds(UserId $userId): ?Collection
+    {
+        $accessibleAclResQb = $this->getAccessibleAclResourcesQueryBuilder();
+
+        // Tier 1 — legacy `if ($accessGroups === []) return []`: a user with no accessible ACL resource
+        // is fully restricted (fails closed), not unrestricted. Returning an empty Collection keeps the
+        // "sees nothing" contract distinct from the "sees everything" null below.
+        $hasAccessibleResourceQb = $this->connection->createQueryBuilder();
+        $hasAccessibleResourceQb
+            ->select('1')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->setParameter('contactId', $userId->value)
+            ->setMaxResults(1);
+
+        if ($this->connection->fetchOne($hasAccessibleResourceQb->getSQL(), ['contactId' => $userId->value]) === false) {
+            return new Collection([], HostSeverityId::class);
+        }
+
+        // Tier 2 — legacy `hasRestrictedAccessToHostCategories() === false`: accessible resources exist
+        // but none carry a host-category ACL relation (of any level), so no category restriction is in
+        // force and the user sees host templates of any severity.
+        $hasHostCategoryRelationQb = $this->connection->createQueryBuilder();
+        $hasHostCategoryRelationQb
+            ->select('1')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources_hc_relations', 'arhcr', 'arhcr.acl_res_id = accessible_res.acl_res_id')
+            ->setParameter('contactId', $userId->value)
+            ->setMaxResults(1);
+
+        if ($this->connection->fetchOne($hasHostCategoryRelationQb->getSQL(), ['contactId' => $userId->value]) === false) {
+            return null;
+        }
+
+        // Tiers 3 & 4 — legacy `AND hc.hc_id IN (<granted categories>)` on a `hc.level IS NOT NULL`
+        // join: the user is restricted to the host severities (level-bearing categories) their
+        // accessible resources grant. A user granted only regular (levelless) categories yields an
+        // empty set and therefore sees nothing, matching legacy — which never surfaces a severity-less
+        // template once a category restriction is in force.
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('DISTINCT arhcr.hc_id')
+            ->from('(' . $accessibleAclResQb->getSQL() . ')', 'accessible_res')
+            ->innerJoin('accessible_res', 'acl_resources_hc_relations', 'arhcr', 'arhcr.acl_res_id = accessible_res.acl_res_id')
+            ->innerJoin('arhcr', 'hostcategories', 'hc', 'hc.hc_id = arhcr.hc_id')
+            ->where('hc.level IS NOT NULL')
+            ->setParameter('contactId', $userId->value);
+
+        /** @var list<array{hc_id: numeric-string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($qb->getSQL(), ['contactId' => $userId->value]);
+
+        return new Collection(
+            array_map(static fn (array $row): HostSeverityId => new HostSeverityId((int) $row['hc_id']), $rows),
+            HostSeverityId::class,
+        );
     }
 
     public function findAccessiblePollerIds(UserId $userId): ?Collection

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostTemplate/ListHostTemplatesProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/HostTemplate/ListHostTemplatesProviderTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\HostTemplate;
+
+use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\HostTemplate\HostTemplateResource;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Uid\Uuid;
+use Tests\App\Shared\ApiTestCase;
+use Webmozart\Assert\Assert;
+
+final class ListHostTemplatesProviderTest extends ApiTestCase
+{
+    private const BASE_ENDPOINT = '/api/configuration/host_templates';
+
+    // topology pages whose hierarchy builds ROLE_CONFIGURATION_HOSTS_TEMPLATES_R
+    // (Configuration > Hosts > Templates), bridged to HostTemplatePermissionEnum::CanRead
+    // via DbalCredentialTransformer::LEGACY_PERMISSION_MAP.
+    private const HOST_TEMPLATE_READ_TOPOLOGY_PAGES = [6, 601, 60103];
+
+    private Connection $connection;
+
+    private string $tag;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        $this->tag = Uuid::v4()->toRfc4122();
+    }
+
+    public function testItRequiresAuthentication(): void
+    {
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    public function testItIsForbiddenForUserWithoutSufficientAcl(): void
+    {
+        $username = bin2hex(random_bytes(8));
+        $this->createApiUser($this->connection, $username, admin: false);
+        $this->login($username);
+
+        $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testItListsHostTemplatesAsAdminWithOnlyIdAndName(): void
+    {
+        $this->insertHostTemplate("tpl-A-{$this->tag}");
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => "tpl-A-{$this->tag}"]]]);
+        self::assertResponseIsSuccessful();
+        self::assertMatchesResourceCollectionJsonSchema(HostTemplateResource::class);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => "tpl-A-{$this->tag}"],
+            ],
+        ]);
+
+        /** @var list<array<string, mixed>> $member */
+        $member = $response->toArray()['member'];
+        self::assertEqualsCanonicalizing(['@id', '@type', 'id', 'name'], array_keys($member[0]));
+    }
+
+    public function testItFiltersHostTemplatesByNameUsingLikeOperator(): void
+    {
+        $this->insertHostTemplate("match-{$this->tag}");
+        $this->insertHostTemplate("other-{$this->tag}");
+
+        $this->login();
+
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => "match-{$this->tag}"]]]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => "match-{$this->tag}"],
+            ],
+        ]);
+    }
+
+    public function testItPaginatesHostTemplates(): void
+    {
+        $this->insertHostTemplate("pg-{$this->tag}-A");
+        $this->insertHostTemplate("pg-{$this->tag}-B");
+        $this->insertHostTemplate("pg-{$this->tag}-C");
+
+        $this->login();
+
+        // scope to our own rows via the name filter so pre-seeded templates cannot skew the total
+        $response = $this->request('GET', self::BASE_ENDPOINT, [
+            'query' => ['name' => ['lk' => "pg-{$this->tag}-"], 'page' => '1', 'itemsPerPage' => '2'],
+        ]);
+        self::assertResponseIsSuccessful();
+        self::assertCount(2, (array) $response->toArray()['member']);
+        self::assertEquals(3, $response->toArray()['totalItems']);
+    }
+
+    public function testItRestrictsListingToAccessibleSeveritiesForARestrictedUser(): void
+    {
+        // legacy scopes restricted viewers by host *severities* (categories with a level), not by
+        // regular host categories, even when the regular category is in the viewer's ACL.
+        $severityId = $this->insertHostCategory("sev-{$this->tag}", level: 1);
+        $regularId = $this->insertHostCategory("reg-{$this->tag}");
+
+        $inSeverity = $this->insertHostTemplate("acl-severity-{$this->tag}");
+        $this->linkTemplateToCategory($inSeverity, $severityId);
+        $inRegular = $this->insertHostTemplate("acl-regular-{$this->tag}");
+        $this->linkTemplateToCategory($inRegular, $regularId);
+        $this->insertHostTemplate("acl-none-{$this->tag}");
+
+        $username = bin2hex(random_bytes(8));
+        $contactId = $this->createNonAdminContact($username);
+        $this->grantHostTemplateReadTopologyRole($contactId);
+        $this->restrictContactToHostCategories($contactId, [$severityId, $regularId]);
+
+        $this->login($username);
+
+        $response = $this->request('GET', self::BASE_ENDPOINT);
+        self::assertResponseIsSuccessful();
+        // only the severity-linked template is returned; the regular-linked one (though its category
+        // is in the ACL), the uncategorized one, and any pre-seeded templates are excluded.
+        self::assertCount(1, (array) $response->toArray()['member']);
+        self::assertJsonContains([
+            'member' => [
+                ['name' => "acl-severity-{$this->tag}"],
+            ],
+        ]);
+    }
+
+    public function testItIgnoresAnEmptyNameFilter(): void
+    {
+        $this->insertHostTemplate("empty-{$this->tag}");
+
+        $this->login();
+
+        // an empty "like" value must be ignored (not applied, not rejected, not a 500 from the VO)
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '']]]);
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testItFiltersByANameOfLiteralZero(): void
+    {
+        $this->insertHostTemplate('0');
+
+        $this->login();
+
+        // "0" is a legitimate name; the criteria's Assert::stringNotEmpty must not reject it
+        $response = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => ['lk' => '0']]]);
+        self::assertResponseIsSuccessful();
+        self::assertContains('0', array_column((array) $response->toArray()['member'], 'name'));
+    }
+
+    public function testItRejectsAScalarNameFilter(): void
+    {
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['name' => "tpl-{$this->tag}"]]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    public function testItRejectsZeroItemsPerPage(): void
+    {
+        $this->login();
+
+        $this->request('GET', self::BASE_ENDPOINT, ['query' => ['itemsPerPage' => '0']]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    private function insertHostTemplate(string $name): int
+    {
+        $this->connection->insert('host', ['host_name' => $name, 'host_register' => '0', 'host_activate' => '1']);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertHostCategory(string $name, ?int $level = null): int
+    {
+        // a host category with a level is a host "severity"; a levelless one is a regular category
+        $this->connection->insert('hostcategories', ['hc_name' => $name, 'hc_activate' => '1', 'level' => $level]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function linkTemplateToCategory(int $hostTemplateId, int $hostCategoryId): void
+    {
+        $this->connection->insert('hostcategories_relation', [
+            'hostcategories_hc_id' => $hostCategoryId,
+            'host_host_id' => $hostTemplateId,
+        ]);
+    }
+
+    private function createNonAdminContact(string $alias): int
+    {
+        $this->createApiUser($this->connection, $alias, admin: false);
+
+        $contactId = $this->connection->fetchOne(
+            'SELECT contact_id FROM contact WHERE contact_alias = :alias',
+            ['alias' => $alias]
+        );
+        Assert::notFalse($contactId);
+        Assert::scalar($contactId);
+
+        return (int) $contactId;
+    }
+
+    private function grantHostTemplateReadTopologyRole(int $contactId): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => "topology-group-{$this->tag}",
+            'acl_group_alias' => "topology-group-{$this->tag}",
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_topology', [
+            'acl_topo_name' => "topology-rule-{$this->tag}",
+            'acl_topo_alias' => "topology-rule-{$this->tag}",
+            'acl_topo_activate' => '1',
+        ]);
+        $aclTopoId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_topology_relations', [
+            'acl_group_id' => $aclGroupId,
+            'acl_topology_id' => $aclTopoId,
+        ]);
+
+        foreach (self::HOST_TEMPLATE_READ_TOPOLOGY_PAGES as $topologyPage) {
+            $topologyId = $this->connection->fetchOne(
+                'SELECT topology_id FROM topology WHERE topology_page = :page',
+                ['page' => $topologyPage]
+            );
+            Assert::notFalse($topologyId, "topology_page {$topologyPage} not found in fixtures");
+            Assert::scalar($topologyId);
+
+            $this->connection->insert('acl_topology_relations', [
+                'topology_topology_id' => (int) $topologyId,
+                'acl_topo_id' => $aclTopoId,
+                'access_right' => 2, // read-only
+            ]);
+        }
+    }
+
+    /**
+     * @param list<int> $hostCategoryIds
+     */
+    private function restrictContactToHostCategories(int $contactId, array $hostCategoryIds): void
+    {
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => "hc-scope-{$this->tag}",
+            'acl_res_alias' => "hc-scope-{$this->tag}",
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $aclGroupId = $this->connection->fetchOne(
+            'SELECT acl_group_id FROM acl_group_contacts_relations WHERE contact_contact_id = :contactId',
+            ['contactId' => $contactId]
+        );
+        Assert::notFalse($aclGroupId);
+        Assert::scalar($aclGroupId);
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => (int) $aclGroupId,
+        ]);
+
+        foreach ($hostCategoryIds as $hostCategoryId) {
+            $this->connection->insert('acl_resources_hc_relations', [
+                'acl_res_id' => $aclResId,
+                'hc_id' => $hostCategoryId,
+            ]);
+        }
+    }
+}

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostTemplateRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalHostTemplateRepositoryTest.php
@@ -1,0 +1,256 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\MonitoringConfiguration\Infrastructure\Dbal;
+
+use App\MonitoringConfiguration\Domain\Aggregate\HostTemplate\HostTemplate;
+use App\MonitoringConfiguration\Domain\Repository\Criteria\HostTemplateCriteria;
+use App\MonitoringConfiguration\Infrastructure\Dbal\DbalHostTemplateRepository;
+use App\MonitoringConfiguration\Infrastructure\Dbal\HostTemplateTransformer;
+use App\Security\Domain\Aggregate\UserId;
+use App\Security\Infrastructure\Dbal\DbalResourceAccessRepository;
+use App\Shared\Domain\Repository\Paginator;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class DbalHostTemplateRepositoryTest extends KernelTestCase
+{
+    private Connection $connection;
+
+    private DbalHostTemplateRepository $repository;
+
+    private string $tag;
+
+    protected function setUp(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        $this->connection = $connection;
+
+        // The repository has no ApiPlatform consumer yet (that lands with the Provider), so the
+        // container would prune it; construct it directly from the always-public DBAL connection.
+        $this->repository = new DbalHostTemplateRepository(
+            $this->connection,
+            new HostTemplateTransformer(),
+            new DbalResourceAccessRepository($this->connection),
+        );
+
+        // unique per test run so assertions are isolated from any pre-seeded host templates
+        $this->tag = Uuid::v4()->toRfc4122();
+    }
+
+    public function testFindAllReturnsHostTemplatesAndExcludesRegularHosts(): void
+    {
+        $templateName = "tpl-{$this->tag}";
+        $hostName = "host-{$this->tag}";
+        $this->insertHostTemplate($templateName);
+        $this->insertRegularHost($hostName);
+
+        $names = $this->names($this->repository->findAll());
+
+        self::assertContains($templateName, $names);
+        self::assertNotContains($hostName, $names, 'A regular host (host_register = 1) must not appear among host templates.');
+    }
+
+    public function testFindAllFiltersByNameUsingLike(): void
+    {
+        $this->insertHostTemplate("match-{$this->tag}");
+        $this->insertHostTemplate("other-{$this->tag}");
+
+        $names = $this->names($this->repository->findAll((new HostTemplateCriteria())->withName("match-{$this->tag}")));
+
+        self::assertSame(["match-{$this->tag}"], $names);
+    }
+
+    public function testFindAllPaginatesAndReturnsATotalAcrossAllPages(): void
+    {
+        $this->insertHostTemplate("pg-{$this->tag}-A");
+        $this->insertHostTemplate("pg-{$this->tag}-B");
+        $this->insertHostTemplate("pg-{$this->tag}-C");
+
+        // scope to our own rows via the name filter so pre-seeded templates cannot skew the total.
+        // page 2 @ 1 item/page proves the OFFSET arithmetic (a page-1 request cannot).
+        $result = $this->repository->findAll(
+            (new HostTemplateCriteria())->withName("pg-{$this->tag}-")->withPagination(2, 1)
+        );
+
+        self::assertInstanceOf(Paginator::class, $result);
+        self::assertSame(3, $result->getTotalItems());
+        // rows are ordered by host_id (insertion order A, B, C), so page 2 is the second row
+        self::assertSame(["pg-{$this->tag}-B"], $this->names($result));
+    }
+
+    public function testFindAllRestrictsToAccessibleSeveritiesForARestrictedViewer(): void
+    {
+        // legacy scopes restricted viewers by host *severities* (categories with a level), not by
+        // regular host categories, even when the regular category is in the viewer's ACL.
+        $severityId = $this->insertHostCategory("sev-{$this->tag}", level: 1);
+        $regularId = $this->insertHostCategory("reg-{$this->tag}");
+
+        $inSeverity = $this->insertHostTemplate("acl-severity-{$this->tag}");
+        $this->linkTemplateToCategory($inSeverity, $severityId);
+        $inRegular = $this->insertHostTemplate("acl-regular-{$this->tag}");
+        $this->linkTemplateToCategory($inRegular, $regularId);
+        $uncategorizedName = "acl-none-{$this->tag}";
+        $this->insertHostTemplate($uncategorizedName);
+
+        // the viewer's ACL grants BOTH the severity and the regular category
+        $viewerId = new UserId($this->createContactRestrictedToHostCategories([$severityId, $regularId]));
+
+        $names = $this->names($this->repository->findAll((new HostTemplateCriteria())->withViewerId($viewerId)));
+
+        self::assertContains("acl-severity-{$this->tag}", $names);
+        self::assertNotContains("acl-regular-{$this->tag}", $names, 'A template linked only to a regular (levelless) category is excluded even though that category is in the ACL — legacy scopes by severities.');
+        self::assertNotContains($uncategorizedName, $names, 'A template with no category is excluded for a restricted viewer.');
+    }
+
+    public function testFindAllReturnsAllTemplatesForAViewerWithNoCategoryRestriction(): void
+    {
+        $severityId = $this->insertHostCategory("sev-{$this->tag}", level: 1);
+        $categorizedId = $this->insertHostTemplate("acl-in-{$this->tag}");
+        $this->linkTemplateToCategory($categorizedId, $severityId);
+        $uncategorizedName = "acl-out-{$this->tag}";
+        $this->insertHostTemplate($uncategorizedName);
+
+        // ACL resource without any host-category relation → no restriction → sees everything
+        $viewerId = new UserId($this->createContactRestrictedToHostCategories([]));
+
+        $names = $this->names($this->repository->findAll((new HostTemplateCriteria())->withViewerId($viewerId)));
+
+        self::assertContains("acl-in-{$this->tag}", $names);
+        self::assertContains($uncategorizedName, $names);
+    }
+
+    public function testFindAllReturnsNothingForAViewerGrantedOnlyRegularCategories(): void
+    {
+        // A viewer whose ACL restricts to host categories but grants only regular (levelless) ones has
+        // an empty accessible-severity set. Legacy fails closed here (the category restriction is in
+        // force yet no severity matches), so the viewer must see no host template — not everything.
+        $regularId = $this->insertHostCategory("reg-{$this->tag}");
+        $severityId = $this->insertHostCategory("sev-{$this->tag}", level: 1);
+
+        $categorized = $this->insertHostTemplate("acl-sev-{$this->tag}");
+        $this->linkTemplateToCategory($categorized, $severityId);
+        $this->insertHostTemplate("acl-none-{$this->tag}");
+
+        $viewerId = new UserId($this->createContactRestrictedToHostCategories([$regularId]));
+
+        $result = $this->repository->findAll((new HostTemplateCriteria())->withViewerId($viewerId));
+
+        self::assertSame([], $this->names($result), 'A viewer granted only regular categories sees no host template.');
+    }
+
+    /**
+     * @param \IteratorAggregate<int, HostTemplate>&\Countable $result
+     *
+     * @return list<string>
+     */
+    private function names(\IteratorAggregate&\Countable $result): array
+    {
+        return array_values(array_map(
+            static fn (HostTemplate $hostTemplate): string => $hostTemplate->name->value,
+            iterator_to_array($result)
+        ));
+    }
+
+    private function insertHostTemplate(string $name): int
+    {
+        $this->connection->insert('host', ['host_name' => $name, 'host_register' => '0', 'host_activate' => '1']);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertRegularHost(string $name): int
+    {
+        $this->connection->insert('host', ['host_name' => $name, 'host_register' => '1', 'host_activate' => '1']);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function insertHostCategory(string $name, ?int $level = null): int
+    {
+        // a host category with a level is a host "severity"; a levelless one is a regular category
+        $this->connection->insert('hostcategories', ['hc_name' => $name, 'hc_activate' => '1', 'level' => $level]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function linkTemplateToCategory(int $hostTemplateId, int $hostCategoryId): void
+    {
+        $this->connection->insert('hostcategories_relation', [
+            'hostcategories_hc_id' => $hostCategoryId,
+            'host_host_id' => $hostTemplateId,
+        ]);
+    }
+
+    /**
+     * @param list<int> $accessibleHostCategoryIds empty means the ACL resource carries no host-category restriction
+     */
+    private function createContactRestrictedToHostCategories(array $accessibleHostCategoryIds): int
+    {
+        $alias = "viewer-{$this->tag}";
+        $this->connection->insert('contact', [
+            'contact_name' => $alias,
+            'contact_alias' => $alias,
+            'contact_admin' => '0',
+            'contact_register' => '1',
+            'contact_activate' => '1',
+            'contact_email' => $alias . '@email.com',
+        ]);
+        $contactId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => "group-{$this->tag}",
+            'acl_group_alias' => "group-{$this->tag}",
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => "resource-{$this->tag}",
+            'acl_res_alias' => "resource-{$this->tag}",
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($accessibleHostCategoryIds as $hostCategoryId) {
+            $this->connection->insert('acl_resources_hc_relations', [
+                'acl_res_id' => $aclResId,
+                'hc_id' => $hostCategoryId,
+            ]);
+        }
+
+        return $contactId;
+    }
+}

--- a/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
+++ b/centreon/tests/php/App/Security/Infrastructure/Dbal/DbalResourceAccessRepositoryTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Tests\App\Security\Infrastructure\Dbal;
 
 use App\MonitoringConfiguration\Domain\Aggregate\HostGroup\HostGroupId;
+use App\MonitoringConfiguration\Domain\Aggregate\HostSeverity\HostSeverityId;
 use App\MonitoringConfiguration\Domain\Aggregate\Poller\PollerId;
 use App\Security\Domain\Aggregate\UserId;
 use App\Security\Infrastructure\Dbal\DbalResourceAccessRepository;
@@ -51,6 +52,87 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
         $this->connection->insert('nagios_server', ['id' => 102, 'name' => 'Poller-102', 'localhost' => '0', 'ns_activate' => '1', 'ns_ip_address' => '10.0.0.102', 'uid' => 200000000000102]);
         $this->connection->insert('hostgroup', ['hg_id' => 201, 'hg_name' => 'HostGroup-201']);
         $this->connection->insert('hostgroup', ['hg_id' => 202, 'hg_name' => 'HostGroup-202']);
+    }
+
+    public function testUserWithNoAclGroupSeesNoHostSeverity(): void
+    {
+        // Legacy `if ($accessGroups === []) return []`: a user with no accessible ACL resource is
+        // fully restricted (fails closed), returning an empty Collection rather than the null "see all".
+        $userId = new UserId($this->createContact('user-no-acl-hs'));
+
+        $accessibleSeverities = $this->repository->findAccessibleHostSeverityIds($userId);
+
+        self::assertNotNull($accessibleSeverities);
+        self::assertSame([], $accessibleSeverities->toArray());
+    }
+
+    public function testUserWithAclResourceHavingNoHostSeverityRestrictionReturnsNull(): void
+    {
+        $contactId = $this->createContact('user-unrestricted-hs');
+        $this->linkContactToHostSeverityAclResource($contactId, restrictToHostSeverityIds: []);
+
+        self::assertNull($this->repository->findAccessibleHostSeverityIds(new UserId($contactId)));
+    }
+
+    public function testUserWithAclResourceGrantingOnlyRegularCategoriesSeesNoHostSeverity(): void
+    {
+        // Legacy pivot: hasRestrictedAccessToHostCategories() is true as soon as the ACL carries any
+        // host-category relation (regardless of level), and the level-scoped join then surfaces no
+        // severity for a resource granting only regular (levelless) categories — so the user sees
+        // nothing. The empty Collection (not null) preserves that fail-closed behaviour.
+        $regularCategory = $this->insertHostCategory('HC-regular-only');
+
+        $contactId = $this->createContact('user-regular-only-hs');
+        $this->linkContactToHostSeverityAclResource($contactId, restrictToHostSeverityIds: [$regularCategory]);
+
+        $accessibleSeverities = $this->repository->findAccessibleHostSeverityIds(new UserId($contactId));
+
+        self::assertNotNull($accessibleSeverities, 'A resource granting only regular categories must not grant access to every severity.');
+        self::assertSame([], $accessibleSeverities->toArray());
+    }
+
+    public function testUserWithAclResourceRestrictedToHostSeveritiesReturnsOnlySeverityIds(): void
+    {
+        $severityA = $this->insertHostSeverity('HS-A');
+        $severityB = $this->insertHostSeverity('HS-B');
+        $this->insertHostSeverity('HS-C'); // not linked to the user
+        // a levelless (regular) category granted through the same resource must be filtered out
+        $regularCategory = $this->insertHostCategory('HC-regular');
+
+        $contactId = $this->createContact('user-restricted-hs');
+        $this->linkContactToHostSeverityAclResource(
+            $contactId,
+            restrictToHostSeverityIds: [$severityA, $severityB, $regularCategory]
+        );
+
+        $accessibleSeverities = $this->repository->findAccessibleHostSeverityIds(new UserId($contactId));
+
+        self::assertNotNull($accessibleSeverities);
+        $accessibleIds = array_map(
+            static fn (HostSeverityId $hostSeverityId): int => $hostSeverityId->value,
+            $accessibleSeverities->toArray()
+        );
+        self::assertEqualsCanonicalizing([$severityA, $severityB], $accessibleIds);
+    }
+
+    public function testUserWithOneRestrictedAndOneUnrelatedResourceStaysRestrictedToTheUnion(): void
+    {
+        // Regression for the mixed-resource over-exposure class of bug (see PR #11523): a second
+        // accessible resource that carries no host-severity relation must NOT widen access to "all".
+        // The accessible set is the union across every resource; unrestricted only when zero anywhere.
+        $severityA = $this->insertHostSeverity('HS-A');
+
+        $contactId = $this->createContact('user-mixed-hs');
+        $this->linkContactToHostSeverityAclResource($contactId, restrictToHostSeverityIds: [$severityA]);
+        $this->linkContactToHostSeverityAclResource($contactId, restrictToHostSeverityIds: []);
+
+        $accessibleSeverities = $this->repository->findAccessibleHostSeverityIds(new UserId($contactId));
+
+        self::assertNotNull($accessibleSeverities, 'A resource with no host-severity relation must not grant access to every severity.');
+        self::assertEqualsCanonicalizing(
+            [$severityA],
+            array_map(static fn (HostSeverityId $id): int => $id->value, $accessibleSeverities->toArray())
+        );
     }
 
     public function testUserWithNoAclGroupHasAccessToAllPollers(): void
@@ -177,6 +259,23 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
         self::assertNull($this->repository->findAccessibleHostGroupIds($userId));
     }
 
+    private function insertHostSeverity(string $name): int
+    {
+        // a host category carrying a level is a host "severity"
+        return $this->insertHostCategory($name, level: 1);
+    }
+
+    private function insertHostCategory(string $name, ?int $level = null): int
+    {
+        $this->connection->insert('hostcategories', [
+            'hc_name' => $name,
+            'hc_activate' => '1',
+            'level' => $level,
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
     private function createContact(string $alias): int
     {
         $this->connection->insert('contact', [
@@ -189,6 +288,45 @@ final class DbalResourceAccessRepositoryTest extends KernelTestCase
         ]);
 
         return (int) $this->connection->lastInsertId();
+    }
+
+    /**
+     * @param list<int> $restrictToHostSeverityIds hc_ids granted through this resource's relations
+     *                                             (the shared acl_resources_hc_relations table); empty
+     *                                             means the resource carries no host-severity restriction
+     */
+    private function linkContactToHostSeverityAclResource(int $contactId, array $restrictToHostSeverityIds): void
+    {
+        $this->connection->insert('acl_groups', [
+            'acl_group_name' => 'hs-group-' . $contactId . '-' . random_int(1, PHP_INT_MAX),
+            'acl_group_alias' => 'hs-group-' . $contactId . '-' . random_int(1, PHP_INT_MAX),
+            'acl_group_activate' => '1',
+        ]);
+        $aclGroupId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_group_contacts_relations', [
+            'acl_group_id' => $aclGroupId,
+            'contact_contact_id' => $contactId,
+        ]);
+
+        $this->connection->insert('acl_resources', [
+            'acl_res_name' => 'hs-resource-' . $aclGroupId,
+            'acl_res_alias' => 'hs-resource-' . $aclGroupId,
+            'acl_res_activate' => '1',
+        ]);
+        $aclResId = (int) $this->connection->lastInsertId();
+
+        $this->connection->insert('acl_res_group_relations', [
+            'acl_res_id' => $aclResId,
+            'acl_group_id' => $aclGroupId,
+        ]);
+
+        foreach ($restrictToHostSeverityIds as $hostCategoryId) {
+            $this->connection->insert('acl_resources_hc_relations', [
+                'acl_res_id' => $aclResId,
+                'hc_id' => $hostCategoryId,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Backport to `dev-26.10.x` of the host template selector: exposes `GET /configuration/host_templates` returning `{id, name}` as a Hydra collection with name filtering and pagination.

**Fixes** MON-208977

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 26.10.x

## How this pull request can be tested ?

- `GET /api/configuration/host_templates` returns a Hydra collection of `{id, name}`.
- Filter by name and paginate.
- Backend: PHPStan + App unit suite green.

## Stacked PR

Based on #11596 — merge that first.