### PR TITLE
fix(unattended): add 26.10 to the supported versions

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -35,7 +35,7 @@ trap 'on_error "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
 OPTIONS="hsDt:v:r:l:p:d:V:-:"
 declare -A SUPPORTED_LOG_LEVEL=([DEBUG]=0 [INFO]=1 [WARN]=2 [ERROR]=3)
 declare -A SUPPORTED_TOPOLOGY=([central]=1 [poller]=1)
-declare -A SUPPORTED_VERSION=([24.10]=1 [25.10]=1 [26.07]=1)
+declare -A SUPPORTED_VERSION=([24.10]=1 [25.10]=1 [26.07]=1 [26.10]=1)
 declare -A SUPPORTED_REPOSITORY=([testing-hotfix]=1 [testing-release]=1 [unstable]=1 [stable]=1)
 declare -A SUPPORTED_DBMS=([MariaDB]=1 [MySQL]=1)
 declare -A SUPPORTED_TLS=([enabled]=1 [disabled]=1)
@@ -121,7 +121,7 @@ function usage() {
 	echo
 	echo "Usage:"
 	echo
-	echo " $script_short_name [install|update (default: install)] [-t <central|poller> (default: central)] [-v <24.10|25.10|26.07> (default: 25.10)] [-r <stable|testing-hotfix|testing-release|unstable> (default: stable)] [-d <MariaDB|MySQL> (default: MariaDB)] [--tls <enabled|disabled> (default: disabled)] [-l <DEBUG|INFO|WARN|ERROR>] [-s (for silent install)] [-p <centreon admin password>] [-D (enable debug mode: shell xtrace + DEBUG log level)] [-h (show this help output)] [-V configure a vault, using format <address>;<port>;<root_path>;<role_id>;<secret_id>]"
+	echo " $script_short_name [install|update (default: install)] [-t <central|poller> (default: central)] [-v <24.10|25.10|26.07|26.10> (default: 25.10)] [-r <stable|testing-hotfix|testing-release|unstable> (default: stable)] [-d <MariaDB|MySQL> (default: MariaDB)] [--tls <enabled|disabled> (default: disabled)] [-l <DEBUG|INFO|WARN|ERROR>] [-s (for silent install)] [-p <centreon admin password>] [-D (enable debug mode: shell xtrace + DEBUG log level)] [-h (show this help output)] [-V configure a vault, using format <address>;<port>;<root_path>;<role_id>;<secret_id>]"
 	echo
 	echo Example:
 	echo


### PR DESCRIPTION
## Description

`unattended.sh` rejects `-v 26.10`:

```
ERROR - Unsupported version: 26.10
```

`26.10` was simply missing from the `SUPPORTED_VERSION` whitelist, so the argument
was refused before any of the install logic ran.

Fixes MON-209074.

## Changes

- add `[26.10]=1` to `SUPPORTED_VERSION`
- list `26.10` in the `-v` usage line

## Is 26.10 needed anywhere else in the script?

No. I audited every version-dependent branch. All of them (except the whitelist) go
through `version_int()` `>=` comparisons, so `26.10` (2610) already lands on the right
side of each gate:

| Location | Gate | 26.10 result |
|---|---|---|
| `set_mariadb_repos` | `>= 26.07` | MariaDB 11.8 ✔ |
| `setup_mysql` | `>= 26.07` | MySQL 8.4 ✔ |
| el8 branch | `>= 26.07` → error | rejected ✔ |
| el9 branch | `>= 26.07` | PHP 8.4 via remi ✔ |
| el10 branch | `< 26.07` → error | accepted ✔ |
| Debian 13 | `< 26.07` → error | accepted, PHP 8.4 ✔ |
| Debian 12 | whitelist `24.10`/`25.10` | rejected ✔ (same as 26.07) |
| `install_central` / `install_poller` | `24.10..24.12` | not matched ✔ |
| `play_install_wizard` step4 | `case "24."*` | falls to default ✔ |
| `uses_internal_repo` | minor `!= "10"` | public repo ✔ |

The two remaining literal whitelists (`"24.10" | "25.10"` for PHP on el8, and the
Debian 12 gate) are only reachable for versions `< 26.07`, or intentionally exclude
`>= 26.07` — so they are already correct for 26.10 and left untouched.

## Tests

No Docker available locally, so I drove the script's own code from a harness that sources
everything above `MAIN SCRIPT EXECUTION`, fakes `/etc/os-release` and stubs the package
managers. **49 assertions, all passing.** Nothing in the harness re-implements a version
condition: each check either calls the shipped function or `eval`s the verbatim source range.

Real functions called directly:

- `parse_subcommand_options` — `-v 24.10/25.10/26.07/26.10` accepted, `26.09`/`27.10` rejected
- `set_required_prerequisite` — el8/el9/el10/deb12/deb13 x 26.07/26.10/25.10, asserting both the
  accept/reject verdict and the resulting `PHP_SERVICE_UNIT`
- `set_release_repo_file` / `set_centreon_repos` — 26.10 URL and repo-name output
- `set_mariadb_repos` — 26.10 yields `detected_mariadb_version=11.8` **and** the real args handed to
  the repo-setup script (`--mariadb-server-version=mariadb-11.8` on el9, `=11.8` on deb13); 25.10 yields 10.11
- `setup_mysql` — 26.10 yields `detected_mysql_version=8.4`; 25.10 yields 8.0
- `version_int` / `uses_internal_repo`

Verbatim source ranges extracted from the file and evaluated (not retyped):

- the `case $version` step4 block in `play_install_wizard` — 26.10 takes the non-`cbmod` payload
- the `install_central` PHP-selection block — 26.10 → PHP 8.4, including the mismatch path where an
  installed 8.2 correctly overrides the expected 8.4

### Does 26.10 actually propagate?

Yes. Two pieces of evidence:

1. The propagation suite (13 of the 49 assertions, covering MariaDB/MySQL/PHP/wizard) passes
   **identically on unmodified `develop` and on this branch**. That is the expected result and the
   point of running it: those paths were never version-whitelisted, so once the argument is accepted
   they already handle 26.10. The whitelist was the only thing blocking it.
2. Running the main suite against unmodified `develop` fails on **exactly one** assertion —
   `-v 26.10 accepted`. So this change flips that one gate and nothing else.

I also traced every one of the 21 uses of `$version` in the script; all are covered by the table above.

Verified against the live repositories that the URLs the script builds for 26.10 exist:

- `https://packages.centreon.com/artifactory/rpm-standard/26.10/el9/centreon-26.10.repo` → 200
- `https://packages.centreon.com/artifactory/rpm-standard/26.10/el10/centreon-26.10.repo` → 200

and that the repo IDs published there (`centreon-26.10-stable`, `centreon-26.10-stable-noarch`)
match the `centreon-26.10-stable*` glob the script passes to `--enablerepo`. The internal-vs-public
routing is also consistent: 26.07 resolves to `rpm-standard-internal` (200), 25.10/26.10 to the
public repo (200).

`bash -n` clean; `shellcheck -S error` reports only the 3 pre-existing findings already on `develop`.

## Note for the reviewer

The default version (line 53) is still `25.10` — I did not touch it, since the ticket only
asks to add 26.10 as a supported value. Let me know if the default should move too.
