### PR TITLE
fix(upgrade): use CentreonDB instead of DbalConnectionAdapter for update scripts

### DIFF
--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalModuleRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalModuleRepository.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Infrastructure\Dbal;
 
-use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Domain\Repository\ModuleRepository;
+use App\Upgrade\Infrastructure\Legacy\LegacyConnectionFactory;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -46,7 +46,7 @@ final class DbalModuleRepository implements ModuleRepository
         private readonly Connection $configConnection,
         #[Autowire(param: 'upgrade.modules_dir')]
         private readonly string $modulesDir,
-        private readonly ConnectionConfig $connectionConfig,
+        private readonly LegacyConnectionFactory $legacyConnectionFactory,
         #[Autowire(param: 'upgrade.centreon_path')]
         private readonly string $centreonPath,
         private readonly LoggerInterface $logger,
@@ -292,18 +292,9 @@ final class DbalModuleRepository implements ModuleRepository
             return;
         }
 
-        // TODO: temporary bridge — replace with proper ConnectionInterface injection once module upgrade scripts are migrated
-        $pearDB = new \CentreonDB(connectionConfig: $this->connectionConfig);
-        $pearDBO = new \CentreonDB(connectionConfig: new ConnectionConfig(
-            host: $this->connectionConfig->getHost(),
-            user: $this->connectionConfig->getUser(),
-            password: $this->connectionConfig->getPassword(),
-            databaseNameConfiguration: $this->connectionConfig->getDatabaseNameRealTime(),
-            databaseNameRealTime: $this->connectionConfig->getDatabaseNameRealTime(),
-            port: $this->connectionConfig->getPort(),
-            charset: $this->connectionConfig->getCharset(),
-            driver: $this->connectionConfig->getDriver(),
-        ));
+        // See LegacyConnectionFactory: module upgrade scripts still call legacy CentreonDB/PDO methods.
+        $pearDB = $this->legacyConnectionFactory->createConfigurationConnection();
+        $pearDBO = $this->legacyConnectionFactory->createRealtimeConnection();
         $centreon_path = $this->centreonPath;
 
         require_once $filePath;

--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Infrastructure\Dbal;
 
-use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Domain\Repository\UpdateRepository;
+use App\Upgrade\Infrastructure\Legacy\LegacyConnectionFactory;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
@@ -40,7 +40,7 @@ final readonly class DbalUpdateRepository implements UpdateRepository
         private Connection $configConnection,
         #[Autowire(service: 'doctrine.dbal.realtime_connection')]
         private Connection $realtimeConnection,
-        private ConnectionConfig $connectionConfig,
+        private LegacyConnectionFactory $legacyConnectionFactory,
         #[Autowire(param: 'upgrade.lib_dir')]
         private string $libDir,
         #[Autowire(param: 'upgrade.install_dir')]
@@ -69,12 +69,10 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     public function runScript(string $version): void
     {
-        // TODO: temporary bridge — replace with proper ConnectionInterface injection once upgrade scripts are migrated
         // $pearDB and $pearDBO are exposed as local variables to the included update script.
-        // Core Update-*.php scripts still call legacy CentreonDB/PDO methods (query, prepare, beginTransaction…),
-        // so they need the superset CentreonDB, not the ConnectionInterface-only DbalConnectionAdapter.
-        $pearDB = $this->createLegacyConnection();
-        $pearDBO = $this->createLegacyRealtimeConnection();
+        // See LegacyConnectionFactory: scripts still call legacy CentreonDB/PDO methods.
+        $pearDB = $this->legacyConnectionFactory->createConfigurationConnection();
+        $pearDBO = $this->legacyConnectionFactory->createRealtimeConnection();
 
         $filePath = $this->installDir . '/php/Update-' . $version . '.php';
         if (is_readable($filePath)) {
@@ -93,12 +91,10 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     public function runPostScript(string $version): void
     {
-        // TODO: temporary bridge — replace with proper ConnectionInterface injection once upgrade scripts are migrated
         // $pearDB and $pearDBO are exposed as local variables to the included post-update script.
-        // Core Update-*.post.php scripts still call legacy CentreonDB/PDO methods (query, prepare, beginTransaction…),
-        // so they need the superset CentreonDB, not the ConnectionInterface-only DbalConnectionAdapter.
-        $pearDB = $this->createLegacyConnection();
-        $pearDBO = $this->createLegacyRealtimeConnection();
+        // See LegacyConnectionFactory: scripts still call legacy CentreonDB/PDO methods.
+        $pearDB = $this->legacyConnectionFactory->createConfigurationConnection();
+        $pearDBO = $this->legacyConnectionFactory->createRealtimeConnection();
 
         $filePath = $this->installDir . '/php/Update-' . $version . '.post.php';
         if (is_readable($filePath)) {
@@ -136,31 +132,6 @@ final readonly class DbalUpdateRepository implements UpdateRepository
     public function removeInstallDirectory(): void
     {
         $this->filesystem->remove($this->installDir);
-    }
-
-    /**
-     * Builds a legacy connection to the configuration database exposed to update scripts as $pearDB.
-     */
-    private function createLegacyConnection(): \CentreonDB
-    {
-        return new \CentreonDB(connectionConfig: $this->connectionConfig);
-    }
-
-    /**
-     * Builds a legacy connection to the real-time (storage) database exposed to update scripts as $pearDBO.
-     */
-    private function createLegacyRealtimeConnection(): \CentreonDB
-    {
-        return new \CentreonDB(connectionConfig: new ConnectionConfig(
-            host: $this->connectionConfig->getHost(),
-            user: $this->connectionConfig->getUser(),
-            password: $this->connectionConfig->getPassword(),
-            databaseNameConfiguration: $this->connectionConfig->getDatabaseNameRealTime(),
-            databaseNameRealTime: $this->connectionConfig->getDatabaseNameRealTime(),
-            port: $this->connectionConfig->getPort(),
-            charset: $this->connectionConfig->getCharset(),
-            driver: $this->connectionConfig->getDriver(),
-        ));
     }
 
     private function runSqlFile(Connection $connection, string $filePath): void

--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace App\Upgrade\Infrastructure\Dbal;
 
-use Adaptation\Database\Connection\Adapter\Dbal\DbalConnectionAdapter;
 use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Domain\Repository\UpdateRepository;
 use Doctrine\DBAL\Connection;
@@ -70,10 +69,12 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     public function runScript(string $version): void
     {
+        // TODO: temporary bridge — replace with proper ConnectionInterface injection once upgrade scripts are migrated
         // $pearDB and $pearDBO are exposed as local variables to the included update script.
-        // Scripts expect ConnectionInterface (Adaptation), not raw PDO.
-        $pearDB = DbalConnectionAdapter::createFromDbalConnection($this->configConnection, $this->connectionConfig);
-        $pearDBO = DbalConnectionAdapter::createFromDbalConnection($this->realtimeConnection, $this->connectionConfig);
+        // Core Update-*.php scripts still call legacy CentreonDB/PDO methods (query, prepare, beginTransaction…),
+        // so they need the superset CentreonDB, not the ConnectionInterface-only DbalConnectionAdapter.
+        $pearDB = $this->createLegacyConnection();
+        $pearDBO = $this->createLegacyRealtimeConnection();
 
         $filePath = $this->installDir . '/php/Update-' . $version . '.php';
         if (is_readable($filePath)) {
@@ -92,10 +93,12 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     public function runPostScript(string $version): void
     {
+        // TODO: temporary bridge — replace with proper ConnectionInterface injection once upgrade scripts are migrated
         // $pearDB and $pearDBO are exposed as local variables to the included post-update script.
-        // Scripts expect ConnectionInterface (Adaptation), not raw PDO.
-        $pearDB = DbalConnectionAdapter::createFromDbalConnection($this->configConnection, $this->connectionConfig);
-        $pearDBO = DbalConnectionAdapter::createFromDbalConnection($this->realtimeConnection, $this->connectionConfig);
+        // Core Update-*.post.php scripts still call legacy CentreonDB/PDO methods (query, prepare, beginTransaction…),
+        // so they need the superset CentreonDB, not the ConnectionInterface-only DbalConnectionAdapter.
+        $pearDB = $this->createLegacyConnection();
+        $pearDBO = $this->createLegacyRealtimeConnection();
 
         $filePath = $this->installDir . '/php/Update-' . $version . '.post.php';
         if (is_readable($filePath)) {
@@ -133,6 +136,31 @@ final readonly class DbalUpdateRepository implements UpdateRepository
     public function removeInstallDirectory(): void
     {
         $this->filesystem->remove($this->installDir);
+    }
+
+    /**
+     * Builds a legacy connection to the configuration database exposed to update scripts as $pearDB.
+     */
+    private function createLegacyConnection(): \CentreonDB
+    {
+        return new \CentreonDB(connectionConfig: $this->connectionConfig);
+    }
+
+    /**
+     * Builds a legacy connection to the real-time (storage) database exposed to update scripts as $pearDBO.
+     */
+    private function createLegacyRealtimeConnection(): \CentreonDB
+    {
+        return new \CentreonDB(connectionConfig: new ConnectionConfig(
+            host: $this->connectionConfig->getHost(),
+            user: $this->connectionConfig->getUser(),
+            password: $this->connectionConfig->getPassword(),
+            databaseNameConfiguration: $this->connectionConfig->getDatabaseNameRealTime(),
+            databaseNameRealTime: $this->connectionConfig->getDatabaseNameRealTime(),
+            port: $this->connectionConfig->getPort(),
+            charset: $this->connectionConfig->getCharset(),
+            driver: $this->connectionConfig->getDriver(),
+        ));
     }
 
     private function runSqlFile(Connection $connection, string $filePath): void

--- a/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepository.php
@@ -69,15 +69,18 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     public function runScript(string $version): void
     {
+        $filePath = $this->installDir . '/php/Update-' . $version . '.php';
+        if (! is_readable($filePath)) {
+            return;
+        }
+
         // $pearDB and $pearDBO are exposed as local variables to the included update script.
         // See LegacyConnectionFactory: scripts still call legacy CentreonDB/PDO methods.
+        // Built only once the script exists: each connection opens a real PDO socket.
         $pearDB = $this->legacyConnectionFactory->createConfigurationConnection();
         $pearDBO = $this->legacyConnectionFactory->createRealtimeConnection();
 
-        $filePath = $this->installDir . '/php/Update-' . $version . '.php';
-        if (is_readable($filePath)) {
-            include_once $filePath;
-        }
+        include_once $filePath;
     }
 
     public function runConfigurationSql(string $version): void
@@ -91,15 +94,18 @@ final readonly class DbalUpdateRepository implements UpdateRepository
 
     public function runPostScript(string $version): void
     {
+        $filePath = $this->installDir . '/php/Update-' . $version . '.post.php';
+        if (! is_readable($filePath)) {
+            return;
+        }
+
         // $pearDB and $pearDBO are exposed as local variables to the included post-update script.
         // See LegacyConnectionFactory: scripts still call legacy CentreonDB/PDO methods.
+        // Built only once the script exists: each connection opens a real PDO socket.
         $pearDB = $this->legacyConnectionFactory->createConfigurationConnection();
         $pearDBO = $this->legacyConnectionFactory->createRealtimeConnection();
 
-        $filePath = $this->installDir . '/php/Update-' . $version . '.post.php';
-        if (is_readable($filePath)) {
-            include_once $filePath;
-        }
+        include_once $filePath;
     }
 
     public function updateVersionInformation(string $version): void

--- a/centreon/src/App/Upgrade/Infrastructure/Legacy/LegacyConnectionFactory.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Legacy/LegacyConnectionFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Upgrade\Infrastructure\Legacy;
+
+use Adaptation\Database\Connection\Model\ConnectionConfig;
+
+/**
+ * Temporary bridge, kept isolated under Infrastructure/Legacy so it stays easy to trace and remove.
+ *
+ * Core (Update-*.php) and module (upgrade.php) upgrade scripts are exposed a $pearDB / $pearDBO
+ * connection and still call legacy CentreonDB/PDO methods (query, prepare, beginTransaction,
+ * isColumnExist, lastInsertId...) that the ConnectionInterface-only DbalConnectionAdapter does not
+ * provide. This factory builds the superset \CentreonDB connection those scripts require.
+ *
+ * TODO: remove once every upgrade script is migrated to ConnectionInterface.
+ */
+final readonly class LegacyConnectionFactory
+{
+    public function __construct(
+        private ConnectionConfig $connectionConfig,
+    ) {
+    }
+
+    /**
+     * Builds the connection to the configuration database, exposed to upgrade scripts as $pearDB.
+     */
+    public function createConfigurationConnection(): \CentreonDB
+    {
+        return new \CentreonDB(connectionConfig: $this->connectionConfig);
+    }
+
+    /**
+     * Builds the connection to the real-time (storage) database, exposed to upgrade scripts as $pearDBO.
+     */
+    public function createRealtimeConnection(): \CentreonDB
+    {
+        return new \CentreonDB(connectionConfig: new ConnectionConfig(
+            host: $this->connectionConfig->getHost(),
+            user: $this->connectionConfig->getUser(),
+            password: $this->connectionConfig->getPassword(),
+            databaseNameConfiguration: $this->connectionConfig->getDatabaseNameRealTime(),
+            databaseNameRealTime: $this->connectionConfig->getDatabaseNameRealTime(),
+            port: $this->connectionConfig->getPort(),
+            charset: $this->connectionConfig->getCharset(),
+            driver: $this->connectionConfig->getDriver(),
+        ));
+    }
+}

--- a/centreon/src/App/Upgrade/Infrastructure/Legacy/LegacyConnectionFactory.php
+++ b/centreon/src/App/Upgrade/Infrastructure/Legacy/LegacyConnectionFactory.php
@@ -55,6 +55,8 @@ final readonly class LegacyConnectionFactory
      */
     public function createRealtimeConnection(): \CentreonDB
     {
+        // CentreonDB builds its DSN from the "configuration" database name slot, so that slot must
+        // carry the real-time database name here for $pearDBO to actually target the storage schema.
         return new \CentreonDB(connectionConfig: new ConnectionConfig(
             host: $this->connectionConfig->getHost(),
             user: $this->connectionConfig->getUser(),

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalModuleRepositoryTest.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalModuleRepositoryTest.php
@@ -25,6 +25,7 @@ namespace Tests\App\Upgrade\Infrastructure\Dbal;
 
 use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Infrastructure\Dbal\DbalModuleRepository;
+use App\Upgrade\Infrastructure\Legacy\LegacyConnectionFactory;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -54,7 +55,9 @@ final class DbalModuleRepositoryTest extends TestCase
         $this->repository = new DbalModuleRepository(
             $this->configConnection,
             $this->modulesDir,
-            new ConnectionConfig('localhost', 'centreon', 'password', 'centreon', 'centreon_storage'),
+            new LegacyConnectionFactory(
+                new ConnectionConfig('localhost', 'centreon', 'password', 'centreon', 'centreon_storage')
+            ),
             '/usr/share/centreon/',
             new NullLogger(),
         );

--- a/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepositoryTest.php
+++ b/centreon/tests/php/App/Upgrade/Infrastructure/Dbal/DbalUpdateRepositoryTest.php
@@ -25,6 +25,7 @@ namespace Tests\App\Upgrade\Infrastructure\Dbal;
 
 use Adaptation\Database\Connection\Model\ConnectionConfig;
 use App\Upgrade\Infrastructure\Dbal\DbalUpdateRepository;
+use App\Upgrade\Infrastructure\Legacy\LegacyConnectionFactory;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -256,7 +257,7 @@ final class DbalUpdateRepositoryTest extends TestCase
         return new DbalUpdateRepository(
             $this->configConnection,
             $this->realtimeConnection,
-            $this->connectionConfig,
+            new LegacyConnectionFactory($this->connectionConfig),
             $this->libDir,
             $this->installDir,
             $filesystem ?? $this->realFilesystem,


### PR DESCRIPTION
## Description

`DbalUpdateRepository` runs the core upgrade scripts (`www/install/php/Update-*.php` and `Update-*.post.php`) by exposing `$pearDB` / `$pearDBO` to the included scripts. It exposed a `DbalConnectionAdapter`, which only implements `ConnectionInterface`.

Many core upgrade scripts still call **legacy** `CentreonDB`/PDO methods (`query`, `prepare`, `isColumnExist`, `beginTransaction`, `commit`, `rollBack`, `lastInsertId`, `exec`…) that `DbalConnectionAdapter` does not provide. Running them through the update runner therefore fataled with `Call to undefined method`, breaking the upgrade itself — a release blocker.

Fix: expose the **superset** `\CentreonDB` connection to the included scripts (both the legacy PDO API and `ConnectionInterface`), exactly as already done for module upgrade scripts in `DbalModuleRepository`.

- `runScript()` / `runPostScript()` now build `$pearDB` (configuration DB) and `$pearDBO` (real-time DB) via a dedicated `LegacyConnectionFactory` (isolated under `Infrastructure/Legacy`).
- The legacy connections are opened only once the update script actually exists (no needless PDO socket otherwise).
- Removed the now-unused `DbalConnectionAdapter` import.

## How to test

> ⚠️ This bug only reproduces **through the API** (`POST /platform/updates`). The legacy web install wizard (`www/install/steps/...`) uses the old mechanism (`$pearDB = new \CentreonDB()` directly), does **not** go through `DbalUpdateRepository`, and therefore does not trigger it.

### Prerequisites

- A Centreon platform on **24.10.x** (`informations.version = 24.10.x`), config + storage DBs OK.
- The **target 25.10** code/packages deployed on top, **without** having run the update yet.

### 1. Deliberately place a legacy call (repro probe)

On the target platform, edit an `Update-*.php` **within the replay window** (version `> 24.10.x` and `<=` target) — e.g. `centreon/www/install/php/Update-25.11.0.php` — and insert it as the **first statement of the script body**:

```php
// --- MON-209075 repro probe (remove after reproducing) ---
// DbalConnectionAdapter only implements ConnectionInterface: no query().
// \CentreonDB (the expected superset) exposes it.
$pearDB->query('SELECT 1');
// --- end probe ---
```

`SELECT 1` has no SQL side effect, is a 100% deterministic trigger, and is independent of the other scripts' business content.

### 2. Trigger the upgrade through the API only, as **Super Admin**

```bash
# 1) login
curl -s -X POST "$BASE/centreon/api/latest/login" \
  -H 'Content-Type: application/json' \
  -d '{"security":{"credentials":{"login":"admin","password":"<pwd>"}}}'

# 2) trigger the update (token from the login response)
curl -i -X POST "$BASE/centreon/api/latest/platform/updates" \
  -H "X-AUTH-TOKEN: <token>"
```

(or the `Platform_Update / Super Administrator Profile / POST /platform/updates` Bruno request.)

### 3. Expected result — **bug present (before the fix)**

- API response: **HTTP 500** (instead of 204).
- Upgrade log (`LoggerUpgrade`): `stepFailure`, step `php_script`, message:
  `Call to undefined method Adaptation\Database\Connection\Adapter\Dbal\DbalConnectionAdapter::query()`
- `informations.version` **unchanged** (upgrade aborted).

### 4. After the fix

- Same probe, same API call → **HTTP 204**, `stepCompleted` logged for every step.
- Legacy calls (`query`, `isColumnExist`, `beginTransaction`, `lastInsertId`…) resolve against `\CentreonDB` provided by `LegacyConnectionFactory`.
- `informations.version` is bumped to the target version.
- Remove the probe, replay a **real 24.10 → 25.10 upgrade** end to end → 204, version up to date, legacy script effects applied (e.g. a column created by `$pearDB->query('ALTER TABLE ...')`).
- **`$pearDBO` routing** (subtle point): a legacy write via `$pearDBO` lands in **`centreon_storage`**, not in `centreon`.

### 5. Automated

- `composer stan:new:src` green + `DbalUpdateRepositoryTest` / `DbalModuleRepositoryTest` green.

## Links

### Jira ticket

Resolves: [MON-209075](https://centreon.atlassian.net/browse/MON-209075)

### PR Github

- Relates to: #11387 — same fix applied to `DbalModuleRepository` (module upgrade scripts), same superset-connection pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MON-209075]: https://centreon.atlassian.net/browse/MON-209075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
