### PR TITLE
fix(e2e): target a MySQL 8.4-compatible version for the 'first minor' scenario

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
@@ -118,7 +118,14 @@ Given(
           }
           let minorVersionIndex = 0;
           if (versionFromExpression === 'first minor') {
-            minorVersionIndex = 0;
+            // Versions below 24.10.21 aren't installable on MySQL 8.4 (see MON-209081).
+            const firstMysql84CompatibleIndex = stableMinorVersions.findIndex(
+              (minor) => minor >= 21
+            );
+            minorVersionIndex =
+              firstMysql84CompatibleIndex === -1
+                ? 0
+                : firstMysql84CompatibleIndex;
           } else {
             switch (versionFromExpression) {
               case 'last stable':


### PR DESCRIPTION
## What
`Platform-upgrade-update/01-platform-update.feature`'s `'first minor'` scenario example always targeted `minorVersionIndex = 0`, i.e. the literal first-ever release of the branch (24.10.0). On the `bookworm-mysql:8.4` combo this fails: that package predates MySQL 8.4 support and its `createTables.sql` can't create the schema on it.

## Why this is a test fix, not a product fix (MON-209081)
Confirmed with product: the underlying schema issue (FK on `cb_list` missing a required unique key, MySQL error 6125) was already fixed in sources by #9474, which landed in **24.10.21**. Versions ≥ 24.10.21 install cleanly on MySQL 8.4 — confirmed by the `'last stable'/'penultimate stable'/'antepenultimate stable'` examples (24.10.28/29/30) already passing consistently in CI. Only `'first minor'` broke, because it pins to a frozen, pre-fix build.

## Fix
Instead of always using index 0, `'first minor'` now targets the first stable minor version ≥ 21 (falls back to 0 if none is found, e.g. on branches where this doesn't apply). No product/packaging change needed.

Full investigation and evidence: https://centreon.atlassian.net/browse/MON-209081