### PR TITLE
fix(unattended): align unattended.sh with develop (adds 26.10 support) [MON-209112]

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -35,7 +35,7 @@ trap 'on_error "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
 OPTIONS="hsDt:v:r:l:p:d:V:-:"
 declare -A SUPPORTED_LOG_LEVEL=([DEBUG]=0 [INFO]=1 [WARN]=2 [ERROR]=3)
 declare -A SUPPORTED_TOPOLOGY=([central]=1 [poller]=1)
-declare -A SUPPORTED_VERSION=([24.10]=1 [25.10]=1 [26.07]=1)
+declare -A SUPPORTED_VERSION=([24.10]=1 [25.10]=1 [26.07]=1 [26.10]=1)
 declare -A SUPPORTED_REPOSITORY=([testing-hotfix]=1 [testing-release]=1 [unstable]=1 [stable]=1)
 declare -A SUPPORTED_DBMS=([MariaDB]=1 [MySQL]=1)
 declare -A SUPPORTED_TLS=([enabled]=1 [disabled]=1)
@@ -121,7 +121,7 @@ function usage() {
 	echo
 	echo "Usage:"
 	echo
-	echo " $script_short_name [install|update (default: install)] [-t <central|poller> (default: central)] [-v <24.10|25.10|26.07> (default: 25.10)] [-r <stable|testing-hotfix|testing-release|unstable> (default: stable)] [-d <MariaDB|MySQL> (default: MariaDB)] [--tls <enabled|disabled> (default: disabled)] [-l <DEBUG|INFO|WARN|ERROR>] [-s (for silent install)] [-p <centreon admin password>] [-D (enable debug mode: shell xtrace + DEBUG log level)] [-h (show this help output)] [-V configure a vault, using format <address>;<port>;<root_path>;<role_id>;<secret_id>]"
+	echo " $script_short_name [install|update (default: install)] [-t <central|poller> (default: central)] [-v <24.10|25.10|26.07|26.10> (default: 25.10)] [-r <stable|testing-hotfix|testing-release|unstable> (default: stable)] [-d <MariaDB|MySQL> (default: MariaDB)] [--tls <enabled|disabled> (default: disabled)] [-l <DEBUG|INFO|WARN|ERROR>] [-s (for silent install)] [-p <centreon admin password>] [-D (enable debug mode: shell xtrace + DEBUG log level)] [-h (show this help output)] [-V configure a vault, using format <address>;<port>;<root_path>;<role_id>;<secret_id>]"
 	echo
 	echo Example:
 	echo


### PR DESCRIPTION
## Description

Backport of #11600 (merged on `develop`) to `dev-26.10.x` — ticket MON-209112.

`unattended.sh` rejected `-v 26.10`:

```
ERROR - Unsupported version: 26.10
```

`26.10` was missing from the `SUPPORTED_VERSION` whitelist, so the argument was refused
before any install logic ran.

## What this PR does

Rather than cherry-picking the two-line fix, this replaces `centreon/unattended.sh`
wholesale with the version currently on `develop`, so the script is identical across
branches. The resulting file is **byte-identical to `develop`** (verified with `cmp`).

On this branch `unattended.sh` was already in sync with `develop`, so the effective diff is
just the original two-line fix: `[26.10]=1` added to `SUPPORTED_VERSION`, and `26.10` listed in
the `-v` usage line.


## Tests

No Docker available locally, so I drove the script's own code from a harness that sources
everything above `MAIN SCRIPT EXECUTION`, fakes `/etc/os-release` and stubs the package
managers. Nothing in the harness re-implements a version condition — each check either
calls the shipped function or `eval`s the verbatim source range. **32 assertions, all passing**
on this branch:

- real `parse_subcommand_options` — `-v 24.10/25.10/26.07/26.10` accepted, `26.09`/`27.10` rejected
- real `set_required_prerequisite` — el8/el9/el10/deb12/deb13 x 26.07/26.10/25.10, asserting the
  accept/reject verdict
- real `set_release_repo_file` / `set_centreon_repos` — 26.10 URL and repo-name output
- real `set_mariadb_repos` (26.10 → 11.8, 25.10 → 10.11) and `setup_mysql` (26.10 → 8.4, 25.10 → 8.0)
- verbatim `play_install_wizard` step4 `case` — 26.10 takes the non-`cbmod` payload
- verbatim `install_central` PHP-selection block — 26.10 → PHP 8.4
- `version_int` / `uses_internal_repo` for 26.10

Running the same suite against this branch's **unmodified** `unattended.sh` fails on
`-v 26.10 accepted`, confirming the fix lands.

`bash -n` clean; `shellcheck -S error` reports the same 3 pre-existing findings as `develop`.

Live repository check: the URLs the script builds for 26.10 resolve
(`rpm-standard/26.10/el9` and `el10` → 200), and the repo IDs published there
(`centreon-26.10-stable`, `-noarch`) match the `centreon-26.10-stable*` glob passed to `--enablerepo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
