### PR TITLE
fix(unattended): align unattended.sh with develop (adds 26.10 support) [MON-209110]

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -1,16 +1,47 @@
 #!/bin/bash
 
+# Fail fast: exit on any error and on failures inside pipelines.
+# 'set -u' is intentionally NOT enabled: this script relies on many optional unset
+# variables (use_vault, requested_*, ENV_*, ...). 'errtrace' makes the ERR trap fire
+# inside functions, subshells and command substitutions too.
+set -Eeo pipefail
+set -o errtrace
+
+#========= begin of function on_error()
+# ERR trap handler: report any *unanticipated* command failure with a timestamp,
+# exit code, line number and the failing command, then exit with that code.
+# Commands that may carry secrets are redacted so nothing sensitive reaches the
+# persistent log file or the console error line (this does NOT touch the intended
+# credential channels: /etc/centreon/generated.tobesecured and the fd-3 recap).
+function on_error() {
+	local code="${1}" line="${2}" cmd="${3}"
+	case "${cmd}" in
+		*IDENTIFIED\ BY*|*IDENTIFIED\ WITH*|*--data*|*-p\"*|*password*|*genpasswd*|*X-AUTH-TOKEN*|*centreon-auth-token*|*token=*)
+			cmd="<command redacted>" ;;
+	esac
+	printf '%s - ERROR - command failed (exit %s) at line %s: %s\n' \
+		"$(date '+%Y-%m-%d %H:%M:%S.%3N%:z')" "${code}" "${line}" "${cmd}" >&2
+	# Surface the failure on the real console (fd 3) too, so a provisioning run that
+	# sends all output to the log file still shows that (and where) it failed.
+	if [ -n "${LOG_FILE:-}" ]; then
+		printf 'unattended.sh FAILED (exit %s at line %s) - see %s\n' "${code}" "${line}" "${LOG_FILE}" >&3
+	fi
+	exit "${code}"
+}
+#========= end of function on_error()
+trap 'on_error "$?" "${LINENO}" "${BASH_COMMAND}"' ERR
+
 ### Define all supported constants
-OPTIONS="hst:v:r:l:p:d:V:-:"
+OPTIONS="hsDt:v:r:l:p:d:V:-:"
 declare -A SUPPORTED_LOG_LEVEL=([DEBUG]=0 [INFO]=1 [WARN]=2 [ERROR]=3)
 declare -A SUPPORTED_TOPOLOGY=([central]=1 [poller]=1)
-declare -A SUPPORTED_VERSION=([24.10]=1 [25.10]=1 [26.07]=1)
+declare -A SUPPORTED_VERSION=([24.10]=1 [25.10]=1 [26.07]=1 [26.10]=1)
 declare -A SUPPORTED_REPOSITORY=([testing-hotfix]=1 [testing-release]=1 [unstable]=1 [stable]=1)
 declare -A SUPPORTED_DBMS=([MariaDB]=1 [MySQL]=1)
 declare -A SUPPORTED_TLS=([enabled]=1 [disabled]=1)
 default_timeout_in_sec=5
 script_short_name="$(basename $0)"
-default_ip=$(hostname -I | awk '{print $1}')
+default_ip=$(hostname -I | awk '{print $1}') || true
 ###
 
 #Define default values
@@ -28,21 +59,23 @@ selinux_mode=${ENV_SELINUX_MODE:-"permissive"}  #Default SELinux mode to be used
 wizard_autoplay=${ENV_WIZARD_AUTOPLAY:-"false"} #Default the install wizard is not run auto
 central_ip=${ENV_CENTRAL_IP:-$default_ip}       #Default central ip is the first of hostname -I
 tls=${ENV_DB_TLS:-"disabled"}                   # default DB TLS mode
+debug_mode=${ENV_DEBUG_MODE:-"false"}           #Default debug mode (set -x xtrace) is disabled
+LOG_FILE=""                                      #Path of the log file (set up in main, see ENV_LOG_FILE)
 
 function genpasswd() {
 	local _pwd
 
-	PWD_LOWER=$(tr -dc '[:lower:]' </dev/urandom | head -c4)
-	PWD_UPPER=$(tr -dc '[:upper:]' </dev/urandom | head -c4)
-	PWD_DIGIT=$(tr -dc '[:digit:]' </dev/urandom | head -c4)
-	PWD_SPECIAL=$(tr -dc '!?@*' </dev/urandom | head -c4)
+	# 'head -c4' closes the pipe early, so 'tr' receives SIGPIPE and exits non-zero;
+	# under 'pipefail' that would trip the ERR trap. Guard each pipeline with '|| true'.
+	PWD_LOWER=$(tr -dc '[:lower:]' </dev/urandom | head -c4) || true
+	PWD_UPPER=$(tr -dc '[:upper:]' </dev/urandom | head -c4) || true
+	PWD_DIGIT=$(tr -dc '[:digit:]' </dev/urandom | head -c4) || true
+	PWD_SPECIAL=$(tr -dc '!?@*' </dev/urandom | head -c4) || true
 
 	_pwd="$PWD_LOWER$PWD_UPPER$PWD_DIGIT$PWD_SPECIAL"
-	_pwd=$(echo $_pwd |fold -w 1 |shuf |tr -d '\n')
+	_pwd=$(echo $_pwd |fold -w 1 |shuf |tr -d '\n') || true
 
-	echo "Random password generated for user [$1] is [$_pwd]" >>$tmp_passwords_file
-
-	if [ $? -ne 0 ]; then
+	if ! echo "Random password generated for user [$1] is [$_pwd]" >>$tmp_passwords_file; then
 		echo "ERROR: Cannot save the random password to [$tmp_passwords_file]"
 		exit 1
 	fi
@@ -88,7 +121,7 @@ function usage() {
 	echo
 	echo "Usage:"
 	echo
-	echo " $script_short_name [install|update (default: install)] [-t <central|poller> (default: central)] [-v <24.10|25.10|26.07> (default: 25.10)] [-r <stable|testing-hotfix|testing-release|unstable> (default: stable)] [-d <MariaDB|MySQL> (default: MariaDB)] [--tls <enabled|disabled> (default: disabled)] [-l <DEBUG|INFO|WARN|ERROR>] [-s (for silent install)] [-p <centreon admin password>] [-h (show this help output)] [-V configure a vault, using format <address>;<port>;<root_path>;<role_id>;<secret_id>]"
+	echo " $script_short_name [install|update (default: install)] [-t <central|poller> (default: central)] [-v <24.10|25.10|26.07|26.10> (default: 25.10)] [-r <stable|testing-hotfix|testing-release|unstable> (default: stable)] [-d <MariaDB|MySQL> (default: MariaDB)] [--tls <enabled|disabled> (default: disabled)] [-l <DEBUG|INFO|WARN|ERROR>] [-s (for silent install)] [-p <centreon admin password>] [-D (enable debug mode: shell xtrace + DEBUG log level)] [-h (show this help output)] [-V configure a vault, using format <address>;<port>;<root_path>;<role_id>;<secret_id>]"
 	echo
 	echo Example:
 	echo
@@ -114,7 +147,7 @@ function usage() {
 #
 function log() {
 
-	TIMESTAMP=$(date --rfc-3339=seconds)
+	TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S.%3N%:z')
 
 	if [[ -z "${1}" || -z "${2}" ]]; then
 		echo "${TIMESTAMP} - ERROR: Missing argument"
@@ -131,12 +164,17 @@ function log() {
 	# get the log message (full log message)
 	log_message="${@}"
 
-	# check if the log_message_level is greater than the runtime_log_level
-	[[ ${SUPPORTED_LOG_LEVEL[$log_message_level]} ]] || return 1
+	# Skip messages whose level is unknown or below the configured runtime level.
+	# Always return 0 (suppression is a success): a bare "log" call returning a
+	# non-zero status would otherwise abort the script under 'set -e'.
+	[[ ${SUPPORTED_LOG_LEVEL[$log_message_level]} ]] || return 0
 
-	((${SUPPORTED_LOG_LEVEL[$log_message_level]} < ${SUPPORTED_LOG_LEVEL[$runtime_log_level]})) && return 2
+	if ((${SUPPORTED_LOG_LEVEL[$log_message_level]} < ${SUPPORTED_LOG_LEVEL[$runtime_log_level]})); then
+		return 0
+	fi
 
 	echo -e "${TIMESTAMP} - $log_message_level - $log_message"
+	return 0
 
 }
 #======== end of function log()
@@ -211,6 +249,12 @@ function parse_subcommand_options() {
 		s)
 			wizard_autoplay="true"
 			log "INFO" "The installation wizard will be executed by the script"
+			;;
+
+		D)
+			debug_mode="true"
+			runtime_log_level="DEBUG"
+			log "INFO" "Debug mode requested (shell xtrace + DEBUG log level)"
 			;;
 
 		p)
@@ -306,10 +350,52 @@ function parse_subcommand_options() {
 }
 #======== end of function parse_subcommand_options()
 
+#========= begin of function setup_debug_mode()
+# Enable shell xtrace when debug mode is requested (via the -D flag or
+# ENV_DEBUG_MODE=true) and force the DEBUG log level. The PS4 prefix carries a
+# millisecond timestamp and the source/line/function so every traced line is locatable.
+#
+function setup_debug_mode() {
+	if [ "${debug_mode}" == "true" ]; then
+		runtime_log_level="DEBUG"
+		export PS4='+ $(date "+%H:%M:%S.%3N") ${BASH_SOURCE##*/}:${LINENO}:${FUNCNAME[0]:-main}() '
+		# Send xtrace (may expand passwords/tokens) to a dedicated 0600 file so the main log stays secret-free.
+		if [ -n "${LOG_FILE:-}" ]; then
+			DEBUG_TRACE_FILE="${LOG_FILE%.log}.debug.log"
+			if { : > "$DEBUG_TRACE_FILE"; } 2>/dev/null && exec 9>>"$DEBUG_TRACE_FILE"; then
+				chmod 600 "$DEBUG_TRACE_FILE" 2>/dev/null || true
+				export BASH_XTRACEFD=9
+				log "WARN" "Debug trace written to [$DEBUG_TRACE_FILE] - it MAY CONTAIN CREDENTIALS; handle/delete it securely"
+				echo "unattended.sh: debug trace (may contain credentials) -> $DEBUG_TRACE_FILE" >&3
+			fi
+		fi
+		set -x
+	fi
+}
+#========= end of function setup_debug_mode()
+
+#========= begin of function notice()
+# Announce an installation milestone: record it (INFO) in the log file and mirror
+# it to the real console (fd 3) when output is redirected to a log file, so the
+# operator can follow progress in both places during the long-running steps.
+#
+function notice() {
+	log "INFO" ">>> $1"
+	if [ -n "${LOG_FILE:-}" ]; then
+		printf '>>> %s\n' "$1" >&3
+	fi
+}
+#========= end of function notice()
+
 #========= begin of function error_and_exit()
 # display the ERROR log message then exit the script
 function error_and_exit() {
 	log "ERROR" "$1"
+	# When output is redirected to a log file, also surface the failure (and where to
+	# look) on the real console (fd 3), so a provisioning run does not fail silently.
+	if [ -n "${LOG_FILE:-}" ]; then
+		printf 'unattended.sh FAILED: %s - see %s\n' "$1" "${LOG_FILE}" >&3
+	fi
 	exit 1
 }
 #========= end of function error_and_exit()
@@ -319,11 +405,15 @@ function error_and_exit() {
 #
 function pause() {
 	local timeout=$default_timeout_in_sec
-	if [ -n $2 ]; then
+	if [ -n "${2:-}" ]; then
 		timeout=$2
 	fi
-	read -t $timeout -s -n 1 -p "${1}"
+	# Returns 0 if a key was pressed within the timeout, non-zero if the timeout elapsed,
+	# so the caller can report whether the operator skipped the wait.
+	local rc=0
+	read -t $timeout -s -n 1 -p "${1}" || rc=$?
 	echo ""
+	return $rc
 }
 #========= end of function pause()
 
@@ -457,8 +547,8 @@ function install_mariadb_repo_setup() {
 	local script rc
 	script=$(mktemp)
 	curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup -o "$script" || error_and_exit "Failed to download mariadb_repo_setup"
-	bash "$script" "$@"
-	rc=$?
+	rc=0
+	bash "$script" "$@" || rc=$?
 	rm -f "$script"
 	return $rc
 }
@@ -475,23 +565,19 @@ function set_mariadb_repos() {
 	fi
 
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
-		install_mariadb_repo_setup --os-type=debian --os-version="$detected_os_version" --mariadb-server-version="$detected_mariadb_version" --skip-maxscale
+		install_mariadb_repo_setup --os-type=debian --os-version="$detected_os_version" --mariadb-server-version="$detected_mariadb_version" --skip-maxscale || error_and_exit "Could not install the $dbms repository"
 	elif (( $(version_int) >= $(version_int 26.07) )); then
 		# el9 has no 11.8 dnf module stream and el10 dropped dnf modularity, so MariaDB 11.8
 		# is installed from the MariaDB official repository for both.
-		install_mariadb_repo_setup --os-type=rhel --os-version="$detected_os_major" --mariadb-server-version="mariadb-$detected_mariadb_version" --skip-maxscale
+		install_mariadb_repo_setup --os-type=rhel --os-version="$detected_os_major" --mariadb-server-version="mariadb-$detected_mariadb_version" --skip-maxscale || error_and_exit "Could not install the $dbms repository"
 	else
-	    dnf module enable mariadb:$detected_mariadb_version -y -q
+	    dnf module enable mariadb:$detected_mariadb_version -y -q || error_and_exit "Could not install the $dbms repository"
 	fi
-	if [ $? -ne 0 ]; then
-		error_and_exit "Could not install the $dbms repository"
-	else
-		log "INFO" "Successfully installed the $dbms repository"
-	fi
+	log "INFO" "Successfully installed the $dbms repository"
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
-		rm -f /etc/apt/sources.list.d/mariadb.list.old_*  > /dev/null 2>&1
+		rm -f /etc/apt/sources.list.d/mariadb.list.old_*  > /dev/null 2>&1 || true
 	else
-		rm -f /etc/yum.repos.d/mariadb.repo.old_* > /dev/null 2>&1
+		rm -f /etc/yum.repos.d/mariadb.repo.old_* > /dev/null 2>&1 || true
 	fi
 }
 #========= end of function set_mariadb_repos()
@@ -513,7 +599,7 @@ function setup_mysql() {
 			# preselect that channel so the install stays non-interactive.
 			mysql_apt_config="mysql-apt-config_0.8.34-1_all.deb"
 			curl -fJLO "https://dev.mysql.com/get/$mysql_apt_config" || error_and_exit "Failed to download $mysql_apt_config"
-			echo "mysql-apt-config mysql-apt-config/select-server select mysql-8.4-lts" | debconf-set-selections
+			echo "mysql-apt-config mysql-apt-config/select-server select mysql-8.4-lts" | debconf-set-selections || error_and_exit "Failed to preseed mysql-apt-config"
 			export DEBIAN_FRONTEND="noninteractive" && $PKG_MGR install -y "./$mysql_apt_config" || error_and_exit "Failed to install $mysql_apt_config"
 		else
 			curl -fJLO https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb || error_and_exit "Failed to download mysql-apt-config"
@@ -521,15 +607,14 @@ function setup_mysql() {
 		fi
 		# mysql-apt-config ships an expired/unrelated key; refresh the keyring (signed-by in mysql.list)
 		# with the renewed B7B3B788A8D3785C key (valid to 2027) so apt can verify the repo.
-		mysql_keyring=$(grep -ohm1 'signed-by=[^] ]*' /etc/apt/sources.list.d/mysql.list 2>/dev/null | cut -d= -f2)
+		mysql_keyring=$(grep -ohm1 'signed-by=[^] ]*' /etc/apt/sources.list.d/mysql.list 2>/dev/null | cut -d= -f2) || true
 		[ -z "$mysql_keyring" ] && mysql_keyring=/etc/apt/trusted.gpg.d/mysql.gpg
 		# pipefail so a failed download fails here instead of writing an empty keyring
-		( set -o pipefail; curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | gpg --dearmor --yes -o "$mysql_keyring" )
-		if [ $? -ne 0 ]; then
+		if ! ( set -o pipefail; curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | gpg --dearmor --yes -o "$mysql_keyring" ); then
 			error_and_exit "Failed to refresh the MySQL APT signing key from https://repo.mysql.com/RPM-GPG-KEY-mysql-2025"
 		fi
 		$PKG_MGR -y update || error_and_exit "apt update failed after configuring the MySQL repository"
-		$PKG_MGR install -y mysql-server mysql-common
+		$PKG_MGR install -y mysql-server mysql-common || error_and_exit "Could not install the $dbms server packages"
 	else
 		if [[ "$detected_mysql_version" == "8.4" ]]; then
 			# el9 / el10 AppStream only provides MySQL 8.0, so the MySQL 8.4 LTS community
@@ -538,28 +623,24 @@ function setup_mysql() {
 			# The release rpm's signing key expired 2025-10-22, so dnf rejects the re-signed packages. Replace it
 			# with the renewed key (same fingerprint B7B3B788A8D3785C, valid to 2027): refresh the on-disk file,
 			# drop the expired key from the rpm keyring (else the re-import is a no-op), then import the renewed one.
-			curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql-2023
+			curl -fsSL https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql-2023 || error_and_exit "Failed to download the MySQL RPM GPG key"
 			old_mysql_key=$(rpm -q gpg-pubkey 2>/dev/null | grep -i a8d3785c || true)
 			if [ -n "$old_mysql_key" ]; then rpm -e $old_mysql_key 2>/dev/null || true; fi
-			rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql-2023
+			rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql-2023 || error_and_exit "Failed to import the MySQL RPM GPG key"
 			# install_weak_deps=False: the distro mariadb stack is only a Recommends here; without it dnf
 			# pulls mariadb alongside Oracle MySQL and they collide on /usr/bin/mysql.
-			$PKG_MGR install -y --setopt=install_weak_deps=False mysql-server
+			$PKG_MGR install -y --setopt=install_weak_deps=False mysql-server || error_and_exit "Could not install the $dbms server packages"
 		else
-			$PKG_MGR install -y mysql-server mysql
+			$PKG_MGR install -y mysql-server mysql || error_and_exit "Could not install the $dbms server packages"
 		fi
 	fi
-	if [ $? -ne 0 ]; then
-		error_and_exit "Could not install the $dbms repository"
-	else
-		log "INFO" "Successfully installed the $dbms repository"
-	fi
-	systemctl enable --now $mysql_service_name
+	log "INFO" "Successfully installed the $dbms repository"
+	systemctl enable --now $mysql_service_name || error_and_exit "Failed to enable and start $mysql_service_name"
 	if (( $(version_int) < $(version_int 24.10) )); then
 		echo "default-authentication-plugin=mysql_native_password" >> $mysql_config_file
 	fi
-	sed -Ei 's/LimitNOFILE\s\=\s[0-9]{1,}/LimitNOFILE = 32000/' /usr/lib/systemd/system/$mysql_service_name.service
-	systemctl daemon-reload
+	sed -Ei 's/LimitNOFILE\s\=\s[0-9]{1,}/LimitNOFILE = 32000/' /usr/lib/systemd/system/$mysql_service_name.service || log "WARN" "Could not raise LimitNOFILE for $mysql_service_name"
+	systemctl daemon-reload || true
 }
 #========= end of function setup_mysql()
 
@@ -589,25 +670,25 @@ function set_required_prerequisite() {
 			case "$detected_os_release" in
 			redhat-release*)
 				BASE_PACKAGES=(dnf-plugins-core)
-				subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
-				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+				subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms || log "WARN" "Could not enable the codeready-builder repository (best-effort)"
+				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms || true
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || error_and_exit "Failed to install the EPEL release package"
 				;;
 
 			centos-release-8.[3-9]* | centos-linux-release* | centos-stream-release* | almalinux-release* | rocky-release*)
 				BASE_PACKAGES=(dnf-plugins-core epel-release)
-				$PKG_MGR config-manager --set-enabled powertools
+				$PKG_MGR config-manager --set-enabled powertools || true
 				;;
 
 			centos-release-8.[1-2]*)
 				BASE_PACKAGES=(dnf-plugins-core epel-release)
-				$PKG_MGR config-manager --set-enabled PowerTools
+				$PKG_MGR config-manager --set-enabled PowerTools || true
 				;;
 
 			oraclelinux-release* | enterprise-release*)
 				BASE_PACKAGES=(dnf-plugins-core)
-				$PKG_MGR config-manager --set-enabled ol8_codeready_builder
-				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+				$PKG_MGR config-manager --set-enabled ol8_codeready_builder || true
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || error_and_exit "Failed to install the EPEL release package"
 			;;
 			esac
 
@@ -615,9 +696,9 @@ function set_required_prerequisite() {
 				case "$version" in
 					"24.10" | "25.10")
 						log "INFO" "Installing PHP 8.2 and enable it"
-						$PKG_MGR module reset php -y -q
-						$PKG_MGR module install php:8.2 -y -q
-						$PKG_MGR module enable php:8.2 -y -q
+						$PKG_MGR module reset php -y -q || true
+						$PKG_MGR module install php:8.2 -y -q || error_and_exit "Failed to install the PHP 8.2 module"
+						$PKG_MGR module enable php:8.2 -y -q || error_and_exit "Failed to enable the PHP 8.2 module"
 						;;
 					*)
 						log "INFO" "Installing PHP 8.2 from OS official repositories"
@@ -636,20 +717,20 @@ function set_required_prerequisite() {
 			case "$detected_os_release" in
 			redhat-release*)
 				BASE_PACKAGES=(dnf-plugins-core)
-				subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
-				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms
-				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+				subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms || log "WARN" "Could not enable the codeready-builder repository (best-effort)"
+				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms || true
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm || error_and_exit "Failed to install the EPEL release package"
 				;;
 
 			centos-release* | centos-linux-release* | centos-stream-release* | almalinux-release* | rocky-release*)
 				BASE_PACKAGES=(dnf-plugins-core epel-release)
-				$PKG_MGR config-manager --set-enabled crb
+				$PKG_MGR config-manager --set-enabled crb || true
 				;;
 
 			oraclelinux-release* | enterprise-release*)
 				BASE_PACKAGES=(dnf-plugins-core)
-				$PKG_MGR config-manager --set-enabled ol9_codeready_builder
-				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+				$PKG_MGR config-manager --set-enabled ol9_codeready_builder || true
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm || error_and_exit "Failed to install the EPEL release package"
 			;;
 			esac
 
@@ -662,9 +743,9 @@ function set_required_prerequisite() {
 					$PKG_MGR module -y switch-to php:remi-8.4/common || error_and_exit "Failed to switch to the PHP 8.4 module from remi"
 				elif (( $(version_int) >= $(version_int 24.10) )); then
 					log "INFO" "Installing PHP 8.2 and enable it"
-					$PKG_MGR module reset php -y -q
-					$PKG_MGR module install php:8.2 -y -q
-					$PKG_MGR module enable php:8.2 -y -q
+					$PKG_MGR module reset php -y -q || true
+					$PKG_MGR module install php:8.2 -y -q || error_and_exit "Failed to install the PHP 8.2 module"
+					$PKG_MGR module enable php:8.2 -y -q || error_and_exit "Failed to enable the PHP 8.2 module"
 				else
 					log "INFO" "Installing PHP from OS official repositories"
 				fi
@@ -684,20 +765,20 @@ function set_required_prerequisite() {
 			case "$detected_os_release" in
 			redhat-release*)
 				BASE_PACKAGES=(dnf-plugins-core)
-				subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms
-				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-10-rhui-rpms
-				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+				subscription-manager repos --enable codeready-builder-for-rhel-10-x86_64-rpms || log "WARN" "Could not enable the codeready-builder repository (best-effort)"
+				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-10-rhui-rpms || true
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm || error_and_exit "Failed to install the EPEL release package"
 				;;
 
 			centos-release* | centos-linux-release* | centos-stream-release* | almalinux-release* | rocky-release*)
 				BASE_PACKAGES=(dnf-plugins-core epel-release)
-				$PKG_MGR config-manager --set-enabled crb
+				$PKG_MGR config-manager --set-enabled crb || true
 				;;
 
 			oraclelinux-release* | enterprise-release*)
 				BASE_PACKAGES=(dnf-plugins-core)
-				$PKG_MGR config-manager --set-enabled ol10_codeready_builder
-				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+				$PKG_MGR config-manager --set-enabled ol10_codeready_builder || true
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm || error_and_exit "Failed to install the EPEL release package"
 			;;
 			esac
 
@@ -714,10 +795,10 @@ function set_required_prerequisite() {
 		esac
 
 		log "INFO" "Installing packages ${BASE_PACKAGES[@]}"
-		$PKG_MGR -q install -y ${BASE_PACKAGES[@]}
+		$PKG_MGR -q install -y ${BASE_PACKAGES[@]} || error_and_exit "Failed to install base packages: ${BASE_PACKAGES[*]}"
 
 		log "INFO" "Updating package gnutls"
-		$PKG_MGR -q update -y gnutls
+		$PKG_MGR -q update -y gnutls || log "WARN" "Could not update gnutls"
 
 		set_centreon_repos
 		if [ "$topology" == "central" ]; then
@@ -727,7 +808,8 @@ function set_required_prerequisite() {
 				setup_mysql
 			fi
 			log "INFO" "Installing glibc langpack for Centreon UI translation"
-			$PKG_MGR-q install -y glibc-langpack-fr glibc-langpack-es glibc-langpack-pt glibc-langpack-de > /dev/null 2>&1
+			# Optional UI-translation langpacks: keep non-fatal (was masked by a '$PKG_MGR-q' typo).
+			$PKG_MGR -q install -y glibc-langpack-fr glibc-langpack-es glibc-langpack-pt glibc-langpack-de > /dev/null 2>&1 || true
 		fi
 		;;
 	debian-release*)
@@ -755,14 +837,14 @@ function set_required_prerequisite() {
 		# Don't gate prerequisite install on 'apt update': a prior run may have added the not-yet-signed
 		# Centreon repos, making update fail. Run it best-effort, then install wget/gnupg2/curl unconditionally
 		# (a '&&' here would skip them and leave gpg absent for the key import below).
-		${PKG_MGR} update
+		${PKG_MGR} update || true
 		base_apt_packages="lsb-release ca-certificates apt-transport-https wget gnupg2 curl"
 		# software-properties-common (add-apt-repository) is kept on Debian 12 but dropped on Debian 13,
 		# where the package no longer exists; this script adds repos via .list files, so it is not needed.
 		if [[ "$detected_os_version" == "12" ]]; then
 			base_apt_packages="$base_apt_packages software-properties-common"
 		fi
-		${PKG_MGR} install -y $base_apt_packages
+		${PKG_MGR} install -y $base_apt_packages || error_and_exit "Failed to install base Debian packages: $base_apt_packages"
 		repo_prefix="apt"
 		# non-".10" versions are only published to the internal APT repository
 		if uses_internal_repo; then
@@ -771,8 +853,8 @@ function set_required_prerequisite() {
 			apt_standard_repo="$repo_prefix-standard"
 		fi
 
-		# Get CPU architecture type
-		VENDORID=$(lscpu | grep -e '^Vendor ID:' | cut -d ':' -f2 | tr -d '[:space:]')
+		# Get CPU architecture type ('|| true': absent 'Vendor ID' line just means non-ARM)
+		VENDORID=$(lscpu | grep -e '^Vendor ID:' | cut -d ':' -f2 | tr -d '[:space:]') || true
 		ARCH=""
 		if [[ "$VENDORID" == "ARM" ]]; then
 			ARCH="[ arch=all,arm64 ]"
@@ -793,8 +875,7 @@ function set_required_prerequisite() {
 		done
 		# Import the Centreon APT signing key (pipefail so a failed download/dearmor is caught, not hidden).
 		log "INFO" "Importing the Centreon APT signing key"
-		( set -o pipefail; wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null )
-		if [ $? -ne 0 ]; then
+		if ! ( set -o pipefail; wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null ); then
 			error_and_exit "Failed to import the Centreon APT signing key from https://apt-key.centreon.com"
 		fi
 
@@ -807,7 +888,7 @@ function set_required_prerequisite() {
 				setup_mysql
 			fi
 		else
-			${PKG_MGR} update
+			${PKG_MGR} update || true
 		fi
 		;;
 	esac
@@ -839,9 +920,7 @@ function set_selinux_config() {
 	if [ -e /etc/selinux/config ]; then
 		log "WARN" "Modifying /etc/selinux/config. You must reboot your machine."
 
-		sed -i "s/^SELINUX=.*\$/SELINUX=$1/" /etc/selinux/config
-
-		if [ $? -ne 0 ]; then
+		if ! sed -i "s/^SELINUX=.*\$/SELINUX=$1/" /etc/selinux/config; then
 			error_and_exit "Could not change SELinux mode. You might need to run this script as root."
 		fi
 	else
@@ -857,7 +936,7 @@ function set_selinux_config() {
 function set_runtime_selinux_mode() {
 	log "INFO" "Set runtime SELinux mode to [$1]"
 
-	_current_mode=$(getenforce | tr '[:upper:]' '[:lower:]')
+	_current_mode=$(getenforce 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)
 
 	log "DEBUG" "Current SELinux mode is [$_current_mode]"
 
@@ -881,11 +960,14 @@ function set_runtime_selinux_mode() {
 		;;
 	esac
 
-	setenforce $_request_mode
+	# Capture setenforce's status once: reading $? twice (as before) tested the
+	# previous '[' instead of setenforce, making the "disabled" branch dead code.
+	_se_rc=0
+	setenforce $_request_mode || _se_rc=$?
 
-	if [ $? -eq 2 ]; then
+	if [ "$_se_rc" -eq 2 ]; then
 		error_and_exit "Could not change SELinux mode. You might need to run this script as root."
-	elif [ $? -eq 1 ]; then
+	elif [ "$_se_rc" -eq 1 ]; then
 		log "WARN" "Current SELinux mode is disabled. Nothing to do"
 	fi
 
@@ -982,14 +1064,15 @@ function generate_db_tls_certificates() {
 		echo "DNS.2 = localhost"
 		ip_idx=1
 		echo "IP.$ip_idx = 127.0.0.1"
-		for ip in $(ip -o -4 addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | grep -vx "0.0.0.0" | grep -vx "127.0.0.1" | sort -u); do
+		for ip in $(ip -o -4 addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | grep -vx "0.0.0.0" | grep -vx "127.0.0.1" | sort -u || true); do
 			ip_idx=$((ip_idx + 1))
 			echo "IP.$ip_idx = $ip"
 		done
 	} > "$ext_file"
 
 	log "INFO" "Generating DB server certificate (CN=$fqdn) with SANs for all interface IPs"
-	openssl genrsa -out "$srv_key" 2048 || error_and_exit "Failed to generate the DB server key"
+	# umask 077 so the private key is never briefly world-readable before the chmod 600 below.
+	( umask 077; openssl genrsa -out "$srv_key" 2048 ) || error_and_exit "Failed to generate the DB server key"
 	openssl req -new -key "$srv_key" -out "$csr_file" -subj "/C=FR/L=Paris/O=Centreon/CN=$fqdn" || error_and_exit "Failed to generate the DB server certificate request"
 	openssl x509 -req -in "$csr_file" -CA "$ca_cert" -CAkey "$ca_key" -CAcreateserial \
 		-out "$srv_cert" -days 825 -sha256 -extfile "$ext_file" -extensions v3_req || error_and_exit "Failed to sign the DB server certificate"
@@ -998,7 +1081,7 @@ function generate_db_tls_certificates() {
 	# Cert is public (0644). The key must be readable by the DB user only: MariaDB/MySQL run as
 	# 'mysql' and refuse a world-readable key.
 	chmod 644 "$srv_cert"
-	chown mysql:mysql "$srv_key" "$srv_cert"
+	chown mysql:mysql "$srv_key" "$srv_cert" || error_and_exit "Failed to set ownership on the DB TLS key/cert"
 	chmod 600 "$srv_key"
 
 	TLS_CA_CERT="$ca_cert"
@@ -1025,8 +1108,8 @@ function configure_db_tls() {
 	# OS-specific destinations for the trust store, server drop-in and client cnf.
 	local server_dropin client_dropin
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
-		cp "$TLS_CA_CERT" /usr/local/share/ca-certificates/centreon-db-ca.crt
-		update-ca-certificates >/dev/null
+		cp "$TLS_CA_CERT" /usr/local/share/ca-certificates/centreon-db-ca.crt || error_and_exit "Failed to stage the DB CA certificate into the trust store"
+		update-ca-certificates >/dev/null || error_and_exit "Failed to update the system CA trust store"
 		if [[ "$dbms" == "MariaDB" ]]; then
 			server_dropin="/etc/mysql/mariadb.conf.d/99-centreon-tls.cnf"
 		else
@@ -1034,8 +1117,8 @@ function configure_db_tls() {
 		fi
 		client_dropin="/etc/mysql/conf.d/centreon-tls-client.cnf"
 	else
-		cp "$TLS_CA_CERT" /etc/pki/ca-trust/source/anchors/centreon-db-ca.crt
-		update-ca-trust extract
+		cp "$TLS_CA_CERT" /etc/pki/ca-trust/source/anchors/centreon-db-ca.crt || error_and_exit "Failed to stage the DB CA certificate into the trust store"
+		update-ca-trust extract || error_and_exit "Failed to update the system CA trust store"
 		server_dropin="/etc/my.cnf.d/centreon-tls.cnf"
 		client_dropin="/etc/my.cnf.d/centreon-tls-client.cnf"
 	fi
@@ -1099,7 +1182,7 @@ function configure_db_tls_consumers() {
 	local gorgone_cfg="/etc/centreon/config.d/10-database.yaml"
 	if [[ -f "$gorgone_cfg" ]]; then
 		log "INFO" "Patching gorgone DB DSN with mysql_ssl in $gorgone_cfg"
-		sed -i "/dsn: \"mysql:/{/mysql_ssl=/! s|\(dsn: \"mysql:[^\"]*\)\"|\1;mysql_ssl=1;mysql_ssl_ca=$ca_cert\"|}" "$gorgone_cfg"
+		sed -i "/dsn: \"mysql:/{/mysql_ssl=/! s|\(dsn: \"mysql:[^\"]*\)\"|\1;mysql_ssl=1;mysql_ssl_ca=$ca_cert\"|}" "$gorgone_cfg" || log "WARN" "Could not patch gorgone DB DSN for TLS in $gorgone_cfg"
 		systemctl restart gorgoned >/dev/null 2>&1 || true
 	else
 		log "WARN" "gorgone DB config $gorgone_cfg not found; skipping gorgone DB TLS (run the web install wizard first)"
@@ -1108,6 +1191,7 @@ function configure_db_tls_consumers() {
 	# centreon-broker DB TLS is driven by Centreon's configuration (stored in DB, regenerated on export),
 	# so it cannot be set reliably from this script. Surface it as a manual follow-up.
 	log "WARN" "centreon-broker DB TLS must be enabled via Centreon configuration (broker config export); not set by this script"
+	return 0
 }
 #========= end of function configure_db_tls_consumers()
 
@@ -1175,8 +1259,8 @@ function configure_web_tls() {
 
 	# Open 443 if firewalld is active (update_firewall_config only opens http/snmp). No-op on Debian (no firewalld).
 	if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
-		firewall-cmd --zone=public --add-service=https --permanent >/dev/null 2>&1
-		firewall-cmd --reload >/dev/null 2>&1
+		firewall-cmd --zone=public --add-service=https --permanent >/dev/null 2>&1 || log "WARN" "Could not add firewall service https (best-effort)"
+		firewall-cmd --reload >/dev/null 2>&1 || log "WARN" "Could not reload firewall rules"
 	fi
 
 	systemctl restart "$HTTP_SERVICE_UNIT" || error_and_exit "Could not restart $HTTP_SERVICE_UNIT after enabling HTTPS"
@@ -1195,22 +1279,27 @@ function secure_dbms_setup() {
 	log "WARN" "You can use mysqladmin in order to set a new password for user root"
 
 	log "INFO" "Restarting $dbms service first"
-	systemctl daemon-reload
+	systemctl daemon-reload || error_and_exit "Could not reload systemd before restarting $dbms"
+	# Note: SQL runs via 'if ! client ...' so a failure is handled with a clean message and never
+	# reaches the ERR trap (which could otherwise expose the password from the command).
 	if [[ $dbms == "MariaDB" ]]; then
-		systemctl restart mariadb
+		systemctl restart mariadb || error_and_exit "Could not restart $dbms service"
 		log "INFO" "Executing SQL requests for $dbms"
 		# MariaDB 11.x (Debian 13) no longer ships the legacy 'mysql' client symlink; prefer 'mariadb'.
 		if command -v mariadb >/dev/null 2>&1; then mariadb_client="mariadb"; else mariadb_client="mysql"; fi
-		$mariadb_client -u root --verbose <<-EOF
+		if ! $mariadb_client -u root --verbose <<-EOF
 			ALTER USER 'root'@'localhost' IDENTIFIED BY '${db_root_password//\'/\'\'}';
 			DELETE FROM mysql.global_priv WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
 			DELETE FROM mysql.global_priv WHERE User='';
 			DROP DATABASE IF EXISTS test;
 			DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
 			FLUSH PRIVILEGES;
-EOF
+		EOF
+		then
+			error_and_exit "Could not apply the requests"
+		fi
 	else
-		systemctl restart $mysql_service_name
+		systemctl restart $mysql_service_name || error_and_exit "Could not restart $dbms service"
 		log "INFO" "Executing SQL requests for $dbms"
 		if (( $(version_int) >= $(version_int 24.10) )); then
 			default_authentication_plugin="caching_sha2_password"
@@ -1231,28 +1320,27 @@ EOF
 			else
 				mysql_error_log="/var/log/mysqld.log"
 			fi
-			mysql_temp_pw=$(grep 'temporary password is generated for root@localhost' "$mysql_error_log" 2>/dev/null | tail -1 | sed -E 's/.*root@localhost: //')
+			mysql_temp_pw=$(grep 'temporary password is generated for root@localhost' "$mysql_error_log" 2>/dev/null | tail -1 | sed -E 's/.*root@localhost: //') || true
 			if [ -z "$mysql_temp_pw" ]; then
 				error_and_exit "Could not authenticate to MySQL as root (no passwordless access and no temporary password in $mysql_error_log)"
 			fi
 			mysql_root_auth=(--ssl-mode=DISABLED --connect-expired-password -u root -p"${mysql_temp_pw}")
 		fi
 
-		mysql "${mysql_root_auth[@]}" --verbose <<-EOF
+		if ! mysql "${mysql_root_auth[@]}" --verbose <<-EOF
 			ALTER USER 'root'@'localhost' IDENTIFIED WITH '${default_authentication_plugin}' BY '${db_root_password}';
 			DELETE FROM mysql.user WHERE User='';
 			DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
 			DROP DATABASE IF EXISTS test;
 			DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
 			FLUSH PRIVILEGES;
-EOF
+		EOF
+		then
+			error_and_exit "Could not apply the requests"
+		fi
 	fi
 
-	if [ $? -ne 0 ]; then
-		error_and_exit "Could not apply the requests"
-	else
-		log "INFO" "Successfully applied the SQL requests for enhancing your $dbms"
-	fi
+	log "INFO" "Successfully applied the SQL requests for enhancing your $dbms"
 
 }
 #========= end of function secure_dbms_setup()
@@ -1265,8 +1353,7 @@ function install_centreon_repo() {
 
 	log "INFO" "Centreon official repositories installation..."
 
-	$PKG_MGR config-manager --add-repo $RELEASE_REPO_FILE
-	if [ $? -ne 0 ]; then
+	if ! $PKG_MGR config-manager --add-repo $RELEASE_REPO_FILE; then
 		error_and_exit "Could not install Centreon repository"
 	fi
 }
@@ -1278,25 +1365,18 @@ function install_centreon_repo() {
 function update_firewall_config() {
 
 	log "INFO" "Update firewall configuration..."
-	command -v firewall-cmd >/dev/null 2>&1
-
-	if [ $? -eq 0 ]; then
-		firewall-cmd --state >/dev/null 2>&1
-		if [ $? -eq 0 ]; then
+	if command -v firewall-cmd >/dev/null 2>&1; then
+		if firewall-cmd --state >/dev/null 2>&1; then
 			for svc in http snmp snmptrap; do
-				firewall-cmd --zone=public --add-service=$svc --permanent >/dev/null 2>&1
-				if [ $? -ne 0 ]; then
-					error_and_exit "Could not configure firewall. You might need to run this script as root."
-				fi
+				firewall-cmd --zone=public --add-service=$svc --permanent >/dev/null 2>&1 ||
+					log "WARN" "Could not add firewall service $svc (best-effort)"
 			done
 			for port in "5556/tcp" "5669/tcp"; do
-				firewall-cmd --zone=public --add-port=$port --permanent >/dev/null 2>&1
-				if [ $? -ne 0 ]; then
-					error_and_exit "Could not configure firewall. You might need to run this script as root."
-				fi
+				firewall-cmd --zone=public --add-port=$port --permanent >/dev/null 2>&1 ||
+					log "WARN" "Could not add firewall port $port (best-effort)"
 			done
 			log "INFO" "Reloading firewall rules"
-			firewall-cmd --reload
+			firewall-cmd --reload || log "WARN" "Could not reload firewall rules"
 		else
 			log "WARN" "Firewall was not active"
 		fi
@@ -1324,15 +1404,17 @@ function enable_new_services() {
 				;;
 			esac
 			log "DEBUG" "On central..."
-			systemctl enable "$DBMS_SERVICE_NAME" "$PHP_SERVICE_UNIT" "$HTTP_SERVICE_UNIT" snmpd snmptrapd gorgoned centreontrapd cbd centengine centreon
-			systemctl restart "$DBMS_SERVICE_NAME" "$PHP_SERVICE_UNIT" "$HTTP_SERVICE_UNIT" snmpd snmptrapd
-			systemctl start centreontrapd
+			# Best-effort: a single service failing to start must not abort the run,
+			# so the final health recap can report it (see display_services_recap).
+			systemctl enable "$DBMS_SERVICE_NAME" "$PHP_SERVICE_UNIT" "$HTTP_SERVICE_UNIT" snmpd snmptrapd gorgoned centreontrapd cbd centengine centreon || log "WARN" "Some services could not be enabled (see recap below)"
+			systemctl restart "$DBMS_SERVICE_NAME" "$PHP_SERVICE_UNIT" "$HTTP_SERVICE_UNIT" snmpd snmptrapd || log "WARN" "Some services could not be restarted (see recap below)"
+			systemctl start centreontrapd || log "WARN" "centreontrapd could not be started (see recap below)"
 			;;
 
 		poller)
 			log "DEBUG" "On poller..."
-			systemctl enable centreon centengine centreontrapd snmpd snmptrapd gorgoned
-			systemctl start centreontrapd snmptrapd
+			systemctl enable centreon centengine centreontrapd snmpd snmptrapd gorgoned || log "WARN" "Some services could not be enabled"
+			systemctl start centreontrapd snmptrapd || log "WARN" "Some services could not be started"
 			;;
 		esac
 	else
@@ -1371,15 +1453,38 @@ function urlencode() {
 }
 #========= end of function urlencode()
 
+#========= begin of function api_curl()
+# Single fail-hard entry point for every wizard/API curl call: aborts unless the HTTP
+# status is 200/201/204 (widen per-call with API_EXTRA_OK). Sets API_HTTP_CODE; writes
+# the response body to $2. Call as a plain statement, never $(api_curl ...).
+function api_curl() {
+	local desc="$1" body="$2"; shift 2
+	local rc=0
+	API_HTTP_CODE=$(curl --silent --insecure --output "$body" --write-out '%{http_code}' "$@") || rc=$?
+	if [ "$rc" -ne 0 ]; then
+		error_and_exit "${desc}: could not reach the Centreon API on ${central_ip} (curl exit ${rc})"
+	fi
+	local ok
+	for ok in 200 201 204 ${API_EXTRA_OK:-}; do
+		[ "$API_HTTP_CODE" = "$ok" ] && return 0
+	done
+	error_and_exit "${desc}: unexpected HTTP status ${API_HTTP_CODE} (response: $(head -c 400 "$body" 2>/dev/null | tr -d '\n'))"
+}
+#========= end of function api_curl()
+
 #========= begin of function install_wizard_post()
-# execute a post request of the install wizard
-# - session cookie
-# - php command
-# - request body
+# execute a post request of the install wizard (fail-hard via api_curl)
+# - $1 : session cookie
+# - $2 : wizard step php script
+# - $3 : request body (optional)
 function install_wizard_post() {
-	log "INFO" " wizard install step ${2} response ->  $(curl -s -o /dev/null -w "%{http_code}" "http://${central_ip}/centreon/install/steps/process/${2}" \
-		-H 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' \
-		-H "Cookie: ${1}" --data "${3}")"
+	api_curl "install wizard step ${2}" /dev/null \
+		"http://${central_ip}/centreon/install/steps/process/${2}" \
+		--request POST \
+		--header 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' \
+		--header "Cookie: ${1}" \
+		--data "${3:-}"
+	log "INFO" "wizard install step ${2} response -> ${API_HTTP_CODE}"
 }
 #========= end of function install_wizard_post()
 
@@ -1392,8 +1497,10 @@ function play_install_wizard() {
 	enc_db_centreon_password=$(urlencode "$db_centreon_password")
 	enc_centreon_admin_password=$(urlencode "$centreon_admin_password")
 
-	sessionID=$(curl -s -v "http://${central_ip}/centreon/install/install.php" 2>&1 | grep Set-Cookie | awk '{print $3}')
-	curl -s "http://${central_ip}/centreon/install/steps/step.php?action=stepContent" -H "Cookie: ${sessionID}" >/dev/null
+	sessionID=$(curl -s -v "http://${central_ip}/centreon/install/install.php" 2>&1 | grep Set-Cookie | awk '{print $3}') || true
+	[ -n "$sessionID" ] || error_and_exit "Could not obtain an install-wizard session cookie from ${central_ip}"
+	api_curl "install wizard stepContent" /dev/null \
+		"http://${central_ip}/centreon/install/steps/step.php?action=stepContent" --header "Cookie: ${sessionID}"
 	install_wizard_post ${sessionID} "process_step3.php" 'centreon_engine_stats_binary=%2Fusr%2Fsbin%2Fcentenginestats&monitoring_var_lib=%2Fvar%2Flib%2Fcentreon-engine&centreon_engine_connectors=%2Fusr%2Flib64%2Fcentreon-connector&centreon_engine_lib=%2Fusr%2Flib64%2Fcentreon-engine&centreonplugins=%2Fusr%2Flib%2Fcentreon%2Fplugins%2F'
     case $version in
     "24."*)
@@ -1425,274 +1532,111 @@ function play_install_wizard() {
 function test_api_connection () {
 	log "INFO" "Test admin password to access Centreon's API"
 
-	# Define temporary files
-	api_output="/tmp/unattended.sh_api_output"
-	api_return_code="/tmp/unattended.sh_api_return_code"
-	api_error_message="/tmp/unattended.sh_api_error_message"
-	api_error_keys="/tmp/unattended.sh_api_error_keys"
-
-	#
-	# Log in to Centreon API to get token
-	#
-	curl "${central_ip}/centreon/api/latest/login" \
-	--silent \
-	--insecure \
-	--request POST \
-	--header 'Content-Type: application/json' \
-	--data "{\"security\": {\"credentials\": {\"login\": \"admin\",\"password\": \"${centreon_admin_password}\"}}}" \
-	--output ${api_output} \
-	--write-out %{http_code} \
-	> ${api_return_code} 2> ${api_error_message}
-
-	# Analyse result
-	errorLevel=$?
-	httpResponse=$(cat ${api_return_code})
-	message=$(cat ${api_output})
-
-	if [[ $errorLevel -gt 0 ]] || [[ "$httpResponse" != "200" ]]; then
-		error_and_exit "API connection error (errorLevel $errorLevel, http response code $httpResponse, message: $message)"
-	else
-		token=$(echo $message | sed 's/.*{"token":"\(.*\)"}}/\1/g')
-		if [ -z "${token}" ]; then
-			error_and_exit "Unable to extract token from message: $message"
-		fi
-		log "DEBUG" "APIv2 token: ${token}"
-	fi
+	local api_output
+	api_output=$(mktemp)
+	# Log in to Centreon API to get a token (fail-hard via api_curl: only 200/201/204 pass)
+	api_curl "Centreon API login" "$api_output" \
+		"${central_ip}/centreon/api/latest/login" \
+		--request POST \
+		--header 'Content-Type: application/json' \
+		--data "{\"security\": {\"credentials\": {\"login\": \"admin\",\"password\": \"${centreon_admin_password}\"}}}"
+	token=$(sed 's/.*{"token":"\(.*\)"}}/\1/g' "$api_output")
+	rm -f "$api_output"
+	[ -n "${token}" ] || error_and_exit "Unable to extract the API token from the login response"
+	log "DEBUG" "APIv2 token: ${token}"
 }
 #========= end of function test_api_connection()
 
 #========= begin of function play_update_api()
 function play_update_api () {
 	log "INFO" "Install jq binary"
-	$PKG_MGR -q install -y jq > /dev/null 2>&1
+	$PKG_MGR -q install -y jq > /dev/null 2>&1 || error_and_exit "Failed to install jq (required for the update API)"
 
 	log "INFO" "Update Centreon using API"
 
-	# Define temporary files
-	api_output="/tmp/unattended.sh_api_output"
-	api_return_code="/tmp/unattended.sh_api_return_code"
-	api_error_message="/tmp/unattended.sh_api_error_message"
-	api_error_keys="/tmp/unattended.sh_api_error_keys"
+	local api_body message modules module widgets widget clear_line status status_message
+	local -a module_information widget_information
+	api_body=$(mktemp)
 
-	#
-	# Log in to Centreon API to get token
-	#
-	curl "${central_ip}/centreon/api/latest/login" \
-	--silent \
-	--insecure \
-	--request POST \
-	--header 'Content-Type: application/json' \
-	--data "{\"security\": {\"credentials\": {\"login\": \"admin\",\"password\": \"${centreon_admin_password}\"}}}" \
-	--output ${api_output} \
-	--write-out %{http_code} \
-	> ${api_return_code} 2> ${api_error_message}
+	# APIv2 login -> token
+	api_curl "Centreon API login" "$api_body" \
+		"${central_ip}/centreon/api/latest/login" \
+		--request POST \
+		--header 'Content-Type: application/json' \
+		--data "{\"security\": {\"credentials\": {\"login\": \"admin\",\"password\": \"${centreon_admin_password}\"}}}"
+	token=$(sed 's/.*{"token":"\(.*\)"}}/\1/g' "$api_body")
+	[ -n "${token}" ] || error_and_exit "Unable to extract the API token from the login response"
+	log "DEBUG" "APIv2 token: ${token}"
 
-	# Analyse result
-	errorLevel=$?
-	httpResponse=$(cat ${api_return_code})
-	message=$(cat ${api_output})
-	if [[ -f ${api_output} && -s "${api_output}" ]];then
-		jq --raw-output 'keys | @csv' ${api_output} | sed 's/"//g' > ${api_error_keys}
-		hasErrors=`grep --quiet --invert errors ${api_error_keys};echo $?`
-	else
-		hasErrors=0
-	fi
+	# Trigger the centreon-web update. 204 = done; 404 is tolerated (returned when there is
+	# nothing to update on this version).
+	API_EXTRA_OK="404"
+	api_curl "Centreon Web update" "$api_body" \
+		"${central_ip}/centreon/api/latest/platform/updates" \
+		--request PATCH \
+		--header "X-AUTH-TOKEN: ${token}" \
+		--header 'Content-Type: application/json' \
+		--data '{"components":[{"name":"centreon-web"}]}'
+	API_EXTRA_OK=""
+	log "INFO" "Centreon Web update completed"
 
-	if [[ $errorLevel -gt 0 ]] || [[ $hasErrors -gt 0 ]] || [[ "$httpResponse" != "200" ]]; then
-		error_and_exit "API connection error (errorLevel $errorLevel, http response code $httpResponse, message: $message)"
-	else
-		token=$(echo $message | sed 's/.*{"token":"\(.*\)"}}/\1/g')
-		if [ -z "${token}" ]; then
-			error_and_exit "Unable to extract token from message: $message"
+	# APIv1 login -> tokenv1
+	api_curl "Centreon APIv1 login" "$api_body" \
+		"${central_ip}/centreon/api/index.php?action=authenticate" \
+		--request POST \
+		--data "username=admin&password=${centreon_admin_password}"
+	tokenv1=$(cut -f2 -d":" "$api_body" | sed -e "s/\"//g" -e "s/}//" -e 's|\\||g')
+	[ -n "${tokenv1}" ] || error_and_exit "Unable to extract the APIv1 token from the login response"
+	log "DEBUG" "APIv1 token: ${tokenv1}"
+
+	# Get the list of installed modules and widgets
+	api_curl "Centreon module/widget list" "$api_body" \
+		"${central_ip}/centreon/api/index.php?object=centreon_module&action=list" \
+		--request GET \
+		--header "centreon-auth-token: ${tokenv1}"
+	message=$(cat "$api_body")
+
+	# Update each module whose current version differs from the available one
+	# '[]?' tolerates a valid "no modules" response (empty/missing list); a jq parse error
+	# (malformed/non-JSON body) still exits non-zero and fails hard.
+	modules=$(echo "${message}" | jq '.result.module.entities[]? | "\(.id)|\(.version.current)|\(.version.available)"') || error_and_exit "Failed to parse the module list from the API response (invalid JSON)"
+	for module in ${modules}; do
+		clear_line=$(sed -e 's/^"//' -e 's/"$//' <<< "${module}")
+		IFS="|" read -a module_information <<< "${clear_line}"
+		if [ "${module_information[1]}" != "${module_information[2]}" ]; then
+			api_curl "update of ${module_information[0]} module" "$api_body" \
+				"${central_ip}/centreon/api/index.php?object=centreon_module&action=update&id=${module_information[0]}&type=module" \
+				--request POST \
+				--header "centreon-auth-token: ${tokenv1}"
+			status=$(jq '.status' "$api_body") || true
+			status_message=$(jq '.result.message' "$api_body") || true
+			if [ "${status}" = "false" ]; then
+				log "WARN" "Error during update of ${module_information[0]} module: ${status_message}"
+			fi
 		fi
-		log "DEBUG" "APIv2 token: ${token}"
-	fi
+	done
 
-	# Clean files
-	rm -f ${api_output} ${api_return_code} ${api_error_message} ${api_error_keys}
+	# Update each widget whose current version differs from the available one
+	# see the module list above: tolerate an empty list, fail hard on malformed JSON.
+	widgets=$(echo "${message}" | jq '.result.widget.entities[]? | "\(.id)|\(.version.current)|\(.version.available)"') || error_and_exit "Failed to parse the widget list from the API response (invalid JSON)"
+	for widget in ${widgets}; do
+		clear_line=$(sed -e 's/^"//' -e 's/"$//' <<< "${widget}")
+		IFS="|" read -a widget_information <<< "${clear_line}"
+		if [ "${widget_information[1]}" != "${widget_information[2]}" ]; then
+			api_curl "update of ${widget_information[0]} widget" "$api_body" \
+				"${central_ip}/centreon/api/index.php?object=centreon_module&action=update&id=${widget_information[0]}&type=widget" \
+				--request POST \
+				--header "centreon-auth-token: ${tokenv1}"
+			status=$(jq '.status' "$api_body") || true
+			status_message=$(jq '.result.message' "$api_body") || true
+			if [ "${status}" = "false" ]; then
+				log "WARN" "Error during update of ${widget_information[0]} widget: ${status_message}"
+			fi
+		fi
+	done
 
-	#
-	# Call Centreon Web update API
-	#
-	curl "${central_ip}/centreon/api/latest/platform/updates"  \
-	--silent \
-	--insecure \
-	--request PATCH \
-	--header "X-AUTH-TOKEN: ${token}" \
-	--header 'Content-Type: application/json' \
-	--data '{"components":[{"name":"centreon-web"}]}' \
-	--output ${api_output} \
-	--write-out %{http_code} \
-	> ${api_return_code} 2> ${api_error_message}
-
-	errorLevel=$?
-	httpResponse=$(cat ${api_return_code})
-	message=$(cat ${api_output})
-	if [[ -f ${api_output} && -s "${api_output}" ]];then
-		jq --raw-output 'keys | @csv' ${api_output} | sed 's/"//g' > ${api_error_keys}
-		hasErrors=`grep --quiet --invert errors ${api_error_keys};echo $?`
-	else
-		hasErrors=0
-	fi
-
-	if [[ $errorLevel -gt 0 ]] || [[ $hasErrors -gt 0 ]] || [[ "$httpResponse" != "204" && "$httpResponse" != "404" ]]; then
-		error_and_exit "Error during update (errorLevel $errorLevel, http response code $httpResponse, message: $message)"
-	else
-		log "INFO" "Centreon Web update completed"
-	fi
-
-	# Clean files
-	rm -f ${api_output} ${api_return_code} ${api_error_message} ${api_error_keys}
-
-	#
-	# Log in to Centreon APIv1 to get token
-	#
-    curl "${central_ip}/centreon/api/index.php?action=authenticate"  \
-    --silent \
-    --insecure \
-    --request POST \
-    --data "username=admin&password=${centreon_admin_password}" \
-    --output ${api_output} \
-    --write-out %{http_code} \
-    > ${api_return_code} 2> ${api_error_message}
-
-
-    # Analyse result
-    errorLevel=$?
-    httpResponse=$(cat ${api_return_code})
-    message=$(cat ${api_output})
-    if [[ -f ${api_output} && -s "${api_output}" ]];then
-        jq --raw-output 'keys | @csv' ${api_output} | sed 's/"//g' > ${api_error_keys}
-        hasErrors=`grep --quiet --invert errors ${api_error_keys};echo $?`
-    else
-        hasErrors=0
-    fi
-
-    if [[ $errorLevel -gt 0 ]] || [[ $hasErrors -gt 0 ]] || [[ "$httpResponse" != "200" ]]; then
-        error_and_exit "API connection error (errorLevel $errorLevel, http response code $httpResponse, message: $message)"
-    else
-        tokenv1=$(echo ${message} | cut -f2 -d":" | sed -e "s/\"//g" -e "s/}//" -e 's|\\||g')
-        if [ -z "${tokenv1}" ]; then
-            error_and_exit "Unable to extract token from message: $message"
-        fi
-		log "DEBUG" "APIv1 token: ${token}"
-    fi
-
-	rm -f ${api_output} ${api_return_code} ${api_error_message} ${api_error_keys}
-
-    #
-    # Get list of installed extensions
-    #
-    curl "${central_ip}/centreon/api/index.php?object=centreon_module&action=list"  \
-    --silent \
-    --insecure \
-    --request GET \
-    --header "centreon-auth-token: ${tokenv1}" \
-    --output ${api_output} \
-    --write-out %{http_code} \
-    > ${api_return_code} 2> ${api_error_message}
-
-    # Analyse result
-    errorLevel=$?
-    httpResponse=$(cat ${api_return_code})
-    message=$(cat ${api_output})
-	if [[ -f ${api_output} && -s "${api_output}" ]];then
-        jq --raw-output 'keys | @csv' ${api_output} | sed 's/"//g' > ${api_error_keys}
-        hasErrors=`grep --quiet --invert errors ${api_error_keys};echo $?`
-    else
-        hasErrors=0
-    fi
-
-    if [[ $errorLevel -gt 0 ]] || [[ $hasErrors -gt 0 ]] || [[ "$httpResponse" != "200" ]]; then
-        error_and_exit "Error during update (errorLevel $errorLevel, http response code $httpResponse, message: $message)"
-    else
-	    #
-        # Get list of modules and update them if needed
-		#
-        modules=$(echo ${message} | jq '.result.module.entities[] | "\(.id)|\(.version.current)|\(.version.available)"')
-        for module in ${modules}
-        do
-			rm -f ${api_output} ${api_return_code} ${api_error_message} ${api_error_keys}
-            clear_line=$(sed -e 's/^"//' -e 's/"$//' <<< ${module})
-            IFS="|" read -a module_information <<< ${clear_line}
-            if [ "${module_information[1]}" != "${module_information[2]}" ]; then
-                curl "${central_ip}/centreon/api/index.php?object=centreon_module&action=update&id=${module_information[0]}&type=module" \
-                --silent \
-                --insecure \
-                --request POST \
-                --header "centreon-auth-token: ${tokenv1}" \
-                --output ${api_output} \
-                --write-out %{http_code} \
-                > ${api_return_code} 2> ${api_error_message}
-
-                # Analyse result
-                errorLevel=$?
-                httpResponse=$(cat ${api_return_code})
-                sub_message=$(cat ${api_output})
-
-				if [[ -f ${api_output} && -s "${api_output}" ]];then
-					jq --raw-output 'keys | @csv' ${api_output} | sed 's/"//g' > ${api_error_keys}
-					hasErrors=`grep --quiet --invert errors ${api_error_keys};echo $?`
-				else
-					hasErrors=0
-				fi
-
-                if [[ $errorLevel -gt 0 ]] || [[ $hasErrors -gt 0 ]] || [[ "$httpResponse" != "200" ]]; then
-                    error_and_exit "Error during update of ${module_information[0]} module (errorLevel $errorLevel, http response code $httpResponse, message: $sub_message)"
-                else
-                    status=$(echo ${sub_message} | jq '.status')
-                    status_message=$(echo ${sub_message} | jq '.result.message')
-                    if [ "${status}" = "false" ]; then
-                        log "WARN" "Error during update of ${module_information[0]} module: ${status_message}"
-                    fi
-                fi
-            fi
-        done
-
-		#
-        # Get list of widgets and update them if needed
-		#
-        widgets=$(echo ${message} | jq '.result.widget.entities[] | "\(.id)|\(.version.current)|\(.version.available)"')
-        for widget in ${widgets}
-        do
-			rm -f ${api_output} ${api_return_code} ${api_error_message} ${api_error_keys}
-            clear_line=$(sed -e 's/^"//' -e 's/"$//' <<< ${widget})
-            IFS="|" read -a widget_information <<< ${clear_line}
-            if [ "${widget_information[1]}" != "${widget_information[2]}" ]; then
-                curl "${central_ip}/centreon/api/index.php?object=centreon_module&action=update&id=${widget_information[0]}&type=widget" \
-                --silent \
-                --insecure \
-                --request POST \
-                --header "centreon-auth-token: ${tokenv1}" \
-                --output ${api_output} \
-                --write-out %{http_code} \
-                > ${api_return_code} 2> ${api_error_message}
-
-                # Analyse result
-                errorLevel=$?
-                httpResponse=$(cat ${api_return_code})
-                sub_message=$(cat ${api_output})
-
-				if [[ -f ${api_output} && -s "${api_output}" ]];then
-					jq --raw-output 'keys | @csv' ${api_output} | sed 's/"//g' > ${api_error_keys}
-					hasErrors=`grep --quiet --invert errors ${api_error_keys};echo $?`
-				else
-					hasErrors=0
-				fi
-
-                if [[ $errorLevel -gt 0 ]] || [[ $hasErrors -gt 0 ]] || [[ "$httpResponse" != "200" ]]; then
-                    error_and_exit "Error during update of ${widget_information[0]} widget (errorLevel $errorLevel, http response code $httpResponse, message: $sub_message)"
-                else
-                    status=$(echo ${sub_message} | jq '.status')
-                    status_message=$(echo ${sub_message} | jq '.result.message')
-                    if [ "${status}" = "false" ]; then
-                        log "WARN" "Error during update of ${widget_information[0]} widget: ${status_message}"
-                    fi
-                fi
-            fi
-        done
-    fi
-
+	rm -f "$api_body"
+	return 0
 }
 #========= end of function play_update_api()
 
@@ -1723,13 +1667,14 @@ function install_central() {
 	fi
 
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
+		_install_rc=0
 		if (( $(version_int) >= $(version_int 24.10) && $(version_int) <= $(version_int 24.12) )); then
-			$PKG_MGR install -y $CENTREON_DBMS_PKG centreon
+			$PKG_MGR install -y $CENTREON_DBMS_PKG centreon || _install_rc=$?
 		else
-			$PKG_MGR install -y --no-install-recommends $CENTREON_DBMS_PKG centreon
+			$PKG_MGR install -y --no-install-recommends $CENTREON_DBMS_PKG centreon || _install_rc=$?
 		fi
 
-		if [ $? -ne 0 ]; then
+		if [ "$_install_rc" -ne 0 ]; then
 			error_and_exit "Could not install Centreon (package centreon)"
 		fi
 	else
@@ -1739,9 +1684,7 @@ function install_central() {
 		local db_opts=""
 		[[ "$dbms" == "MySQL" ]] && db_opts="--setopt=install_weak_deps=False"
 		# install core Centreon packages from enabled repo
-		$PKG_MGR -q clean all --enablerepo="*" && $PKG_MGR -q install -y $db_opts $CENTREON_DBMS_PKG centreon --enablerepo="$CENTREON_REPO"
-
-		if [ $? -ne 0 ]; then
+		if ! { $PKG_MGR -q clean all --enablerepo="*" && $PKG_MGR -q install -y $db_opts $CENTREON_DBMS_PKG centreon --enablerepo="$CENTREON_REPO"; }; then
 			error_and_exit "Could not install Centreon (package centreon)"
 		fi
 	fi
@@ -1759,7 +1702,7 @@ function install_central() {
 			$timezoneName = "UTC";
 		}
 		echo $timezoneName;
-	' 2>/dev/null)
+	' 2>/dev/null) || true
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
 		# Determine the PHP version Centreon expects for this release...
 		if (( $(version_int) >= $(version_int 26.07) )); then
@@ -1770,7 +1713,7 @@ function install_central() {
 			expected_php_version=""
 		fi
 		# ...then cross-check against the PHP actually installed (authoritative for the on-disk path).
-		installed_php_version=$($PHP_BIN -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;' 2>/dev/null)
+		installed_php_version=$($PHP_BIN -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;' 2>/dev/null) || true
 		if [[ -z "$expected_php_version" ]]; then
 			php_version="$installed_php_version"
 		elif [[ -n "$installed_php_version" && "$installed_php_version" != "$expected_php_version" ]]; then
@@ -1802,18 +1745,18 @@ function install_poller() {
 	log "INFO" "Poller installation from ${CENTREON_REPO}"
 
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
+		_install_rc=0
 		if (( $(version_int) >= $(version_int 24.10) && $(version_int) <= $(version_int 24.12) )); then
-			$PKG_MGR install -y $CENTREON_DBMS_PKG centreon-poller
+			$PKG_MGR install -y $CENTREON_DBMS_PKG centreon-poller || _install_rc=$?
 		else
-			$PKG_MGR install -y --no-install-recommends $CENTREON_DBMS_PKG centreon-poller
+			$PKG_MGR install -y --no-install-recommends $CENTREON_DBMS_PKG centreon-poller || _install_rc=$?
 		fi
 
-		if [ $? -ne 0 ]; then
+		if [ "$_install_rc" -ne 0 ]; then
 			error_and_exit "Could not install Centreon (package centreon)"
 		fi
 	else
-		$PKG_MGR -q clean all --enablerepo="*" && $PKG_MGR -q install -y centreon-poller-centreon-engine --enablerepo=$CENTREON_REPO
-		if [ $? -ne 0 ]; then
+		if ! { $PKG_MGR -q clean all --enablerepo="*" && $PKG_MGR -q install -y centreon-poller-centreon-engine --enablerepo=$CENTREON_REPO; }; then
 			error_and_exit "Could not install Centreon (package centreon)"
 		fi
 	fi
@@ -1826,10 +1769,9 @@ function install_poller() {
 function update_centreon_packages() {
 	log "INFO" "Update Centreon packages using ${CENTREON_REPO}"
 	if [[ "${detected_os_release}" =~ debian-release-.* ]]; then
-		$PKG_MGR upgrade centreon
+		$PKG_MGR upgrade centreon || error_and_exit "Could not update Centreon"
 	else
-		$PKG_MGR -q clean all --enablerepo="*" && $PKG_MGR -q update -y centreon\* --enablerepo=$CENTREON_REPO
-		if [ $? -ne 0 ]; then
+		if ! { $PKG_MGR -q clean all --enablerepo="*" && $PKG_MGR -q update -y centreon\* --enablerepo=$CENTREON_REPO; }; then
 			error_and_exit "Could not update Centreon"
 		fi
 	fi
@@ -1840,7 +1782,7 @@ function update_centreon_packages() {
 # Restart Centreon process
 #
 function restart_centreon_process() {
-	systemctl restart centreon snmpd snmptrapd
+	systemctl restart centreon snmpd snmptrapd || log "WARN" "Could not restart all Centreon processes (see recap below)"
 }
 #========= end of function restart_centreon_process()
 
@@ -1859,9 +1801,9 @@ function update_after_installation() {
 
 	if ! [[ "${detected_os_release}" =~ debian-release-.* ]]; then
 		# install Centreon SELinux packages first (as getenforce is still at 0)
-		$PKG_MGR -q install -y ${CENTREON_SELINUX_PACKAGES[@]} --enablerepo="$CENTREON_REPO"
-		if [ $? -ne 0 ]; then
-			log "ERROR" "Could not install Centreon SELinux packages"
+		# Non-fatal: missing SELinux rules should not abort the installation.
+		if ! $PKG_MGR -q install -y ${CENTREON_SELINUX_PACKAGES[@]} --enablerepo="$CENTREON_REPO"; then
+			log "WARN" "Could not install Centreon SELinux packages (best-effort)"
 		else
 			log "INFO" "Centreon SELinux rules are installed. Please consult the documentation https://docs.centreon.com/docs/administration/secure-platform for more details."
 		fi
@@ -1883,6 +1825,82 @@ function test_password_policy() {
     fi
 }
 #========= end of function test_password_policy()
+
+#========= begin of function display_services_recap()
+# Print a final platform healthcheck just before the credentials are displayed.
+# Topology-aware (only the services relevant to the installed role are checked) and
+# rendered in the same banner style as the run summary, recorded in the log file and
+# mirrored to the console. Purely informational: it tolerates inactive units (guarded
+# systemctl calls) so it never aborts the script.
+#
+function display_services_recap() {
+	local entry name unit topos active enabled state db_unit
+
+	if [ "${has_systemd:-0}" -ne 1 ]; then
+		log "WARN" "Systemd is not available: cannot report platform healthcheck"
+		return 0
+	fi
+
+	# Resolve the database unit from the chosen DBMS (robust for install and update).
+	if [ "$dbms" == "MariaDB" ]; then
+		db_unit="mariadb"
+	else
+		db_unit="${mysql_service_name:-mysqld}"
+	fi
+
+	# label | systemd unit | topologies the check applies to (space-separated)
+	# http and php units differ per distro (httpd/php-fpm on EL, apache2/php8.x-fpm on
+	# Debian); they are resolved via the variables set in set_required_prerequisite.
+	# Topologies mirror what enable_new_services actually starts: centengine runs on
+	# central AND pollers; cbd is central-only (pollers do not ship/enable a cbd unit).
+	local -a recap_services=(
+		"database|${db_unit}|central"
+		"httpd|${HTTP_SERVICE_UNIT:-httpd}|central"
+		"php-fpm|${PHP_SERVICE_UNIT:-php-fpm}|central"
+		"centengine|centengine|central poller"
+		"gorgone|gorgoned|central poller"
+		"cbd|cbd|central"
+		"centreontrapd|centreontrapd|central poller"
+		"snmptrapd|snmptrapd|central poller"
+		"snmpd|snmpd|central poller"
+	)
+
+	local -a results=()
+	for entry in "${recap_services[@]}"; do
+		IFS='|' read -r name unit topos <<<"$entry"
+		# Skip services that do not apply to the installed topology.
+		[[ " $topos " == *" $topology "* ]] || continue
+		active=$(systemctl is-active "$unit" 2>/dev/null || true)
+		enabled=$(systemctl is-enabled "$unit" 2>/dev/null || true)
+		if [ "$active" == "active" ]; then
+			state="[OK]    "
+		else
+			state="[FAILED]"
+		fi
+		results+=("$(printf '  %s %-14s (%-13s) active=%-10s enabled=%s' \
+			"$state" "$name" "$unit" "${active:-unknown}" "${enabled:-unknown}")")
+	done
+
+	# Record in the log file.
+	log "INFO" "============== Centreon platform healthcheck ([$topology]) =============="
+	for entry in "${results[@]}"; do
+		log "INFO" "$entry"
+	done
+	log "INFO" "========================================================================"
+
+	# Mirror to the console (fd 3) when output is redirected to a log file.
+	if [ -n "${LOG_FILE:-}" ]; then
+		{
+			echo "============== Centreon platform healthcheck ([$topology]) =============="
+			for entry in "${results[@]}"; do
+				echo "$entry"
+			done
+			echo "========================================================================"
+		} >&3
+	fi
+	return 0
+}
+#========= end of function display_services_recap()
 
 #####################################################
 ################ MAIN SCRIPT EXECUTION ##############
@@ -1918,6 +1936,35 @@ install)
 
 esac
 
+# Keep a handle to the original console (fd 3) for the credentials recap and the
+# start/finish/failure notices, so they remain visible even when all other output
+# is redirected to the log file.
+exec 3>&1
+
+# Write all output (stdout+stderr) straight to a real log file with a plain redirect.
+# Set up AFTER argument parsing so that '-h'/usage and argument errors stay on the
+# console (no log file created for them), but BEFORE setup_debug_mode and password
+# generation so '-D' xtrace (which would echo generated passwords) lands in the file,
+# not on the console. This is deliberately NOT 'tee'/process-substitution: in
+# packer/provisioning runs bash does not wait for the async 'tee' to flush on exit,
+# which can truncate the log. A direct redirect is synchronous and preserves the exit
+# code (no pipeline). Disable with ENV_LOG_TO_FILE=false; override path with ENV_LOG_FILE.
+if [ "${ENV_LOG_TO_FILE:-true}" == "true" ]; then
+	LOG_FILE=${ENV_LOG_FILE:-/var/log/centreon-unattended-$(date +%Y%m%d-%H%M%S).log}
+	if mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null && : > "$LOG_FILE" 2>/dev/null; then
+		chmod 600 "$LOG_FILE" 2>/dev/null || true
+		echo "unattended.sh: all output is written to [$LOG_FILE] (credentials are shown on the console only)." >&3
+		exec >> "$LOG_FILE" 2>&1
+		log "INFO" "===== unattended.sh started, logging to [$LOG_FILE] ====="
+	else
+		log "WARN" "Could not create log file [$LOG_FILE]; continuing with console output only"
+		LOG_FILE=""
+	fi
+fi
+
+# Enable shell xtrace now if debug mode was requested (-D flag or ENV_DEBUG_MODE=true)
+setup_debug_mode
+
 # Validate the resolved TLS mode (from ENV_DB_TLS or the --tls flag) before using it.
 [[ ${SUPPORTED_TLS[$tls]} ]] || error_and_exit "Unsupported TLS mode: '$tls' (expected enabled or disabled)"
 
@@ -1933,7 +1980,9 @@ if [ "$operation" == "install" ]; then
 			centreon_admin_password=${ENV_CENTREON_ADMIN_PASSWD:-"$(genpasswd "Centreon user: admin")"}
 		else
 			test_password_policy
-   		echo "User defined password set for user [Centreon user: admin] is [$centreon_admin_password]" >>$tmp_passwords_file
+			if ! echo "User defined password set for user [Centreon user: admin] is [$centreon_admin_password]" >>$tmp_passwords_file; then
+				error_and_exit "Cannot save the admin password to [$tmp_passwords_file]"
+			fi
 		fi
 		# Set from ENV or Administrator first name
 		centreon_admin_firstname=${ENV_CENTREON_ADMIN_FIRSTNAME:-"John"}
@@ -1952,19 +2001,51 @@ else
 	fi
 fi
 
-## Display all configured parameters
+## Display all configured parameters (recorded in the log file)
 log "INFO" "Start to execute operation [$operation] with following configuration parameters:"
 log "INFO" " topology: \t[$topology]"
 log "INFO" " version: \t[$version]"
 log "INFO" " repository: [$repo]"
+log "INFO" " database: \t[$dbms]"
 log "INFO" " TLS mode: \t[$tls]"
-
+log "INFO" " debug mode: [$debug_mode]"
 log "WARN" "It will start in [$default_timeout_in_sec] seconds. If you don't want to wait, press any key to continue or Ctrl-C to exit"
-pause "" $default_timeout_in_sec
+
+# Mirror the run summary + countdown to the real console (fd 3) so the operator sees
+# what the run will use, even when all output is redirected to the log file.
+# Skipped when logging to console only (LOG_FILE empty), to avoid printing twice.
+if [ -n "${LOG_FILE:-}" ]; then
+	{
+		echo "================ unattended.sh - run summary ================"
+		echo "  operation : $operation"
+		echo "  topology  : $topology"
+		echo "  version   : $version"
+		echo "  repository: $repo"
+		echo "  database  : $dbms"
+		echo "  TLS mode  : $tls"
+		echo "  debug mode: $debug_mode"
+		echo "  log file  : $LOG_FILE"
+		echo "============================================================"
+		echo "Starting in $default_timeout_in_sec seconds - press any key to continue now, or Ctrl-C to abort."
+	} >&3
+fi
+
+# Wait (or until a key is pressed), then confirm the input registered and announce
+# what happens next, so the operator is not left staring at a silent terminal.
+if pause "" $default_timeout_in_sec; then
+	start_trigger="key pressed"
+else
+	start_trigger="${default_timeout_in_sec}s timeout elapsed"
+fi
+log "INFO" "Input registered ($start_trigger). Starting [$operation] of Centreon [$topology] now - configuring repositories and installing packages, this may take several minutes."
+if [ -n "${LOG_FILE:-}" ]; then
+	echo "Input registered ($start_trigger). Starting [$operation] of Centreon [$topology] now (this may take several minutes); follow progress in $LOG_FILE" >&3
+fi
 
 ##
 # Analyze system and set the variables
 ##
+notice "Phase 1: checking prerequisites and configuring repositories"
 set_required_prerequisite
 ##
 # Check if systemd is present
@@ -1980,6 +2061,7 @@ install)
 
 	gorgone_selinux_package_name="centreon-gorgone-selinux"
 
+	notice "Phase 2: installing Centreon [$topology] packages (this is the longest step)"
 	case $topology in
 	central)
 		CENTREON_SELINUX_PACKAGES=(centreon-common-selinux centreon-web-selinux centreon-broker-selinux centreon-engine-selinux $gorgone_selinux_package_name centreon-plugins-selinux)
@@ -1994,9 +2076,11 @@ install)
 		;;
 	esac
 
+	notice "Phase 3: post-install configuration (services, firewall, SELinux)"
 	update_after_installation
 
 	if [ "$topology" == "central" ] && [ "$wizard_autoplay" == "true" ]; then
+		notice "Phase 4: running the Centreon installation wizard"
 		# The wizard talks plain HTTP (no -L/-k); run it BEFORE enabling the HTTPS :80->:443 redirect.
 		play_install_wizard
 	else
@@ -2024,8 +2108,10 @@ update)
 	case $topology in
 
 	central)
+		notice "Phase 1: updating Centreon [$topology] packages"
 		update_centreon_packages
 		if [ "$wizard_autoplay" == "true" ]; then
+			notice "Phase 2: applying updates through the Centreon API"
 			play_update
 			restart_centreon_process
 			log "INFO" "Log in to Centreon web interface via the URL: http://$central_ip/centreon"
@@ -2036,6 +2122,7 @@ update)
 		;;
 	poller)
 		CENTREON_DOC_URL=""
+		notice "Phase 1: updating Centreon [$topology] packages"
 		update_centreon_packages
 		restart_centreon_process
 		;;
@@ -2046,25 +2133,36 @@ update)
 
 esac
 
+# Final platform healthcheck (topology-aware), just before the credentials output.
+display_services_recap
+
 ## Major change - remind it again (in case of log level is ERROR)
 if [ -e $tmp_passwords_file ] && [ "$topology" == "central" ] && [ "$operation" = "install" ]; then
-	# Move the tmp file to the dest file
-	mv $tmp_passwords_file $passwords_file
-	echo
-	echo "****** IMPORTANT ******"
-	if [ "$wizard_autoplay" == "true" ]; then
-		echo "As you will need passwords for users such as [root,centreon] on your $DBMS database system and [admin] on your Centreon platform, random passwords are generated"
-	else
-		echo "As you will need a password for the user [root] on your $DBMS database system, a random password is generated"
-	fi
-	echo "Passwords are currently saved in [$passwords_file]"
-	cat $passwords_file
-	echo
-	echo "Please save them securely and then delete this file!"
-	echo
+	# Move the tmp file to the dest file (non-fatal: the install already succeeded)
+	mv $tmp_passwords_file $passwords_file || log "WARN" "Could not move $tmp_passwords_file to $passwords_file"
+	# Send the credentials to the console only (fd 3), never to the log file.
+	{
+		echo
+		echo "****** IMPORTANT ******"
+		if [ "$wizard_autoplay" == "true" ]; then
+			echo "As you will need passwords for users such as [root,centreon] on your $dbms database system and [admin] on your Centreon platform, random passwords are generated"
+		else
+			echo "As you will need a password for the user [root] on your $dbms database system, a random password is generated"
+		fi
+		echo "Passwords are currently saved in [$passwords_file]"
+		cat $passwords_file || true
+		echo
+		echo "Please save them securely and then delete this file!"
+		echo
+	} >&3
 fi
 if [ -e $tmp_passwords_file ] && [ "$operation" = "update" ]; then
 	rm -f $tmp_passwords_file
+fi
+
+# Final notice on the console (the rest of the run is in the log file).
+if [ -n "${LOG_FILE:-}" ]; then
+	echo "unattended.sh finished successfully. Full log: ${LOG_FILE}" >&3
 fi
 
 exit 0


### PR DESCRIPTION
## Description

Backport of #11600 (merged on `develop`) to `dev-24.10.x` — ticket MON-209110.

`unattended.sh` rejected `-v 26.10`:

```
ERROR - Unsupported version: 26.10
```

`26.10` was missing from the `SUPPORTED_VERSION` whitelist, so the argument was refused
before any install logic ran.

## What this PR does

Rather than cherry-picking the two-line fix, this replaces `centreon/unattended.sh`
wholesale with the version currently on `develop`, so the script is identical across
branches. The resulting file is **byte-identical to `develop`** (verified with `cmp`).

### ⚠️ Note for the reviewer: this is a large diff (+535 / -437)

On this branch `unattended.sh` had drifted well behind `develop`, so aligning it brings across
more than the 26.10 fix. Functional changes that ride along:

- new `on_error()` ERR trap — reports exit code, line number and failing command, with redaction
  of commands that may carry credentials
- new `-D` flag (shell xtrace + DEBUG log level) via `setup_debug_mode()`; `OPTIONS` becomes
  `hsDt:v:r:l:p:d:V:-:`
- all output written to `/var/log/centreon-unattended-<ts>.log` (override `ENV_LOG_FILE`,
  disable with `ENV_LOG_TO_FILE=false`)
- new `api_curl()` helper and `display_services_recap()` end-of-run summary
- assorted fixes already reviewed on `develop` (TLS/DBMS handling, MySQL 8.4 bootstrap,
  non-fatal langpack install, APT signing-key import hardening)

Every one of those was reviewed and merged on `develop` already. Flagging it because
"backport the 26.10 fix" and "sync the whole script" are materially different in scope —
if you would rather this branch received only the two-line whitelist change, say so and
I will reduce it.


## Tests

No Docker available locally, so I drove the script's own code from a harness that sources
everything above `MAIN SCRIPT EXECUTION`, fakes `/etc/os-release` and stubs the package
managers. Nothing in the harness re-implements a version condition — each check either
calls the shipped function or `eval`s the verbatim source range. **32 assertions, all passing**
on this branch:

- real `parse_subcommand_options` — `-v 24.10/25.10/26.07/26.10` accepted, `26.09`/`27.10` rejected
- real `set_required_prerequisite` — el8/el9/el10/deb12/deb13 x 26.07/26.10/25.10, asserting the
  accept/reject verdict
- real `set_release_repo_file` / `set_centreon_repos` — 26.10 URL and repo-name output
- real `set_mariadb_repos` (26.10 → 11.8, 25.10 → 10.11) and `setup_mysql` (26.10 → 8.4, 25.10 → 8.0)
- verbatim `play_install_wizard` step4 `case` — 26.10 takes the non-`cbmod` payload
- verbatim `install_central` PHP-selection block — 26.10 → PHP 8.4
- `version_int` / `uses_internal_repo` for 26.10

Running the same suite against this branch's **unmodified** `unattended.sh` fails on
`-v 26.10 accepted`, confirming the fix lands.

`bash -n` clean; `shellcheck -S error` reports the same 3 pre-existing findings as `develop`.

Live repository check: the URLs the script builds for 26.10 resolve
(`rpm-standard/26.10/el9` and `el10` → 200), and the repo IDs published there
(`centreon-26.10-stable`, `-noarch`) match the `centreon-26.10-stable*` glob passed to `--enablerepo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
