### PR TITLE
fix(ci): fail fast on unreadable pulp indexes

### DIFF
--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -73,9 +73,11 @@ fetch_index() {
 wait_for_metadata() {
   local deadline=$(( SECONDS + METADATA_TIMEOUT ))
   local resolved previous_resolved=-1 stall_rounds=0
-  until resolve_pending; do
+  # a refusal recorded during a round wins even when that round resolved everything
+  while ! resolve_pending || [[ -n "$INDEX_AUTH_DENIED" ]]; do
     if [[ -n "$INDEX_AUTH_DENIED" ]]; then
       echo "::error::The content app refused the CI identity while reading the published index (${INDEX_AUTH_DENIED}): the CI user lacks the download role on the content guard, not waiting for the metadata"
+      FAILED=1
       break
     fi
     resolved=0

--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -19,6 +19,9 @@ switch_pulp_domain "$PULP_DOMAIN" || exit 1
 # content-app cache TTL (600s), the window must survive that worst case
 METADATA_TIMEOUT="${METADATA_TIMEOUT:-900}"
 METADATA_INTERVAL="${METADATA_INTERVAL:-15}"
+# set by fetch_index on a 401/403: the content guard refused the CI identity,
+# a permanent failure wait_for_metadata reports at once instead of polling
+INDEX_AUTH_DENIED=""
 
 # accumulated per-package result rows and the aggregate failure flag
 ROWS=()
@@ -45,10 +48,24 @@ load_expected() {
   echo "[INFO] ${COUNT} expected ${package_type} package(s) to verify"
 }
 
+# fetch_index <url> <outfile> — read a published index (repomd.xml, Release,
+# Packages) through the content app into <outfile>; non-zero when unreadable.
+# A 401/403 is kept in INDEX_AUTH_DENIED: waiting never fixes an authorization refusal.
+fetch_index() {
+  local url=$1 outfile=$2 code
+  code=$(content_curl -sSL -o "$outfile" -w '%{http_code}' "$url" 2>/dev/null) || code=000
+  case "$code" in
+    200) return 0 ;;
+    401|403) INDEX_AUTH_DENIED="HTTP $code on $url" ;;
+  esac
+  : > "$outfile"
+  return 1
+}
+
 # wait_for_metadata — repeatedly call the sourcing script's resolve_pending (one
 # resolution round over the still-unresolved packages, returning 0 once none
-# remain) until everything resolves, METADATA_TIMEOUT is reached, or the
-# resolution stalls. The retry window only covers publication propagation: once
+# remain) until everything resolves, METADATA_TIMEOUT is reached, the
+# resolution stalls, or the content app refuses the CI identity (fetch_index). The retry window only covers publication propagation: once
 # a round reads the published metadata and resolves nothing new while some
 # packages already resolved, the remaining ones are not in the publication at
 # all (e.g. evicted by the retention policy) and no amount of waiting will
@@ -57,6 +74,10 @@ wait_for_metadata() {
   local deadline=$(( SECONDS + METADATA_TIMEOUT ))
   local resolved previous_resolved=-1 stall_rounds=0
   until resolve_pending; do
+    if [[ -n "$INDEX_AUTH_DENIED" ]]; then
+      echo "::error::The content app refused the CI identity while reading the published index (${INDEX_AUTH_DENIED}): the CI user lacks the download role on the content guard, not waiting for the metadata"
+      break
+    fi
     resolved=0
     for i in "${!E_FILENAME[@]}"; do
       [[ "${META_IDX[$i]}" == "true" ]] && resolved=$((resolved + 1))

--- a/.github/scripts/pulp/check-deb.sh
+++ b/.github/scripts/pulp/check-deb.sh
@@ -104,7 +104,7 @@ for i in "${!E_FILENAME[@]}"; do META_IDX[$i]=false; done
 resolve_pending() {
   local -A pkg_cache=()    # key: base_path|suite|arch -> Packages index file
   local -A arches_cache=() # key: base_path|suite -> space separated arches
-  local all_resolved=true i base_path suite arch search_arches sk ck a filename cache_file
+  local all_resolved=true i base_path suite arch search_arches sk ck a filename cache_file release_file
   for i in "${!E_FILENAME[@]}"; do
     [[ "${META_IDX[$i]}" == "true" ]] && continue
     base_path=${E_BASEPATH[$i]}; suite=${E_SUITE[$i]}; arch=${E_ARCH[$i]}
@@ -115,8 +115,10 @@ resolve_pending() {
     if [[ "$arch" == "all" ]]; then
       sk="$base_path|$suite"
       if [[ -z "${arches_cache[$sk]+set}" ]]; then
-        arches_cache[$sk]=$(content_curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" 2>/dev/null \
-          | awk -F': ' '/^Architectures:/ { print $2; exit }')
+        release_file=$(mktemp)
+        fetch_index "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" "$release_file" || true
+        arches_cache[$sk]=$(awk -F': ' '/^Architectures:/ { print $2; exit }' "$release_file")
+        rm -f "$release_file"
       fi
       search_arches="${arches_cache[$sk]:-amd64 arm64 all}"
     fi
@@ -126,7 +128,7 @@ resolve_pending() {
       ck="$base_path|$suite|$a"
       if [[ -z "${pkg_cache[$ck]+set}" ]]; then
         cache_file=$(mktemp)
-        content_curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$a/Packages" 2>/dev/null > "$cache_file" || true
+        fetch_index "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$a/Packages" "$cache_file" || true
         pkg_cache[$ck]=$cache_file
       fi
       filename=$(resolve_filename "${pkg_cache[$ck]}" "${E_SHA256[$i]}")

--- a/.github/scripts/pulp/check-rpm.sh
+++ b/.github/scripts/pulp/check-rpm.sh
@@ -118,15 +118,19 @@ resolve_href() {
 # each pending package's published href by sha256
 resolve_pending() {
   local -A primary_cache=()
-  local all_resolved=true i base_path repomd primary_href href cache_file
+  local all_resolved=true i base_path repomd_file primary_href href cache_file
   for i in "${!E_FILENAME[@]}"; do
     [[ "${META_IDX[$i]}" == "true" ]] && continue
     base_path=${E_BASEPATH[$i]}
 
     if [[ -z "${primary_cache[$base_path]+set}" ]]; then
       cache_file=$(mktemp)
-      repomd=$(content_curl -fsSL "$PULP_CONTENT_URL/$base_path/repodata/repomd.xml" 2>/dev/null || true)
-      primary_href=$(printf '%s' "$repomd" | grep -oP '<location href="\K[^"]+primary\.xml[^"]*' | head -1 || true)
+      repomd_file=$(mktemp)
+      primary_href=""
+      if fetch_index "$PULP_CONTENT_URL/$base_path/repodata/repomd.xml" "$repomd_file"; then
+        primary_href=$(grep -oP '<location href="\K[^"]+primary\.xml[^"]*' "$repomd_file" | head -1 || true)
+      fi
+      rm -f "$repomd_file"
       if [[ -n "$primary_href" ]]; then
         content_curl -fsSL "$PULP_CONTENT_URL/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null > "$cache_file" || true
       fi


### PR DESCRIPTION
Fixes: [MON-209118](https://centreon.atlassian.net/browse/MON-209118)

## Problem

`wait_for_metadata` (`.github/scripts/pulp/check-common.sh`) treats every unresolved package as a publication still propagating and polls the published index every 15 s for up to 900 s. When the content app refuses the CI identity (`401`/`403` from the content guard of the `*business-internal` distributions), no amount of waiting helps: the check loops `0/N package(s) resolvable, waiting 15s...` for the whole window before ending in the non-blocking warning.

The scripts under `.github/scripts/pulp/` are identical copies of the centreon-modules ones, where the loop cost ~16 min per `deliver <distrib> (pulp)` job on every business module delivery on 2026-09-11. The refusal itself is fixed in [delivery-tooling #345](https://github.com/centreon/delivery-tooling/pull/345): the content pods lacked the OIDC audience and rejected the CI token (#343 turned out to be inert); this PR is the same patch as [centreon-modules #9268](https://github.com/centreon/centreon-modules/pull/9268), applied here to keep the copies in sync.

## Change

- `check-common.sh`: new `fetch_index <url> <outfile>` helper reading an index through `content_curl` while keeping the HTTP status. A `401`/`403` is recorded in `INDEX_AUTH_DENIED`; `wait_for_metadata` then stops at once with an explicit `::error` naming the missing download role. Every other failure (404 while the publication propagates, network hiccup) keeps the existing retry window unchanged.
- `check-rpm.sh` / `check-deb.sh`: `repomd.xml`, `Release` and `Packages` are read through `fetch_index` (into temp files instead of shell variables, the `primary.xml.gz` fetch is untouched).

## Validation

- `shellcheck -x` and `bash -n` clean on the three scripts.
- Local harness against a fake content app (`check-common.sh` sourced with a stubbed `content_curl`): with a `403` server `wait_for_metadata` exits after the first round with the `::error` line; with a `404` server it keeps polling until `METADATA_TIMEOUT` as before.


[MON-209118]: https://centreon.atlassian.net/browse/MON-209118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
