### PR TITLE
fix(agent-configuration): resolve engine config id from poller id in addBrokerDirective

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbWriteAgentConfigurationRepository.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbWriteAgentConfigurationRepository.php
@@ -246,7 +246,11 @@ class DbWriteAgentConfigurationRepository extends DatabaseRepository implements 
     public function addBrokerDirective(string $module, array $pollerIds): void
     {
         try {
-            $query = $this->connection->createQueryBuilder()->insert('`:db`.`cfg_nagios_broker_module`')
+            $findEngineConfigQuery = $this->translateDbName(
+                'SELECT nagios_id FROM `:db`.`cfg_nagios` WHERE nagios_server_id = :poller_id LIMIT 1'
+            );
+
+            $insertQuery = $this->connection->createQueryBuilder()->insert('`:db`.`cfg_nagios_broker_module`')
                 ->values(
                     [
                         'bk_mod_id' => ':bk_mod_id',
@@ -255,18 +259,30 @@ class DbWriteAgentConfigurationRepository extends DatabaseRepository implements 
                     ]
                 )->getQuery();
 
-            foreach ($pollerIds as $poller) {
-                $pollerId = $poller;
+            foreach ($pollerIds as $pollerId) {
+                $engineConfigId = $this->connection->fetchOne(
+                    $findEngineConfigQuery,
+                    QueryParameters::create([
+                        QueryParameter::int('poller_id', $pollerId),
+                    ])
+                );
+
+                if ($engineConfigId === false || $engineConfigId === null) {
+                    throw new \RuntimeException(
+                        sprintf('No engine configuration found for poller %d', $pollerId)
+                    );
+                }
+
                 $this->connection->insert(
-                    $this->translateDbName($query),
+                    $this->translateDbName($insertQuery),
                     QueryParameters::create([
                         QueryParameter::null('bk_mod_id'),
-                        QueryParameter::int('cfg_nagios_id', $pollerId),
+                        QueryParameter::int('cfg_nagios_id', (int) $engineConfigId),
                         QueryParameter::string('broker_module', $module),
                     ])
                 );
             }
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             throw new RepositoryException(
                 message: 'Error while adding broker directive in agent configuration',
                 context: ['pollerIds' => $pollerIds, 'broker_module' => $module],


### PR DESCRIPTION
## Description

Backport of the `addBrokerDirective` fix to `dev-25.10.x`, originally introduced in #10293 (develop) and backported to `dev-24.10.x` in #11510.

`addBrokerDirective` used the poller id (`nagios_server.id`) directly as `cfg_nagios_id`, but these are two independent auto-increment sequences. Whenever they diverge for a given poller, the insert into `cfg_nagios_broker_module` fails with a foreign key violation.

This resolves `cfg_nagios.nagios_id` via `nagios_server_id` before inserting the broker directive.

**Fixes**: [MON-209130](https://centreon.atlassian.net/browse/MON-209130)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?

* Create an agent configuration.
* Creation must complete without errors (no foreign key violation on `cfg_nagios_broker_module`).

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-209130]: https://centreon.atlassian.net/browse/MON-209130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ