### PR TITLE
fix(web): validate the filter joiner and the sort direction

### DIFF
--- a/centreon/lib/Centreon/Object/Relation/Host/Template/Host.php
+++ b/centreon/lib/Centreon/Object/Relation/Host/Template/Host.php
@@ -155,10 +155,11 @@ class Centreon_Object_Relation_Host_Template_Host extends Centreon_Object_Relati
         if (! isset($this->firstObject) || ! isset($this->secondObject)) {
             throw new Exception('Unsupported method on this object');
         }
-        if (strtoupper($filterType) !== 'OR' && strtoupper($filterType) !== 'AND') {
+        $filterType = strtoupper($filterType);
+        if ($filterType !== 'OR' && $filterType !== 'AND') {
             throw new InvalidArgumentException('Invalid input');
         }
-        $filterType = strtoupper($filterType);
+
         $fString = '';
         $sString = '';
         foreach ($firstTableParams as $fparams) {

--- a/centreon/lib/Centreon/Object/Relation/Host/Template/Host.php
+++ b/centreon/lib/Centreon/Object/Relation/Host/Template/Host.php
@@ -139,6 +139,7 @@ class Centreon_Object_Relation_Host_Template_Host extends Centreon_Object_Relati
      * @param mixed $offset
      *
      * @throws Exception
+     * @throws InvalidArgumentException
      * @return array
      */
     public function getMergedParameters(
@@ -154,6 +155,10 @@ class Centreon_Object_Relation_Host_Template_Host extends Centreon_Object_Relati
         if (! isset($this->firstObject) || ! isset($this->secondObject)) {
             throw new Exception('Unsupported method on this object');
         }
+        if (strtoupper($filterType) !== 'OR' && strtoupper($filterType) !== 'AND') {
+            throw new InvalidArgumentException('Invalid input');
+        }
+        $filterType = strtoupper($filterType);
         $fString = '';
         $sString = '';
         foreach ($firstTableParams as $fparams) {

--- a/centreon/lib/Centreon/Object/Relation/Relation.php
+++ b/centreon/lib/Centreon/Object/Relation/Relation.php
@@ -173,10 +173,11 @@ abstract class Centreon_Object_Relation
         if (! isset($this->firstObject) || ! isset($this->secondObject)) {
             throw new Exception('Unsupported method on this object');
         }
-        if (strtoupper($filterType) !== 'OR' && strtoupper($filterType) !== 'AND') {
+        $filterType = strtoupper($filterType);
+        if ($filterType !== 'OR' && $filterType !== 'AND') {
             throw new InvalidArgumentException('Invalid input');
         }
-        $filterType = strtoupper($filterType);
+
         $fString = '';
         $sString = '';
         foreach ($firstTableParams as $fparams) {

--- a/centreon/lib/Centreon/Object/Relation/Relation.php
+++ b/centreon/lib/Centreon/Object/Relation/Relation.php
@@ -157,6 +157,7 @@ abstract class Centreon_Object_Relation
      * @param array $filters
      * @param string $filterType
      * @throws Exception
+     * @throws InvalidArgumentException
      * @return false|mixed
      */
     public function getMergedParameters(
@@ -172,6 +173,10 @@ abstract class Centreon_Object_Relation
         if (! isset($this->firstObject) || ! isset($this->secondObject)) {
             throw new Exception('Unsupported method on this object');
         }
+        if (strtoupper($filterType) !== 'OR' && strtoupper($filterType) !== 'AND') {
+            throw new InvalidArgumentException('Invalid input');
+        }
+        $filterType = strtoupper($filterType);
         $fString = '';
         $sString = '';
         foreach ($firstTableParams as $fparams) {


### PR DESCRIPTION
Fixes: [MON-209135](https://centreon.atlassian.net/browse/MON-209135)

Two places where a SQL fragment supplied by a caller reached the query without a local guarantee of what it could contain. Both are hardening — neither was exploitable as the code stands.

## Part 1 — the filter joiner

`getMergedParameters()` in `Centreon_Object_Relation` and `Centreon_Object_Relation_Host_Template_Host` accepts a `$filterType` argument that is interpolated into the `WHERE` clause. It defaulted to `'OR'`, but a caller could override it with any string.

The sibling classes `Centreon_Object` (`Object.php:266`), `Centreon_Object_Rt` (`ObjectRt.php:115`) and `Centreon_Object_Contact` (`Contact.php:100`) already guard this argument, and `Centreon_Object_Relation_Service_Template_Host` normalizes it with a ternary. Only these two `Relation` classes were missed.

Both methods now normalize the case and then restrict the argument to `OR`/`AND`. `InvalidArgumentException` matches the existing style of `Relation.php`, which already throws it from `sanitizeIdentifier()`.

**Compatibility:** all **64** call sites of `getMergedParameters()` — all under `centreon/www/class/centreon-clapi/` — pass the string literal `'AND'`. No existing caller can trigger the new exception.

## Part 2 — the sort direction

`SqlRequestParametersTranslator::translateSortParameterToSql()` interpolated the caller-supplied direction straight into `ORDER BY`:

```php
$orderQuery .= sprintf('%s %s', $col, $order);
```

The column is allowlisted through `$concordanceArray`; the direction was not re-checked here. It is already constrained upstream — `RequestParameters::setSort()` allowlists it against `$authorizedOrders = ['ASC', 'DESC']`, drops anything else and upper-cases the rest, and `RequestParameters` is the only implementer of `RequestParametersInterface` — so the query was never exposed.

The problem was **locality**: the guarantee lived one class away and had to be re-established by reading `setSort()`. The direction is now resolved to one of the two constants before use:

```php
$direction = strtoupper($order) === RequestParameters::ORDER_DESC
    ? RequestParameters::ORDER_DESC
    : RequestParameters::ORDER_ASC;
```

Applied to both sort builders in the class — `translateSortParameterToSql()` and `appendQueryBuilderWithSortParameter()`, which had the identical shape.

**Compatibility:** for `ASC` and `DESC`, the only two values `setSort()` can produce, the generated SQL is byte-identical. Verified by running both code paths side by side over every reachable input.

## Files

| File | Part |
|---|---|
| `centreon/lib/Centreon/Object/Relation/Relation.php` | 1 |
| `centreon/lib/Centreon/Object/Relation/Host/Template/Host.php` | 1 |
| `centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php` | 2 |

## Backport

To be backported to `dev-26.10.x`. The part 1 code is identical on `dev-25.10.x` and `dev-24.10.x`, knowingly out of scope for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MON-209135]: https://centreon.atlassian.net/browse/MON-209135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ