### PR TITLE
fix(unattended): enforce the stable plugins repository

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -869,10 +869,12 @@ function set_required_prerequisite() {
 			else
 				echo "deb https://packages.centreon.com/$apt_standard_repo/ $(lsb_release -sc)-$_repo main" | tee /etc/apt/sources.list.d/centreon-$_repo.list
 			fi
-
-			SIMPLEREPO=$(echo $_repo | cut -d '-' -f2)
-			echo "deb $ARCH https://packages.centreon.com/$repo_prefix-plugins-$SIMPLEREPO/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins-$SIMPLEREPO.list
 		done
+		# Plugins stay on 'stable' whatever stability was requested for the Centreon
+		# packages: the 'testing' and 'unstable' plugins repos do not carry every dependency
+		# (e.g. libcrypt-openssl-aes-perl), which breaks the install. Mirrors the el behaviour.
+		rm -f /etc/apt/sources.list.d/centreon-plugins-testing.list /etc/apt/sources.list.d/centreon-plugins-unstable.list
+		echo "deb $ARCH https://packages.centreon.com/$repo_prefix-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
 		# Import the Centreon APT signing key (pipefail so a failed download/dearmor is caught, not hidden).
 		log "INFO" "Importing the Centreon APT signing key"
 		if ! ( set -o pipefail; wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null ); then
@@ -1356,6 +1358,14 @@ function install_centreon_repo() {
 	if ! $PKG_MGR config-manager --add-repo $RELEASE_REPO_FILE; then
 		error_and_exit "Could not install Centreon repository"
 	fi
+
+	# Plugins stay on 'stable' whatever stability was requested for the Centreon
+	# packages: the 'testing' and 'unstable' plugins repos do not carry every dependency, which
+	# breaks the install. The shipped .repo file already does this; enforce it against local edits.
+	$PKG_MGR config-manager --set-disabled "centreon-plugins-*" ||
+		log "WARN" "Could not disable the non-stable Centreon plugins repositories (best-effort)"
+	$PKG_MGR config-manager --set-enabled "centreon-plugins-*-stable*" ||
+		log "WARN" "Could not enable the stable Centreon plugins repositories (best-effort)"
 }
 #========= end of function install_centreon_repo()
 


### PR DESCRIPTION
## Description

`unattended.sh` derived the **plugins** repository from the stability requested for the **Centreon** packages. On Debian that meant `-r testing-release` configured `apt-plugins-testing` as the *only* plugins source, and that repository does not carry every dependency Centreon needs:

```
Unsatisfied dependencies:
 centreon-perl-libs-common : Depends: libcrypt-openssl-aes-perl but it is not installable
Error: Unable to correct problems, you have held broken packages.
```

`libcrypt-openssl-aes-perl` (and `libkeepass-reader-perl`) exist in `apt-plugins-stable` and `apt-plugins-unstable` but not in `apt-plugins-testing`, for both trixie and bookworm. The plugins repositories other than `stable` are simply not guaranteed to hold the full dependency set at any given time, so Centreon plugins must always be installed from `stable`, whatever stability is used for the Centreon packages themselves.

This is what the el path already does: the shipped `centreon-<version>.repo` keeps `[centreon-plugins-<version>-stable]` at `enabled=1` and the testing/unstable plugins repos at `enabled=0`, and `--enablerepo="centreon-<version>-testing-release*"` never matches a `centreon-plugins-*` repo id. That is why an el build with `-r testing-release` succeeds while the Debian build of the same version fails.

Found while building the 26.10 Debian 13 OVA (`centreon-images`), which installs from `testing-release` because `<codename>-26.10-stable` is not populated before GA.

## Changes

- **Debian**: the plugins source is no longer derived from the requested stability (`SIMPLEREPO=$(echo $_repo | cut -d '-' -f2)` is removed). It is written once, outside the per-repo loop, always pointing at `apt-plugins-stable`. A `centreon-plugins-testing.list` / `-unstable.list` left by an earlier run is removed, as it would otherwise silently defeat the enforcement on a re-run.
- **RPM**: after `config-manager --add-repo`, non-stable plugins repositories are explicitly disabled and the stable ones enabled. The shipped `.repo` file already does this, so this is a guard that keeps the invariant true against a locally edited (or future) repo file rather than a behaviour change. Both calls are best-effort with a `WARN`, like the other repository toggles in the script.

No change to how the Centreon packages themselves follow the requested stability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Target serie

- [x] 26.11.x (develop)

Backports to 26.10 / 25.10 / 24.10 to follow if wanted.

## How this has been tested

- `bash -n` clean. `shellcheck -S error` reports only the three errors that already exist in the file (lines 797, 798, 1815) — none introduced by this change.
- Full dependency closure resolved offline against `apt-standard/trixie-26.10-testing-release` + `apt-plugins-stable/trixie` + Debian trixie `main`: **652 packages, zero unsatisfied** (`mariadb-server` / `mariadb-client` supplied by the MariaDB repository the script adds). The five packages Debian does not ship — `libcrypt-openssl-aes-perl`, `libkeepass-reader-perl`, `libmojo-ioloop-signal-perl`, `libnet-curl-perl`, `libssh-session-perl` — all resolve from plugins-stable.
- Resulting Debian repository files for `-v 26.10 -r testing-release` on trixie:
  ```
  centreon-26.10-testing-release.list: deb https://packages.centreon.com/apt-standard/ trixie-26.10-testing-release main
  centreon-plugins-stable.list:        deb https://packages.centreon.com/apt-plugins-stable/ trixie main
  ```
- Kept as a draft pending a full deb13 OVA build against this branch (the OVA fetches `unattended.sh` from a branch, so the end-to-end run is the real validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
