### PR TITLE
fix(web): validate host-template order columns

### DIFF
--- a/centreon/lib/Centreon/Object/Relation/Host/Template/Host.php
+++ b/centreon/lib/Centreon/Object/Relation/Host/Template/Host.php
@@ -184,7 +184,17 @@ class Centreon_Object_Relation_Host_Template_Host extends Centreon_Object_Relati
             }
         }
         if (isset($order, $sort)   && (strtoupper($sort) == 'ASC' || strtoupper($sort) == 'DESC')) {
-            $sql .= " ORDER BY {$order} {$sort} ";
+            $orderColumns = [];
+            foreach (explode(',', $order) as $orderColumn) {
+                $orderColumn = trim($orderColumn);
+                $isQuoted = str_starts_with($orderColumn, '`') && str_ends_with($orderColumn, '`');
+                $orderColumn = $this->sanitizeIdentifier($orderColumn);
+                if (preg_match('/^[a-zA-Z_][a-zA-Z0-9_.]*$/', $orderColumn) !== 1) {
+                    throw new InvalidArgumentException("Invalid order column: {$orderColumn}");
+                }
+                $orderColumns[] = $isQuoted ? "`{$orderColumn}`" : $orderColumn;
+            }
+            $sql .= ' ORDER BY ' . implode(',', $orderColumns) . " {$sort} ";
         }
         if (isset($count) && $count != -1) {
             $sql = $this->db->limit($sql, $count, $offset);


### PR DESCRIPTION
## Summary

`Centreon_Object_Relation_Host_Template_Host::getMergedParameters()` interpolated its `$order` argument into the `ORDER BY` clause with no validation. The parent class and its siblings validate at the equivalent spot; this subclass overrides the method and lost the call.

Each column of the list is now validated individually against an identifier allowlist, keeping its original backtick quoting. Per-column validation is necessary here: `sanitizeIdentifier()` strips the backticks of the whole string, so applying it to the value both callers pass — ``host,`order` `` — would leave an unbalanced backtick and produce invalid SQL. `order` is a MySQL reserved word, which is why callers quote it.

The method is reached from the `HOST` and `HTPL` exports only, and both call sites pass that same literal, for which the generated SQL is unchanged: ``ORDER BY host,`order` ASC``. Values that now throw (empty string, trailing comma, lone backtick) already produced invalid SQL and failed at `execute()` — the failure just moves earlier.

To be backported to `dev-26.10.x`.

## Jira

[MON-209184]

## Test plan

Needs a platform with a host inheriting at least two templates, so the ordering is observable.

- [ ] On `develop`, capture the reference exports:
      `centreon -u admin -p '<password>' -o HOST -a EXPORT > /tmp/host-before.csv`
      `centreon -u admin -p '<password>' -o HTPL -a EXPORT > /tmp/htpl-before.csv`
- [ ] Switch to the branch, re-run both into `/tmp/host-after.csv` and `/tmp/htpl-after.csv`
- [ ] `diff` each pair — no output; in particular the `HOST;addtemplate;…` and `HTPL;addtemplate;…` lines keep the same order
- [ ] Full export `centreon -u admin -p '<password>' -e` returns 0 and is identical before/after
- [ ] Filtered export `centreon -u admin -p '<password>' -e --select "HOST;<host_name>"` returns that host's templates in the same order
- [ ] Re-import on a clean platform (`centreon -u admin -p '<password>' -i /tmp/host-after.csv`), then check in Configuration > Hosts > `<host>` > Templates that the inheritance order is preserved
- [ ] Generate the configuration for a poller and export it: no error, and the deployed host templates are unchanged

[MON-209184]: https://centreon.atlassian.net/browse/MON-209184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
