### PR TITLE
fix(unattended): align unattended.sh with develop (enforce the stable plugins repository) [MON-209206]

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -869,10 +869,12 @@ function set_required_prerequisite() {
 			else
 				echo "deb https://packages.centreon.com/$apt_standard_repo/ $(lsb_release -sc)-$_repo main" | tee /etc/apt/sources.list.d/centreon-$_repo.list
 			fi
-
-			SIMPLEREPO=$(echo $_repo | cut -d '-' -f2)
-			echo "deb $ARCH https://packages.centreon.com/$repo_prefix-plugins-$SIMPLEREPO/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins-$SIMPLEREPO.list
 		done
+		# Plugins stay on 'stable' whatever stability was requested for the Centreon
+		# packages: the 'testing' and 'unstable' plugins repos do not carry every dependency
+		# (e.g. libcrypt-openssl-aes-perl), which breaks the install. Mirrors the el behaviour.
+		rm -f /etc/apt/sources.list.d/centreon-plugins-testing.list /etc/apt/sources.list.d/centreon-plugins-unstable.list
+		echo "deb $ARCH https://packages.centreon.com/$repo_prefix-plugins-stable/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
 		# Import the Centreon APT signing key (pipefail so a failed download/dearmor is caught, not hidden).
 		log "INFO" "Importing the Centreon APT signing key"
 		if ! ( set -o pipefail; wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null ); then
@@ -1356,6 +1358,14 @@ function install_centreon_repo() {
 	if ! $PKG_MGR config-manager --add-repo $RELEASE_REPO_FILE; then
 		error_and_exit "Could not install Centreon repository"
 	fi
+
+	# Plugins stay on 'stable' whatever stability was requested for the Centreon
+	# packages: the 'testing' and 'unstable' plugins repos do not carry every dependency, which
+	# breaks the install. The shipped .repo file already does this; enforce it against local edits.
+	$PKG_MGR config-manager --set-disabled "centreon-plugins-*" ||
+		log "WARN" "Could not disable the non-stable Centreon plugins repositories (best-effort)"
+	$PKG_MGR config-manager --set-enabled "centreon-plugins-*-stable*" ||
+		log "WARN" "Could not enable the stable Centreon plugins repositories (best-effort)"
 }
 #========= end of function install_centreon_repo()
 


### PR DESCRIPTION
## Description

Backport of #11614 (merged on `develop`) to `release-26.10-next` — ticket MON-209206.
Backport of #11619 https://github.com/centreon/centreon/pull/11619

`unattended.sh` derived the **plugins** repository from the stability requested for the **Centreon** packages. On Debian, `-r testing-release` therefore configured `apt-plugins-testing` as the only plugins source, and that repository does not carry every dependency:

```
Unsatisfied dependencies:
 centreon-perl-libs-common : Depends: libcrypt-openssl-aes-perl but it is not installable
Error: Unable to correct problems, you have held broken packages.
```

The plugins repositories other than `stable` are not guaranteed to hold the full dependency set at any time, so Centreon plugins must always come from `stable`, whatever stability is used for the Centreon packages themselves. This is what the el path already does via the shipped `.repo` file, which is why an el install with `-r testing-release` succeeds where the Debian one fails.

## What this PR does

As with the previous alignment PRs, `centreon/unattended.sh` is replaced wholesale with the version currently on `develop` so the script stays identical across branches.

On this branch there is **no drift**: the file was already byte-identical to `develop` apart from this fix, so the diff is exactly the backported change (**+13 / -3**) and the result is byte-identical to `develop` (verified with `cmp`).

- **Debian**: the plugins repo is no longer derived from the requested stability (`SIMPLEREPO=$(echo $_repo | cut -d '-' -f2)` removed); it is written once, outside the per-repo loop, always pointing at `apt-plugins-stable`. A `centreon-plugins-testing.list` / `-unstable.list` left by an earlier run is removed, as it would otherwise silently defeat the enforcement on a re-run.
- **RPM**: after `config-manager --add-repo`, non-stable plugins repositories are explicitly disabled and the stable ones enabled. The shipped `.repo` file already does this, so this is a guard against a locally edited (or future) repo file rather than a behaviour change. Both calls are best-effort with a `WARN`, like the other repository toggles in the script.

How the Centreon packages themselves follow the requested stability is unchanged.

## Tests

- `bash -n` clean. `shellcheck -S error` reports only the three errors already present in the file (lines 797, 798, 1815) — none introduced.
- Full dependency closure resolved offline against `apt-standard/trixie-26.10-testing-release` + `apt-plugins-stable/trixie` + Debian trixie `main`: **652 packages, zero unsatisfied** (`mariadb-server`/`mariadb-client` from the MariaDB repository the script adds). The five packages Debian does not ship — `libcrypt-openssl-aes-perl`, `libkeepass-reader-perl`, `libmojo-ioloop-signal-perl`, `libnet-curl-perl`, `libssh-session-perl` — all resolve from plugins-stable.
- Resulting Debian repository files for `-v 26.10 -r testing-release` on trixie:
  ```
  centreon-26.10-testing-release.list: deb https://packages.centreon.com/apt-standard/ trixie-26.10-testing-release main
  centreon-plugins-stable.list:        deb https://packages.centreon.com/apt-plugins-stable/ trixie main
  ```
- Opened as a draft: the end-to-end validation is an OVA build driving this script, which runs against the branch it fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
